### PR TITLE
Add #ifdef to make it easier to embed libtomcrypt with LTC_NOTHING

### DIFF
--- a/src/ciphers/aes/aes_tab.c
+++ b/src/ciphers/aes/aes_tab.c
@@ -23,6 +23,8 @@ Td3[x] = Si[x].[09, 0d, 0b, 0e];
 Td4[x] = Si[x].[01, 01, 01, 01];
 */
 
+#ifdef TOMCRYPT_H_
+
 /**
   @file aes_tab.c
   AES tables
@@ -1022,6 +1024,8 @@ static const ulong32 rcon[] = {
     0x10000000UL, 0x20000000UL, 0x40000000UL, 0x80000000UL,
     0x1B000000UL, 0x36000000UL, /* for 128-bit blocks, Rijndael never uses more than 10 rcon values */
 };
+
+#endif	/* TOMCRYPT_H_ */
 
 /* $Source$ */
 /* $Revision$ */

--- a/src/hashes/sha2/sha224.c
+++ b/src/hashes/sha2/sha224.c
@@ -8,6 +8,9 @@
  *
  * Tom St Denis, tomstdenis@gmail.com, http://libtom.org
  */
+
+#ifdef TOMCRYPT_H_
+
 /**
    @param sha224.c
    LTC_SHA-224 new NIST standard based off of LTC_SHA-256 truncated to 224 bits (Tom St Denis)
@@ -119,6 +122,7 @@ int  sha224_test(void)
  #endif
 }
 
+#endif	/* TOMCRYPT_H_ */
 
 /* $Source$ */
 /* $Revision$ */

--- a/src/hashes/sha2/sha384.c
+++ b/src/hashes/sha2/sha384.c
@@ -8,6 +8,9 @@
  *
  * Tom St Denis, tomstdenis@gmail.com, http://libtom.org
  */
+
+#ifdef TOMCRYPT_H_
+
 /** 
    @param sha384.c
    LTC_SHA384 hash included in sha512.c, Tom St Denis
@@ -125,6 +128,7 @@ int  sha384_test(void)
  #endif
 }
 
+#endif	/* TOMCRYPT_H_ */
 
 
 

--- a/src/hashes/whirl/whirltab.c
+++ b/src/hashes/whirl/whirltab.c
@@ -1,3 +1,5 @@
+#ifdef TOMCRYPT_H_
+
 /**
    @file whirltab.c
    LTC_WHIRLPOOL tables, Tom St Denis
@@ -577,6 +579,7 @@ CONST64(0xca2dbf07ad5a8333),
 CONST64(0x6302aa71c81949d9),
 };
 
+#endif	/* TOMCRYPT_H_ */
 
 /* $Source$ */
 /* $Revision$ */

--- a/src/headers/tomcrypt_custom.h
+++ b/src/headers/tomcrypt_custom.h
@@ -68,6 +68,7 @@
 
 /* shortcut to disable automatic inclusion */
 #if defined LTC_NOTHING && !defined LTC_EASY
+  #define LTC_NO_MATH
   #define LTC_NO_CIPHERS
   #define LTC_NO_MODES
   #define LTC_NO_HASHES
@@ -141,11 +142,15 @@
 /* #define LTC_NO_BSWAP */
 
 /* ---> math provider? <--- */
+#ifndef LTC_NO_MATH
+
 /* LibTomMath */
 /* #define LTM_DESC */
 
 /* TomsFastMath */
 /* #define TFM_DESC */
+
+#endif /* LTC_NO_MATH */
 
 /* GNU Multiple Precision Arithmetic Library */
 /* #define GMP_DESC */

--- a/src/math/rand_prime.c
+++ b/src/math/rand_prime.c
@@ -10,6 +10,8 @@
  */
 #include "tomcrypt.h"
 
+#if !defined LTC_NO_MATH && !defined LTC_NO_PRNGS
+
 /**
   @file rand_prime.c
   Generate a random prime, Tom St Denis
@@ -80,6 +82,7 @@ int rand_prime(void *N, long len, prng_state *prng, int wprng)
    return CRYPT_OK;
 }
       
+#endif /* LTC_NO_MATH */
 
 
 /* $Source$ */

--- a/src/pk/dh/dh_sys.c
+++ b/src/pk/dh/dh_sys.c
@@ -9,6 +9,8 @@
  * Tom St Denis, tomstdenis@gmail.com, http://libtomcrypt.org
  */
 
+#ifdef TOMCRYPT_H_
+
 /**
   @file dh_sys.c
   DH Crypto, Tom St Denis
@@ -488,3 +490,5 @@ done:
    mp_clear_multi(tmp, m, g, p, b, a, NULL);
    return err;
 }
+
+#endif	/* TOMCRYPT_H_ */

--- a/src/prngs/sober128tab.c
+++ b/src/prngs/sober128tab.c
@@ -1,3 +1,5 @@
+#ifdef TOMCRYPT_H_
+
 /** 
    @file sober128tab.c
    SOBER-128 Tables
@@ -156,6 +158,8 @@ static const ulong32 Sbox[256] = {
     0x45f0b24f, 0x51fda998, 0xc0d52d71, 0xfa0896a8,
     0xf9e6053f, 0xa4b0d300, 0xd499cbcc, 0xb95e3d40,
 };
+
+#endif	/* TOMCRYPT_H_ */
 
 /* $Source$ */
 /* $Revision$ */


### PR DESCRIPTION
Restore LTC_NO_MATH and make rand_prime.c depend on LTC_NO_MATH & LTC_NO_PRNGS
Make include only .c files depend on tomcrypt.h so that they aren't compiled alone. The source tree now can be easily embedded without selected removing those files.
