### PR TITLE
Add support for two-key Triple-DES

### DIFF
--- a/src/ciphers/des.c
+++ b/src/ciphers/des.c
@@ -1562,17 +1562,27 @@ int des3_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_k
         return CRYPT_INVALID_ROUNDS;
     }
 
-    if (keylen != 24) {
+    if (keylen != 24 && keylen != 16) {
         return CRYPT_INVALID_KEYSIZE;
     }
 
     deskey(key,    EN0, skey->des3.ek[0]);
     deskey(key+8,  DE1, skey->des3.ek[1]);
-    deskey(key+16, EN0, skey->des3.ek[2]);
+    if (keylen == 24) {
+        deskey(key+16, EN0, skey->des3.ek[2]);
+    } else {
+        /* two-key 3DES: K3=K1 */
+        deskey(key, EN0, skey->des3.ek[2]);
+    }
 
     deskey(key,    DE1, skey->des3.dk[2]);
     deskey(key+8,  EN0, skey->des3.dk[1]);
-    deskey(key+16, DE1, skey->des3.dk[0]);
+    if (keylen == 24) {
+        deskey(key+16, DE1, skey->des3.dk[0]);
+    } else {
+        /* two-key 3DES: K3=K1 */
+        deskey(key, DE1, skey->des3.dk[0]);
+    }
 
     return CRYPT_OK;
 }


### PR DESCRIPTION
I am currently trying to unbundle libtomcrypt 1.16 from the python-crypto (pycrypto) package in Fedora Linux. The pycrypto code has long had one additional feature that is not in the upstream libtomcrypt code, namely support for two-key Triple-DES, with 16-byte keys rather than 24-byte ones.

With the inclusion of this feature from pycrypto, I would be able to unbundle libtomcrypt from pycrypto and use the system version (currently 1.17) instead.

Please consider merging this well-tested (in pycrypto) feature.
