### PR TITLE
Enable multiple XTS encryption or decryption

### DIFF
--- a/src/headers/tomcrypt_cipher.h
+++ b/src/headers/tomcrypt_cipher.h
@@ -884,12 +884,12 @@ int xts_start(                int  cipher,
 int xts_encrypt(
    const unsigned char *pt, unsigned long ptlen,
          unsigned char *ct,
-   const unsigned char *tweak,
+         unsigned char *tweak,
          symmetric_xts *xts);
 int xts_decrypt(
    const unsigned char *ct, unsigned long ptlen,
          unsigned char *pt,
-   const unsigned char *tweak,
+         unsigned char *tweak,
          symmetric_xts *xts);
 
 void xts_done(symmetric_xts *xts);

--- a/src/modes/xts/xts_decrypt.c
+++ b/src/modes/xts/xts_decrypt.c
@@ -60,7 +60,7 @@ static int tweak_uncrypt(const unsigned char *C, unsigned char *P, unsigned char
 */int xts_decrypt(
    const unsigned char *ct, unsigned long ptlen,
          unsigned char *pt,
-   const unsigned char *tweak,
+         unsigned char *tweak,
          symmetric_xts *xts)
 {
    unsigned char PP[16], CC[16], T[16];
@@ -128,6 +128,11 @@ static int tweak_uncrypt(const unsigned char *C, unsigned char *P, unsigned char
       if ((err = tweak_uncrypt(CC, pt, T, xts)) != CRYPT_OK) {
          return err;
       }
+   }
+
+   /* Decrypt the tweak back */
+   if ((err = cipher_descriptor[xts->cipher].ecb_decrypt(T, tweak, &xts->key2)) != CRYPT_OK) {
+      return err;
    }
 
    return CRYPT_OK;

--- a/src/modes/xts/xts_encrypt.c
+++ b/src/modes/xts/xts_encrypt.c
@@ -63,7 +63,7 @@ static int tweak_crypt(const unsigned char *P, unsigned char *C, unsigned char *
 int xts_encrypt(
    const unsigned char *pt, unsigned long ptlen,
          unsigned char *ct,
-   const unsigned char *tweak,
+         unsigned char *tweak,
          symmetric_xts *xts)
 {
    unsigned char PP[16], CC[16], T[16];
@@ -129,6 +129,11 @@ int xts_encrypt(
       if ((err = tweak_crypt(PP, ct, T, xts)) != CRYPT_OK) {
          return err;
       }
+   }
+
+   /* Decrypt the tweak back */
+   if ((err = cipher_descriptor[xts->cipher].ecb_decrypt(T, tweak, &xts->key2)) != CRYPT_OK) {
+      return err;
    }
 
    return err;

--- a/src/modes/xts/xts_test.c
+++ b/src/modes/xts/xts_test.c
@@ -142,7 +142,7 @@ int xts_test(void)
 },
 
 };
-   unsigned char OUT[512], T[16];
+   unsigned char OUT[512], Torg[16], T[16];
    ulong64       seq;
    symmetric_xts xts;
    int           i, err, idx;
@@ -161,9 +161,10 @@ int xts_test(void)
        }
  
        seq = tests[i].seqnum;
-       STORE64L(seq,T);
-       XMEMSET(T+8, 0, 8);
+       STORE64L(seq,Torg);
+       XMEMSET(Torg+8, 0, 8);
 
+       XMEMCPY(T, Torg, sizeof(T));
        err = xts_encrypt(tests[i].PTX, tests[i].PTLEN, OUT, T, &xts);
        if (err != CRYPT_OK) {
           xts_done(&xts);
@@ -175,6 +176,7 @@ int xts_test(void)
           return CRYPT_FAIL_TESTVECTOR;
        }
 
+       XMEMCPY(T, Torg, sizeof(T));
        err = xts_decrypt(tests[i].CTX, tests[i].PTLEN, OUT, T, &xts);
        if (err != CRYPT_OK) {
           xts_done(&xts);


### PR DESCRIPTION
multiple xts_encrypt() cannot be performed because the
tweak is not updated. That means that
        xts_encrypt(buffer1, tweak)
        xts_encrypt(buffer2, tweak)
is not the same as
        xts_encrypt(concat(buffer1, buffer2), tweak)

Current patch enables such a functionality by
updating the tweak as output of the encryption.
Note that the tweak is no more constant.

The very same modification is performed
on xts_decrypt()

Signed-off-by: Pascal Brand pascal.brand@st.com
