### PR TITLE
RSA in case CRT optimization parameters are not populated

### DIFF
--- a/src/pk/rsa/rsa_exptmod.c
+++ b/src/pk/rsa/rsa_exptmod.c
@@ -100,16 +100,11 @@ int rsa_exptmod(const unsigned char *in,   unsigned long inlen,
       }
       #endif /* LTC_RSA_BLINDING */
 
-      if (key->dP == NULL) {
+      if ((key->dP == NULL) || (mp_get_digit_count(key->dP) == 0)) {
          /*
-          * In case CRT optimization parameters are provided,
-          * the private key is directly used
+          * In case CRT optimization parameters are not provided,
+          * the private key is directly used to exptmod it
           */
-         LTC_ARGCHK(key->dQ == NULL);
-         LTC_ARGCHK(key->qP == NULL);
-         LTC_ARGCHK(key->p  == NULL);
-         LTC_ARGCHK(key->q  == NULL);
-         /* exptmod it */
          if ((err = mp_exptmod(tmp, key->d, key->N, tmp)) != CRYPT_OK)                              { goto error; }
       } else {
          /* tmpa = tmp^dP mod p */


### PR DESCRIPTION
rsa_exptmod(), ran on the private key, makes use of CRT optimization
parameters. In some use-cases, the given key does not include the
optimization parameters.

This patch allows rsa_exptmod() to run without the CRT parameters,
using directly mp_exptmod().

Signed-off-by: Pascal Brand pascal.brand@st.com
