### PR TITLE
Add incremental CCM authentication processing

### DIFF
--- a/makefile
+++ b/makefile
@@ -121,6 +121,8 @@ src/ciphers/camellia.o src/ciphers/cast5.o src/ciphers/des.o src/ciphers/kasumi.
 src/ciphers/kseed.o src/ciphers/multi2.o src/ciphers/noekeon.o src/ciphers/rc2.o src/ciphers/rc5.o \
 src/ciphers/rc6.o src/ciphers/safer/safer.o src/ciphers/safer/saferp.o src/ciphers/skipjack.o \
 src/ciphers/twofish/twofish.o src/ciphers/xtea.o src/encauth/ccm/ccm_memory.o \
+src/encauth/ccm/ccm_done.o src/encauth/ccm/ccm_process.o src/encauth/ccm/ccm_reset.o \
+src/encauth/ccm/ccm_add_aad.o src/encauth/ccm/ccm_init.o src/encauth/ccm/ccm_add_nonce.o \
 src/encauth/ccm/ccm_memory_ex.o src/encauth/ccm/ccm_test.o src/encauth/eax/eax_addheader.o \
 src/encauth/eax/eax_decrypt.o src/encauth/eax/eax_decrypt_verify_memory.o src/encauth/eax/eax_done.o \
 src/encauth/eax/eax_encrypt_authenticate_memory.o src/encauth/eax/eax_encrypt.o \

--- a/src/encauth/ccm/ccm_add_aad.c
+++ b/src/encauth/ccm/ccm_add_aad.c
@@ -1,0 +1,58 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ *
+ * Tom St Denis, tomstdenis@gmail.com, http://libtom.org
+ */
+#include "tomcrypt.h"
+
+#ifdef LTC_CCM_MODE
+
+/**
+  Add AAD to the CCM state
+  @param ccm       The CCM state
+  @param adata     The additional authentication data to add to the CCM state
+  @param adatalen  The length of the AAD data.
+  @return CRYPT_OK on success
+ */
+int ccm_add_aad(ccm_state *ccm,
+                const unsigned char *adata,  unsigned long adatalen)
+{
+   unsigned long y;
+   int            err;
+
+   if (ccm->aadlen < ccm->current_aadlen + adatalen) {
+      return CRYPT_INVALID_ARG;
+   }
+   ccm->current_aadlen += adatalen;
+
+   /* now add the data */
+   for (y = 0; y < adatalen; y++) {
+      if (ccm->x == 16) {
+         /* full block so let's encrypt it */
+         if ((err = cipher_descriptor[ccm->cipher].ecb_encrypt(ccm->PAD, ccm->PAD, &ccm->K)) != CRYPT_OK) {
+            return CRYPT_ERROR;
+         }
+         ccm->x = 0;
+      }
+      ccm->PAD[ccm->x++] ^= adata[y];
+   }
+
+   /* remainder? */
+   if (ccm->aadlen == ccm->current_aadlen) {
+      if (ccm->x != 0) {
+         if ((err = cipher_descriptor[ccm->cipher].ecb_encrypt(ccm->PAD, ccm->PAD, &ccm->K)) != CRYPT_OK) {
+            return CRYPT_ERROR;
+         }
+      }
+      ccm->x = 0;
+   }
+
+   return CRYPT_OK;
+}
+
+#endif

--- a/src/encauth/ccm/ccm_add_nonce.c
+++ b/src/encauth/ccm/ccm_add_nonce.c
@@ -1,0 +1,108 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ *
+ * Tom St Denis, tomstdenis@gmail.com, http://libtom.org
+ */
+#include "tomcrypt.h"
+
+#ifdef LTC_CCM_MODE
+
+/**
+  Add nonce data to the CCM state
+  @param ccm       The CCM state
+  @param nonce     The nonce data to add
+  @param noncelen  The length of the nonce
+  @return CRYPT_OK on success
+ */
+int ccm_add_nonce(ccm_state *ccm,
+                  const unsigned char *nonce,     unsigned long noncelen)
+{
+   unsigned long x, y, len;
+   int           err;
+
+   /* increase L to match the nonce len */
+   ccm->noncelen = (noncelen > 13) ? 13 : noncelen;
+   if ((15 - ccm->noncelen) > ccm->L) {
+      ccm->L = 15 - ccm->noncelen;
+   }
+
+   /* decrease noncelen to match L */
+   if ((ccm->noncelen + ccm->L) > 15) {
+      ccm->noncelen = 15 - ccm->L;
+   }
+
+   /* form B_0 == flags | Nonce N | l(m) */
+   x = 0;
+   ccm->PAD[x++] = (unsigned char)(((ccm->aadlen > 0) ? (1<<6) : 0) |
+		   (((ccm->taglen - 2)>>1)<<3)        |
+		   (ccm->L-1));
+
+   /* nonce */
+   for (y = 0; y < (16 - (ccm->L + 1)); y++) {
+      ccm->PAD[x++] = nonce[y];
+   }
+
+   /* store len */
+   len = ccm->ptlen;
+
+   /* shift len so the upper bytes of len are the contents of the length */
+   for (y = ccm->L; y < 4; y++) {
+      len <<= 8;
+   }
+
+   /* store l(m) (only store 32-bits) */
+   for (y = 0; ccm->L > 4 && (ccm->L-y)>4; y++) {
+      ccm->PAD[x++] = 0;
+   }
+   for (; y < ccm->L; y++) {
+      ccm->PAD[x++] = (unsigned char)((len >> 24) & 255);
+      len <<= 8;
+   }
+
+   /* encrypt PAD */
+   if ((err = cipher_descriptor[ccm->cipher].ecb_encrypt(ccm->PAD, ccm->PAD, &ccm->K)) != CRYPT_OK) {
+      return err;
+   }
+
+   /* handle header */
+   ccm->x = 0;
+   if (ccm->aadlen > 0) {
+      /* store length */
+      if (ccm->aadlen < ((1UL<<16) - (1UL<<8))) {
+         ccm->PAD[ccm->x++] ^= (ccm->aadlen>>8) & 255;
+         ccm->PAD[ccm->x++] ^= ccm->aadlen & 255;
+      } else {
+         ccm->PAD[ccm->x++] ^= 0xFF;
+         ccm->PAD[ccm->x++] ^= 0xFE;
+         ccm->PAD[ccm->x++] ^= (ccm->aadlen>>24) & 255;
+         ccm->PAD[ccm->x++] ^= (ccm->aadlen>>16) & 255;
+         ccm->PAD[ccm->x++] ^= (ccm->aadlen>>8) & 255;
+         ccm->PAD[ccm->x++] ^= ccm->aadlen & 255;
+      }
+   }
+
+   /* setup the ctr counter */
+   x = 0;
+
+   /* flags */
+   ccm->ctr[x++] = (unsigned char)ccm->L-1;
+
+   /* nonce */
+   for (y = 0; y < (16 - (ccm->L+1)); ++y) {
+      ccm->ctr[x++] = nonce[y];
+   }
+   /* offset */
+   while (x < 16) {
+      ccm->ctr[x++] = 0;
+   }
+
+   ccm->CTRlen = 16;
+   return CRYPT_OK;
+}
+
+#endif

--- a/src/encauth/ccm/ccm_done.c
+++ b/src/encauth/ccm/ccm_done.c
@@ -1,0 +1,61 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ *
+ * Tom St Denis, tomstdenis@gmail.com, http://libtom.org
+ */
+#include "tomcrypt.h"
+
+#ifdef LTC_CCM_MODE
+
+/**
+  Terminate a CCM stream
+  @param ccm     The CCM state
+  @param tag     [out] The destination for the MAC tag
+  @param taglen  [in/out]  The length of the MAC tag
+  @return CRYPT_OK on success
+ */
+int ccm_done(ccm_state *ccm,
+             unsigned char *tag,    unsigned long *taglen)
+{
+   unsigned long x, y;
+   int            err;
+
+   /* Check all data have been processed */
+   if (ccm->ptlen != ccm->current_ptlen) {
+      return CRYPT_ERROR;
+   }
+
+   LTC_ARGCHK(tag    != NULL);
+   LTC_ARGCHK(taglen != NULL);
+
+   if (ccm->x != 0) {
+      if ((err = cipher_descriptor[ccm->cipher].ecb_encrypt(ccm->PAD, ccm->PAD, &ccm->K)) != CRYPT_OK) {
+         return err;
+      }
+   }
+
+   /* setup CTR for the TAG (zero the count) */
+   for (y = 15; y > 15 - ccm->L; y--) {
+      ccm->ctr[y] = 0x00;
+   }
+   if ((err = cipher_descriptor[ccm->cipher].ecb_encrypt(ccm->ctr, ccm->CTRPAD, &ccm->K)) != CRYPT_OK) {
+      return err;
+   }
+
+   cipher_descriptor[ccm->cipher].done(&ccm->K);
+
+   /* store the TAG */
+   for (x = 0; x < 16 && x < *taglen; x++) {
+      tag[x] = ccm->PAD[x] ^ ccm->CTRPAD[x];
+   }
+   *taglen = x;
+
+   return CRYPT_OK;
+}
+
+#endif

--- a/src/encauth/ccm/ccm_init.c
+++ b/src/encauth/ccm/ccm_init.c
@@ -1,0 +1,78 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ *
+ * Tom St Denis, tomstdenis@gmail.com, http://libtom.org
+ */
+#include "tomcrypt.h"
+
+#ifdef LTC_CCM_MODE
+
+/**
+  Initialize a CCM state
+  @param ccm     The CCM state to initialize
+  @param cipher  The index of the cipher to use
+  @param key     The secret key
+  @param keylen  The length of the secret key
+  @param ptlen   The length of the plain/cipher text that will be processed
+  @param taglen  The max length of the MAC tag
+  @param aadlen  The length of the AAD
+
+  @return CRYPT_OK on success
+ */
+int ccm_init(ccm_state *ccm, int cipher,
+             const unsigned char *key, int keylen, int ptlen, int taglen, int aadlen)
+{
+   int            err;
+
+   LTC_ARGCHK(key    != NULL);
+   LTC_ARGCHK(taglen != 0);
+
+   memset(ccm, 0, sizeof(ccm_state));
+
+   /* check cipher input */
+   if ((err = cipher_is_valid(cipher)) != CRYPT_OK) {
+      return err;
+   }
+   if (cipher_descriptor[cipher].block_length != 16) {
+      return CRYPT_INVALID_CIPHER;
+   }
+
+   /* make sure the taglen is even and <= 16 */
+   ccm->taglen = taglen;
+   ccm->taglen &= ~1;
+   if (ccm->taglen > 16) {
+      ccm->taglen = 16;
+   }
+
+   /* can't use < 4 */
+   if (ccm->taglen < 4) {
+      return CRYPT_INVALID_ARG;
+   }
+
+   /* schedule key */
+   if ((err = cipher_descriptor[cipher].setup(key, keylen, 0, &ccm->K)) != CRYPT_OK) {
+      return err;
+   }
+   ccm->cipher = cipher;
+
+   /* let's get the L value */
+   ccm->ptlen = ptlen;
+   ccm->L   = 0;
+   while (ptlen) {
+      ++ccm->L;
+      ptlen >>= 8;
+   }
+   if (ccm->L <= 1) {
+      ccm->L = 2;
+   }
+
+   ccm->aadlen = aadlen;
+   return CRYPT_OK;
+}
+
+#endif

--- a/src/encauth/ccm/ccm_process.c
+++ b/src/encauth/ccm/ccm_process.c
@@ -1,0 +1,84 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ *
+ * Tom St Denis, tomstdenis@gmail.com, http://libtom.org
+ */
+#include "tomcrypt.h"
+
+#ifdef LTC_CCM_MODE
+
+/**
+  Process plaintext/ciphertext through CCM
+  @param ccm       The CCM state
+  @param pt        The plaintext
+  @param ptlen     The plaintext length (ciphertext length is the same)
+  @param ct        The ciphertext
+  @param direction Encrypt or Decrypt mode (CCM_ENCRYPT or CCM_DECRYPT)
+  @return CRYPT_OK on success
+ */
+int ccm_process(ccm_state *ccm,
+                unsigned char *pt,     unsigned long ptlen,
+                unsigned char *ct,
+                int direction)
+{
+   unsigned char  y, z, b;
+   int err;
+
+   /* Check aad has been correctly added */
+   if (ccm->aadlen != ccm->current_aadlen) {
+      return CRYPT_ERROR;
+   }
+
+   /* Check we do not process too much data */
+   if (ccm->ptlen < ccm->current_ptlen + ptlen) {
+      return CRYPT_ERROR;
+   }
+   ccm->current_ptlen += ptlen;
+
+   /* now handle the PT */
+   if (ptlen > 0) {
+      LTC_ARGCHK(pt != NULL);
+      LTC_ARGCHK(ct != NULL);
+      y = 0;
+
+      for (; y < ptlen; y++) {
+         /* increment the ctr? */
+         if (ccm->CTRlen == 16) {
+            for (z = 15; z > 15-ccm->L; z--) {
+               ccm->ctr[z] = (ccm->ctr[z] + 1) & 255;
+               if (ccm->ctr[z]) break;
+            }
+            if ((err = cipher_descriptor[ccm->cipher].ecb_encrypt(ccm->ctr, ccm->CTRPAD, &ccm->K)) != CRYPT_OK) {
+               return err;
+            }
+            ccm->CTRlen = 0;
+         }
+
+         /* if we encrypt we add the bytes to the MAC first */
+         if (direction == CCM_ENCRYPT) {
+            b     = pt[y];
+            ct[y] = b ^ ccm->CTRPAD[ccm->CTRlen++];
+         } else {
+            b     = ct[y] ^ ccm->CTRPAD[ccm->CTRlen++];
+            pt[y] = b;
+         }
+
+         if (ccm->x == 16) {
+            if ((err = cipher_descriptor[ccm->cipher].ecb_encrypt(ccm->PAD, ccm->PAD, &ccm->K)) != CRYPT_OK) {
+               return err;
+            }
+            ccm->x = 0;
+         }
+         ccm->PAD[ccm->x++] ^= b;
+      }
+   }
+
+   return CRYPT_OK;
+}
+
+#endif

--- a/src/encauth/ccm/ccm_reset.c
+++ b/src/encauth/ccm/ccm_reset.c
@@ -1,0 +1,33 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ *
+ * Tom St Denis, tomstdenis@gmail.com, http://libtom.org
+ */
+#include "tomcrypt.h"
+
+#ifdef LTC_CCM_MODE
+
+/**
+  Reset a CCM state to as if you just called ccm_init().  This saves the initialization time.
+  @param ccm   The CCM state to reset
+  @return CRYPT_OK on success
+*/
+int ccm_reset(ccm_state *ccm)
+{
+   LTC_ARGCHK(ccm != NULL);
+   zeromem(ccm->PAD, sizeof(ccm->PAD));
+   zeromem(ccm->ctr, sizeof(ccm->ctr));
+   zeromem(ccm->CTRPAD, sizeof(ccm->CTRPAD));
+   ccm->CTRlen = 0;
+   ccm->current_ptlen = 0;
+   ccm->current_aadlen = 0;
+
+   return CRYPT_OK;
+}
+
+#endif

--- a/src/headers/tomcrypt_mac.h
+++ b/src/headers/tomcrypt_mac.h
@@ -259,6 +259,44 @@ void ocb3_int_xor_blocks(unsigned char *out, const unsigned char *block_a, const
 #define CCM_ENCRYPT 0
 #define CCM_DECRYPT 1
 
+typedef struct {
+   symmetric_key       K;
+   int                 cipher,               /* which cipher */
+                       taglen,               /* length of the tag */
+                       x;                    /* index in PAD */
+
+   unsigned long       L,                    /* L value */
+                       ptlen,                /* length that will be enc / dec */
+                       current_ptlen,        /* current processed length */
+                       aadlen,               /* length of the aad */
+                       current_aadlen,       /* length of the currently provided add */
+                       noncelen;             /* length of the nonce */
+
+   unsigned char       PAD[16],
+                       ctr[16],
+                       CTRPAD[16],
+                       CTRlen;
+} ccm_state;
+
+int ccm_init(ccm_state *ccm, int cipher,
+             const unsigned char *key, int keylen, int ptlen, int taglen, int aad_len);
+
+int ccm_reset(ccm_state *ccm);
+
+int ccm_add_nonce(ccm_state *ccm,
+                  const unsigned char *nonce,     unsigned long noncelen);
+
+int ccm_add_aad(ccm_state *ccm,
+                const unsigned char *adata,  unsigned long adatalen);
+
+int ccm_process(ccm_state *ccm,
+                unsigned char *pt,     unsigned long ptlen,
+                unsigned char *ct,
+                int direction);
+
+int ccm_done(ccm_state *ccm,
+             unsigned char *tag,    unsigned long *taglen);
+
 int ccm_memory(int cipher,
     const unsigned char *key,    unsigned long keylen,
     symmetric_key       *uskey,


### PR DESCRIPTION
CCM is only meant for packet mode where the length of the input is known in
advance. Since it is a packet mode function, CCM only had one function that
performs the protocol.

However, incremental authentication is usefull in some usecases. It also
ensure some kind of coherencies when processing with a given authentication
mode or another. To achieve this aim, this commit adds the following functions:
    ccm_init()
    ccm_add_aad()
    cm_add_nonce()
    ccm_process()
    ccm_done()
    ccm_reset()
as well as the data structure
    ccm_state

Change-Id: I5225a42bb098708c4af07518b561bb00f85bc243
