### PR TITLE
make RSA verification routines constant-time

### DIFF
--- a/makefile
+++ b/makefile
@@ -120,10 +120,10 @@ OBJECTS=src/ciphers/aes/aes_enc.o src/ciphers/aes/aes.o src/ciphers/anubis.o src
 src/ciphers/camellia.o src/ciphers/cast5.o src/ciphers/des.o src/ciphers/kasumi.o src/ciphers/khazad.o \
 src/ciphers/kseed.o src/ciphers/multi2.o src/ciphers/noekeon.o src/ciphers/rc2.o src/ciphers/rc5.o \
 src/ciphers/rc6.o src/ciphers/safer/safer.o src/ciphers/safer/saferp.o src/ciphers/skipjack.o \
-src/ciphers/twofish/twofish.o src/ciphers/xtea.o src/encauth/ccm/ccm_memory.o \
-src/encauth/ccm/ccm_done.o src/encauth/ccm/ccm_process.o src/encauth/ccm/ccm_reset.o \
-src/encauth/ccm/ccm_add_aad.o src/encauth/ccm/ccm_init.o src/encauth/ccm/ccm_add_nonce.o \
-src/encauth/ccm/ccm_memory_ex.o src/encauth/ccm/ccm_test.o src/encauth/eax/eax_addheader.o \
+src/ciphers/twofish/twofish.o src/ciphers/xtea.o src/encauth/ccm/ccm_add_aad.o \
+src/encauth/ccm/ccm_add_nonce.o src/encauth/ccm/ccm_done.o src/encauth/ccm/ccm_init.o \
+src/encauth/ccm/ccm_memory.o src/encauth/ccm/ccm_memory_ex.o src/encauth/ccm/ccm_process.o \
+src/encauth/ccm/ccm_reset.o src/encauth/ccm/ccm_test.o src/encauth/eax/eax_addheader.o \
 src/encauth/eax/eax_decrypt.o src/encauth/eax/eax_decrypt_verify_memory.o src/encauth/eax/eax_done.o \
 src/encauth/eax/eax_encrypt_authenticate_memory.o src/encauth/eax/eax_encrypt.o \
 src/encauth/eax/eax_init.o src/encauth/eax/eax_test.o src/encauth/gcm/gcm_add_aad.o \
@@ -173,7 +173,7 @@ src/misc/crypt/crypt_prng_is_valid.o src/misc/crypt/crypt_register_cipher.o \
 src/misc/crypt/crypt_register_hash.o src/misc/crypt/crypt_register_prng.o src/misc/crypt/crypt_sizes.o \
 src/misc/crypt/crypt_unregister_cipher.o src/misc/crypt/crypt_unregister_hash.o \
 src/misc/crypt/crypt_unregister_prng.o src/misc/error_to_string.o src/misc/hkdf/hkdf.o \
-src/misc/hkdf/hkdf_test.o src/misc/pkcs5/pkcs_5_1.o src/misc/pkcs5/pkcs_5_2.o \
+src/misc/hkdf/hkdf_test.o src/misc/mem_neq.o src/misc/pkcs5/pkcs_5_1.o src/misc/pkcs5/pkcs_5_2.o \
 src/misc/pkcs5/pkcs_5_test.o src/misc/pk_get_oid.o src/misc/zeromem.o src/modes/cbc/cbc_decrypt.o \
 src/modes/cbc/cbc_done.o src/modes/cbc/cbc_encrypt.o src/modes/cbc/cbc_getiv.o \
 src/modes/cbc/cbc_setiv.o src/modes/cbc/cbc_start.o src/modes/cfb/cfb_decrypt.o \

--- a/makefile.icc
+++ b/makefile.icc
@@ -103,8 +103,10 @@ OBJECTS=src/ciphers/aes/aes_enc.o src/ciphers/aes/aes.o src/ciphers/anubis.o src
 src/ciphers/camellia.o src/ciphers/cast5.o src/ciphers/des.o src/ciphers/kasumi.o src/ciphers/khazad.o \
 src/ciphers/kseed.o src/ciphers/multi2.o src/ciphers/noekeon.o src/ciphers/rc2.o src/ciphers/rc5.o \
 src/ciphers/rc6.o src/ciphers/safer/safer.o src/ciphers/safer/saferp.o src/ciphers/skipjack.o \
-src/ciphers/twofish/twofish.o src/ciphers/xtea.o src/encauth/ccm/ccm_memory.o \
-src/encauth/ccm/ccm_memory_ex.o src/encauth/ccm/ccm_test.o src/encauth/eax/eax_addheader.o \
+src/ciphers/twofish/twofish.o src/ciphers/xtea.o src/encauth/ccm/ccm_add_aad.o \
+src/encauth/ccm/ccm_add_nonce.o src/encauth/ccm/ccm_done.o src/encauth/ccm/ccm_init.o \
+src/encauth/ccm/ccm_memory.o src/encauth/ccm/ccm_memory_ex.o src/encauth/ccm/ccm_process.o \
+src/encauth/ccm/ccm_reset.o src/encauth/ccm/ccm_test.o src/encauth/eax/eax_addheader.o \
 src/encauth/eax/eax_decrypt.o src/encauth/eax/eax_decrypt_verify_memory.o src/encauth/eax/eax_done.o \
 src/encauth/eax/eax_encrypt_authenticate_memory.o src/encauth/eax/eax_encrypt.o \
 src/encauth/eax/eax_init.o src/encauth/eax/eax_test.o src/encauth/gcm/gcm_add_aad.o \
@@ -154,7 +156,7 @@ src/misc/crypt/crypt_prng_is_valid.o src/misc/crypt/crypt_register_cipher.o \
 src/misc/crypt/crypt_register_hash.o src/misc/crypt/crypt_register_prng.o src/misc/crypt/crypt_sizes.o \
 src/misc/crypt/crypt_unregister_cipher.o src/misc/crypt/crypt_unregister_hash.o \
 src/misc/crypt/crypt_unregister_prng.o src/misc/error_to_string.o src/misc/hkdf/hkdf.o \
-src/misc/hkdf/hkdf_test.o src/misc/pkcs5/pkcs_5_1.o src/misc/pkcs5/pkcs_5_2.o \
+src/misc/hkdf/hkdf_test.o src/misc/mem_neq.o src/misc/pkcs5/pkcs_5_1.o src/misc/pkcs5/pkcs_5_2.o \
 src/misc/pkcs5/pkcs_5_test.o src/misc/pk_get_oid.o src/misc/zeromem.o src/modes/cbc/cbc_decrypt.o \
 src/modes/cbc/cbc_done.o src/modes/cbc/cbc_encrypt.o src/modes/cbc/cbc_getiv.o \
 src/modes/cbc/cbc_setiv.o src/modes/cbc/cbc_start.o src/modes/cfb/cfb_decrypt.o \

--- a/makefile.mingw
+++ b/makefile.mingw
@@ -50,8 +50,10 @@ OBJECTS=src/ciphers/aes/aes_enc.o src/ciphers/aes/aes.o src/ciphers/anubis.o src
 src/ciphers/camellia.o src/ciphers/cast5.o src/ciphers/des.o src/ciphers/kasumi.o src/ciphers/khazad.o \
 src/ciphers/kseed.o src/ciphers/multi2.o src/ciphers/noekeon.o src/ciphers/rc2.o src/ciphers/rc5.o \
 src/ciphers/rc6.o src/ciphers/safer/safer.o src/ciphers/safer/saferp.o src/ciphers/skipjack.o \
-src/ciphers/twofish/twofish.o src/ciphers/xtea.o src/encauth/ccm/ccm_memory.o \
-src/encauth/ccm/ccm_memory_ex.o src/encauth/ccm/ccm_test.o src/encauth/eax/eax_addheader.o \
+src/ciphers/twofish/twofish.o src/ciphers/xtea.o src/encauth/ccm/ccm_add_aad.o \
+src/encauth/ccm/ccm_add_nonce.o src/encauth/ccm/ccm_done.o src/encauth/ccm/ccm_init.o \
+src/encauth/ccm/ccm_memory.o src/encauth/ccm/ccm_memory_ex.o src/encauth/ccm/ccm_process.o \
+src/encauth/ccm/ccm_reset.o src/encauth/ccm/ccm_test.o src/encauth/eax/eax_addheader.o \
 src/encauth/eax/eax_decrypt.o src/encauth/eax/eax_decrypt_verify_memory.o src/encauth/eax/eax_done.o \
 src/encauth/eax/eax_encrypt_authenticate_memory.o src/encauth/eax/eax_encrypt.o \
 src/encauth/eax/eax_init.o src/encauth/eax/eax_test.o src/encauth/gcm/gcm_add_aad.o \
@@ -101,7 +103,7 @@ src/misc/crypt/crypt_prng_is_valid.o src/misc/crypt/crypt_register_cipher.o \
 src/misc/crypt/crypt_register_hash.o src/misc/crypt/crypt_register_prng.o src/misc/crypt/crypt_sizes.o \
 src/misc/crypt/crypt_unregister_cipher.o src/misc/crypt/crypt_unregister_hash.o \
 src/misc/crypt/crypt_unregister_prng.o src/misc/error_to_string.o src/misc/hkdf/hkdf.o \
-src/misc/hkdf/hkdf_test.o src/misc/pkcs5/pkcs_5_1.o src/misc/pkcs5/pkcs_5_2.o \
+src/misc/hkdf/hkdf_test.o src/misc/mem_neq.o src/misc/pkcs5/pkcs_5_1.o src/misc/pkcs5/pkcs_5_2.o \
 src/misc/pkcs5/pkcs_5_test.o src/misc/pk_get_oid.o src/misc/zeromem.o src/modes/cbc/cbc_decrypt.o \
 src/modes/cbc/cbc_done.o src/modes/cbc/cbc_encrypt.o src/modes/cbc/cbc_getiv.o \
 src/modes/cbc/cbc_setiv.o src/modes/cbc/cbc_start.o src/modes/cfb/cfb_decrypt.o \

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -8,8 +8,10 @@ OBJECTS=src/ciphers/aes/aes_enc.obj src/ciphers/aes/aes.obj src/ciphers/anubis.o
 src/ciphers/camellia.obj src/ciphers/cast5.obj src/ciphers/des.obj src/ciphers/kasumi.obj src/ciphers/khazad.obj \
 src/ciphers/kseed.obj src/ciphers/multi2.obj src/ciphers/noekeon.obj src/ciphers/rc2.obj src/ciphers/rc5.obj \
 src/ciphers/rc6.obj src/ciphers/safer/safer.obj src/ciphers/safer/saferp.obj src/ciphers/skipjack.obj \
-src/ciphers/twofish/twofish.obj src/ciphers/xtea.obj src/encauth/ccm/ccm_memory.obj \
-src/encauth/ccm/ccm_memory_ex.obj src/encauth/ccm/ccm_test.obj src/encauth/eax/eax_addheader.obj \
+src/ciphers/twofish/twofish.obj src/ciphers/xtea.obj src/encauth/ccm/ccm_add_aad.obj \
+src/encauth/ccm/ccm_add_nonce.obj src/encauth/ccm/ccm_done.obj src/encauth/ccm/ccm_init.obj \
+src/encauth/ccm/ccm_memory.obj src/encauth/ccm/ccm_memory_ex.obj src/encauth/ccm/ccm_process.obj \
+src/encauth/ccm/ccm_reset.obj src/encauth/ccm/ccm_test.obj src/encauth/eax/eax_addheader.obj \
 src/encauth/eax/eax_decrypt.obj src/encauth/eax/eax_decrypt_verify_memory.obj src/encauth/eax/eax_done.obj \
 src/encauth/eax/eax_encrypt_authenticate_memory.obj src/encauth/eax/eax_encrypt.obj \
 src/encauth/eax/eax_init.obj src/encauth/eax/eax_test.obj src/encauth/gcm/gcm_add_aad.obj \
@@ -59,7 +61,7 @@ src/misc/crypt/crypt_prng_is_valid.obj src/misc/crypt/crypt_register_cipher.obj 
 src/misc/crypt/crypt_register_hash.obj src/misc/crypt/crypt_register_prng.obj src/misc/crypt/crypt_sizes.obj \
 src/misc/crypt/crypt_unregister_cipher.obj src/misc/crypt/crypt_unregister_hash.obj \
 src/misc/crypt/crypt_unregister_prng.obj src/misc/error_to_string.obj src/misc/hkdf/hkdf.obj \
-src/misc/hkdf/hkdf_test.obj src/misc/pkcs5/pkcs_5_1.obj src/misc/pkcs5/pkcs_5_2.obj \
+src/misc/hkdf/hkdf_test.obj src/misc/mem_neq.obj src/misc/pkcs5/pkcs_5_1.obj src/misc/pkcs5/pkcs_5_2.obj \
 src/misc/pkcs5/pkcs_5_test.obj src/misc/pk_get_oid.obj src/misc/zeromem.obj src/modes/cbc/cbc_decrypt.obj \
 src/modes/cbc/cbc_done.obj src/modes/cbc/cbc_encrypt.obj src/modes/cbc/cbc_getiv.obj \
 src/modes/cbc/cbc_setiv.obj src/modes/cbc/cbc_start.obj src/modes/cfb/cfb_decrypt.obj \

--- a/makefile.shared
+++ b/makefile.shared
@@ -105,8 +105,10 @@ OBJECTS=src/ciphers/aes/aes_enc.o src/ciphers/aes/aes.o src/ciphers/anubis.o src
 src/ciphers/camellia.o src/ciphers/cast5.o src/ciphers/des.o src/ciphers/kasumi.o src/ciphers/khazad.o \
 src/ciphers/kseed.o src/ciphers/multi2.o src/ciphers/noekeon.o src/ciphers/rc2.o src/ciphers/rc5.o \
 src/ciphers/rc6.o src/ciphers/safer/safer.o src/ciphers/safer/saferp.o src/ciphers/skipjack.o \
-src/ciphers/twofish/twofish.o src/ciphers/xtea.o src/encauth/ccm/ccm_memory.o \
-src/encauth/ccm/ccm_memory_ex.o src/encauth/ccm/ccm_test.o src/encauth/eax/eax_addheader.o \
+src/ciphers/twofish/twofish.o src/ciphers/xtea.o src/encauth/ccm/ccm_add_aad.o \
+src/encauth/ccm/ccm_add_nonce.o src/encauth/ccm/ccm_done.o src/encauth/ccm/ccm_init.o \
+src/encauth/ccm/ccm_memory.o src/encauth/ccm/ccm_memory_ex.o src/encauth/ccm/ccm_process.o \
+src/encauth/ccm/ccm_reset.o src/encauth/ccm/ccm_test.o src/encauth/eax/eax_addheader.o \
 src/encauth/eax/eax_decrypt.o src/encauth/eax/eax_decrypt_verify_memory.o src/encauth/eax/eax_done.o \
 src/encauth/eax/eax_encrypt_authenticate_memory.o src/encauth/eax/eax_encrypt.o \
 src/encauth/eax/eax_init.o src/encauth/eax/eax_test.o src/encauth/gcm/gcm_add_aad.o \
@@ -156,7 +158,7 @@ src/misc/crypt/crypt_prng_is_valid.o src/misc/crypt/crypt_register_cipher.o \
 src/misc/crypt/crypt_register_hash.o src/misc/crypt/crypt_register_prng.o src/misc/crypt/crypt_sizes.o \
 src/misc/crypt/crypt_unregister_cipher.o src/misc/crypt/crypt_unregister_hash.o \
 src/misc/crypt/crypt_unregister_prng.o src/misc/error_to_string.o src/misc/hkdf/hkdf.o \
-src/misc/hkdf/hkdf_test.o src/misc/pkcs5/pkcs_5_1.o src/misc/pkcs5/pkcs_5_2.o \
+src/misc/hkdf/hkdf_test.o src/misc/mem_neq.o src/misc/pkcs5/pkcs_5_1.o src/misc/pkcs5/pkcs_5_2.o \
 src/misc/pkcs5/pkcs_5_test.o src/misc/pk_get_oid.o src/misc/zeromem.o src/modes/cbc/cbc_decrypt.o \
 src/modes/cbc/cbc_done.o src/modes/cbc/cbc_encrypt.o src/modes/cbc/cbc_getiv.o \
 src/modes/cbc/cbc_setiv.o src/modes/cbc/cbc_start.o src/modes/cfb/cfb_decrypt.o \

--- a/makefile.unix
+++ b/makefile.unix
@@ -44,8 +44,10 @@ OBJECTS=src/ciphers/aes/aes_enc.o src/ciphers/aes/aes.o src/ciphers/anubis.o src
 src/ciphers/camellia.o src/ciphers/cast5.o src/ciphers/des.o src/ciphers/kasumi.o src/ciphers/khazad.o \
 src/ciphers/kseed.o src/ciphers/multi2.o src/ciphers/noekeon.o src/ciphers/rc2.o src/ciphers/rc5.o \
 src/ciphers/rc6.o src/ciphers/safer/safer.o src/ciphers/safer/saferp.o src/ciphers/skipjack.o \
-src/ciphers/twofish/twofish.o src/ciphers/xtea.o src/encauth/ccm/ccm_memory.o \
-src/encauth/ccm/ccm_memory_ex.o src/encauth/ccm/ccm_test.o src/encauth/eax/eax_addheader.o \
+src/ciphers/twofish/twofish.o src/ciphers/xtea.o src/encauth/ccm/ccm_add_aad.o \
+src/encauth/ccm/ccm_add_nonce.o src/encauth/ccm/ccm_done.o src/encauth/ccm/ccm_init.o \
+src/encauth/ccm/ccm_memory.o src/encauth/ccm/ccm_memory_ex.o src/encauth/ccm/ccm_process.o \
+src/encauth/ccm/ccm_reset.o src/encauth/ccm/ccm_test.o src/encauth/eax/eax_addheader.o \
 src/encauth/eax/eax_decrypt.o src/encauth/eax/eax_decrypt_verify_memory.o src/encauth/eax/eax_done.o \
 src/encauth/eax/eax_encrypt_authenticate_memory.o src/encauth/eax/eax_encrypt.o \
 src/encauth/eax/eax_init.o src/encauth/eax/eax_test.o src/encauth/gcm/gcm_add_aad.o \
@@ -95,7 +97,7 @@ src/misc/crypt/crypt_prng_is_valid.o src/misc/crypt/crypt_register_cipher.o \
 src/misc/crypt/crypt_register_hash.o src/misc/crypt/crypt_register_prng.o src/misc/crypt/crypt_sizes.o \
 src/misc/crypt/crypt_unregister_cipher.o src/misc/crypt/crypt_unregister_hash.o \
 src/misc/crypt/crypt_unregister_prng.o src/misc/error_to_string.o src/misc/hkdf/hkdf.o \
-src/misc/hkdf/hkdf_test.o src/misc/pkcs5/pkcs_5_1.o src/misc/pkcs5/pkcs_5_2.o \
+src/misc/hkdf/hkdf_test.o src/misc/mem_neq.o src/misc/pkcs5/pkcs_5_1.o src/misc/pkcs5/pkcs_5_2.o \
 src/misc/pkcs5/pkcs_5_test.o src/misc/pk_get_oid.o src/misc/zeromem.o src/modes/cbc/cbc_decrypt.o \
 src/modes/cbc/cbc_done.o src/modes/cbc/cbc_encrypt.o src/modes/cbc/cbc_getiv.o \
 src/modes/cbc/cbc_setiv.o src/modes/cbc/cbc_start.o src/modes/cfb/cfb_decrypt.o \

--- a/src/headers/tomcrypt_misc.h
+++ b/src/headers/tomcrypt_misc.h
@@ -39,6 +39,7 @@ int hkdf(int hash_idx,
 #endif  /* LTC_HKDF */
 
 /* ---- MEM routines ---- */
+int mem_neq(const void *a, const void *b, size_t len);
 void zeromem(volatile void *dst, size_t len);
 void burn_stack(unsigned long len);
 

--- a/src/misc/mem_neq.c
+++ b/src/misc/mem_neq.c
@@ -1,0 +1,55 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ *
+ * Tom St Denis, tomstdenis@gmail.com, http://libtom.org
+ */
+#include "tomcrypt.h"
+
+/**
+   @file mem_neq.c
+   Compare two blocks of memory for inequality.
+   Steffen Jaeckel
+*/
+
+/**
+   Compare two blocks of memory for inequality.
+
+   The usage is similar to that of standard memcmp(), but you can only test
+   if the memory is equal or not - you can not determine by how much the
+   first different byte differs.
+
+   @param a     The first memory region
+   @param b     The second memory region
+   @param len   The length of the area to compare (octets)
+
+   @return 0 when a and b are equal for len bytes, else they are not equal.
+*/
+int mem_neq(const void *a, const void *b, size_t len)
+{
+   unsigned char ret = 0;
+   const unsigned char* pa;
+   const unsigned char* pb;
+
+   LTC_ARGCHK(a != NULL);
+   LTC_ARGCHK(b != NULL);
+
+   pa = a;
+   pb = b;
+
+   while (len-- > 0) {
+      ret |= *pa ^ *pb;
+      ++pa;
+      ++pb;
+   }
+
+   return ret;
+}
+
+/* $Source$ */
+/* $Revision$ */
+/* $Date$ */

--- a/src/pk/pkcs1/pkcs_1_oaep_decode.c
+++ b/src/pk/pkcs1/pkcs_1_oaep_decode.c
@@ -136,7 +136,7 @@ int pkcs_1_oaep_decode(const unsigned char *msg,    unsigned long msglen,
    }
 
    /* compare the lhash'es */
-   if (XMEMCMP(seed, DB, hLen) != 0) {
+   if (mem_neq(seed, DB, hLen) != 0) {
       err = CRYPT_OK;
       goto LBL_ERR;
    }

--- a/src/pk/pkcs1/pkcs_1_oaep_decode.c
+++ b/src/pk/pkcs1/pkcs_1_oaep_decode.c
@@ -28,7 +28,7 @@
    @param out              [out] Destination of decoding
    @param outlen           [in/out] The max size and resulting size of the decoding
    @param res              [out] Result of decoding, 1==valid, 0==invalid
-   @return CRYPT_OK if successful (even if invalid)
+   @return CRYPT_OK if successful
 */
 int pkcs_1_oaep_decode(const unsigned char *msg,    unsigned long msglen,
                        const unsigned char *lparam, unsigned long lparamlen,
@@ -38,7 +38,7 @@ int pkcs_1_oaep_decode(const unsigned char *msg,    unsigned long msglen,
 {
    unsigned char *DB, *seed, *mask;
    unsigned long hLen, x, y, modulus_len;
-   int           err;
+   int           err, ret;
 
    LTC_ARGCHK(msg    != NULL);
    LTC_ARGCHK(out    != NULL);
@@ -85,10 +85,12 @@ int pkcs_1_oaep_decode(const unsigned char *msg,    unsigned long msglen,
 
     */
 
+   err = CRYPT_OK;
+   ret = CRYPT_OK;
+
    /* must have leading 0x00 byte */
    if (msg[0] != 0x00) {
-      err = CRYPT_OK;
-      goto LBL_ERR;
+      ret = CRYPT_INVALID_PACKET;
    }
 
    /* now read the masked seed */
@@ -137,8 +139,7 @@ int pkcs_1_oaep_decode(const unsigned char *msg,    unsigned long msglen,
 
    /* compare the lhash'es */
    if (mem_neq(seed, DB, hLen) != 0) {
-      err = CRYPT_OK;
-      goto LBL_ERR;
+      ret = CRYPT_INVALID_PACKET;
    }
 
    /* now zeroes before a 0x01 */
@@ -146,28 +147,27 @@ int pkcs_1_oaep_decode(const unsigned char *msg,    unsigned long msglen,
       /* step... */
    }
 
-   /* error out if wasn't 0x01 */
+   /* error if wasn't 0x01 */
    if (x == (modulus_len - hLen - 1) || DB[x] != 0x01) {
-      err = CRYPT_INVALID_PACKET;
-      goto LBL_ERR;
+      ret = CRYPT_INVALID_PACKET;
    }
 
    /* rest is the message (and skip 0x01) */
    if ((modulus_len - hLen - 1 - ++x) > *outlen) {
-      *outlen = modulus_len - hLen - 1 - x;
-      err = CRYPT_BUFFER_OVERFLOW;
-      goto LBL_ERR;
+      ret = CRYPT_INVALID_PACKET;
    }
 
-   /* copy message */
-   *outlen = modulus_len - hLen - 1 - x;
-   XMEMCPY(out, DB + x, modulus_len - hLen - 1 - x);
-   x += modulus_len - hLen - 1;
+   if (ret == CRYPT_OK) {
+      /* copy message */
+      *outlen = modulus_len - hLen - 1 - x;
+      XMEMCPY(out, DB + x, modulus_len - hLen - 1 - x);
+      x += modulus_len - hLen - 1;
 
-   /* valid packet */
-   *res = 1;
+      /* valid packet */
+      *res = 1;
+   }
+   err = ret;
 
-   err = CRYPT_OK;
 LBL_ERR:
 #ifdef LTC_CLEAN_STACK
    zeromem(DB,   modulus_len);

--- a/src/pk/pkcs1/pkcs_1_pss_decode.c
+++ b/src/pk/pkcs1/pkcs_1_pss_decode.c
@@ -151,7 +151,7 @@ int pkcs_1_pss_decode(const unsigned char *msghash, unsigned long msghashlen,
    }
 
    /* mask == hash means valid signature */
-   if (XMEMCMP(mask, hash, hLen) == 0) {
+   if (mem_neq(mask, hash, hLen) == 0) {
       *res = 1;
    }
 

--- a/src/pk/rsa/rsa_verify_hash.c
+++ b/src/pk/rsa/rsa_verify_hash.c
@@ -153,9 +153,9 @@ int rsa_verify_hash_ex(const unsigned char *sig,      unsigned long siglen,
     /* test OID */
     if ((reallen == outlen) &&
         (digestinfo[0].size == hash_descriptor[hash_idx].OIDlen) &&
-        (XMEMCMP(digestinfo[0].data, hash_descriptor[hash_idx].OID, sizeof(unsigned long) * hash_descriptor[hash_idx].OIDlen) == 0) &&
+        (mem_neq(digestinfo[0].data, hash_descriptor[hash_idx].OID, sizeof(unsigned long) * hash_descriptor[hash_idx].OIDlen) == 0) &&
         (siginfo[1].size == hashlen) &&
-        (XMEMCMP(siginfo[1].data, hash, hashlen) == 0)) {
+        (mem_neq(siginfo[1].data, hash, hashlen) == 0)) {
        *stat = 1;
     }
 

--- a/testprof/rsa_test.c
+++ b/testprof/rsa_test.c
@@ -138,7 +138,7 @@ int rsa_test(void)
 {
    unsigned char in[1024], out[1024], tmp[1024];
    rsa_key       key, privKey, pubKey;
-   int           hash_idx, prng_idx, stat, stat2, i;
+   int           hash_idx, prng_idx, stat, stat2, i, err;
    unsigned long rsa_msgsize, len, len2, len3, cnt, cnt2;
    static unsigned char lparam[] = { 0x01, 0x02, 0x03, 0x04 };
 
@@ -204,11 +204,12 @@ for (cnt = 0; cnt < len; ) {
       DO(rsa_encrypt_key(in, rsa_msgsize, out, &len, NULL, 0, &yarrow_prng, prng_idx, hash_idx, &key));
       /* change a byte */
       out[8] ^= 1;
-      DO(rsa_decrypt_key(out, len, tmp, &len2, NULL, 0, hash_idx, &stat2, &key));
+      DOX((err = rsa_decrypt_key(out, len, tmp, &len2, NULL, 0, hash_idx, &stat2, &key))
+          == CRYPT_INVALID_PACKET ? CRYPT_OK:err, "should fail");
       /* change a byte back */
       out[8] ^= 1;
       if (len2 != rsa_msgsize) {
-         fprintf(stderr, "\nrsa_decrypt_key mismatch len %lu (first decrypt)", len2);
+         fprintf(stderr, "\n%i:rsa_decrypt_key mismatch len %lu (first decrypt)", __LINE__, len2);
          return 1;
       }
 
@@ -235,9 +236,10 @@ for (cnt = 0; cnt < len; ) {
       DO(rsa_encrypt_key(in, rsa_msgsize, out, &len, lparam, sizeof(lparam), &yarrow_prng, prng_idx, hash_idx, &key));
       /* change a byte */
       out[8] ^= 1;
-      DO(rsa_decrypt_key(out, len, tmp, &len2, lparam, sizeof(lparam), hash_idx, &stat2, &key));
+      DOX((err = rsa_decrypt_key(out, len, tmp, &len2, lparam, sizeof(lparam), hash_idx, &stat2, &key))
+          == CRYPT_INVALID_PACKET ? CRYPT_OK:err, "should fail");
       if (len2 != rsa_msgsize) {
-         fprintf(stderr, "\nrsa_decrypt_key mismatch len %lu (first decrypt)", len2);
+         fprintf(stderr, "\n%i:rsa_decrypt_key mismatch len %lu (first decrypt)", __LINE__, len2);
          return 1;
       }
       /* change a byte back */


### PR DESCRIPTION
I thought we should have a constant-time memcmp() as well, as it's not yet provided from some standard library.
Any comments?

I will replace the different calls to the std. memcmp() in the rsa/pkcs#1 code afterwards.