### PR TITLE
Use XMEMCMP_NEQ instead of mem_neq

### DIFF
--- a/src/headers/tomcrypt_custom.h
+++ b/src/headers/tomcrypt_custom.h
@@ -45,6 +45,9 @@
    #endif
 #define XMEMCMP  memcmp
 #endif
+#ifndef XMEM_NEQ
+#define XMEM_NEQ  mem_neq
+#endif
 #ifndef XSTRCMP
    #ifdef strcmp
    #define LTC_NO_PROTOTYPES

--- a/src/pk/pkcs1/pkcs_1_oaep_decode.c
+++ b/src/pk/pkcs1/pkcs_1_oaep_decode.c
@@ -138,7 +138,7 @@ int pkcs_1_oaep_decode(const unsigned char *msg,    unsigned long msglen,
    }
 
    /* compare the lhash'es */
-   if (mem_neq(seed, DB, hLen) != 0) {
+   if (XMEM_NEQ(seed, DB, hLen) != 0) {
       ret = CRYPT_INVALID_PACKET;
    }
 

--- a/src/pk/pkcs1/pkcs_1_pss_decode.c
+++ b/src/pk/pkcs1/pkcs_1_pss_decode.c
@@ -151,7 +151,7 @@ int pkcs_1_pss_decode(const unsigned char *msghash, unsigned long msghashlen,
    }
 
    /* mask == hash means valid signature */
-   if (mem_neq(mask, hash, hLen) == 0) {
+   if (XMEM_NEQ(mask, hash, hLen) == 0) {
       *res = 1;
    }
 

--- a/src/pk/rsa/rsa_verify_hash.c
+++ b/src/pk/rsa/rsa_verify_hash.c
@@ -153,9 +153,9 @@ int rsa_verify_hash_ex(const unsigned char *sig,      unsigned long siglen,
     /* test OID */
     if ((reallen == outlen) &&
         (digestinfo[0].size == hash_descriptor[hash_idx].OIDlen) &&
-        (mem_neq(digestinfo[0].data, hash_descriptor[hash_idx].OID, sizeof(unsigned long) * hash_descriptor[hash_idx].OIDlen) == 0) &&
+        (XMEM_NEQ(digestinfo[0].data, hash_descriptor[hash_idx].OID, sizeof(unsigned long) * hash_descriptor[hash_idx].OIDlen) == 0) &&
         (siginfo[1].size == hashlen) &&
-        (mem_neq(siginfo[1].data, hash, hashlen) == 0)) {
+        (XMEM_NEQ(siginfo[1].data, hash, hashlen) == 0)) {
        *stat = 1;
     }
 


### PR DESCRIPTION
mem_neq is no more used directly. XMEMCMP_NEQ is used instead,
in the same way XMEMCMP, XMEMCPY,... are.

Signed-off-by: Pascal Brand <pascal.brand@st.com>