### PR TITLE
Implement RSA-CRT hardening

### DIFF
--- a/src/headers/tomcrypt_custom.h
+++ b/src/headers/tomcrypt_custom.h
@@ -402,6 +402,11 @@
 #define LTC_RSA_BLINDING
 #endif  /* LTC_NO_RSA_BLINDING */
 
+#if defined(LTC_MRSA) && !defined(LTC_NO_RSA_CRT_HARDENING)
+/* Enable RSA CRT hardening when doing private key operations by default */
+#define LTC_RSA_CRT_HARDENING
+#endif  /* LTC_NO_RSA_CRT_HARDENING */
+
 #if defined(LTC_MECC) && !defined(LTC_NO_ECC_TIMING_RESISTANT)
 /* Enable ECC timing resistant version by default */
 #define LTC_ECC_TIMING_RESISTANT


### PR DESCRIPTION
Please implement RSA-CRT hardening, to avoid leaking RSA private keys in case there is a computation error (hardware fault or bignum library implementation problem) during a signature computation involving the RSA-CRT optimization:

* https://securityblog.redhat.com/2015/09/02/factoring-rsa-keys-with-tls-perfect-forward-secrecy/
* https://people.redhat.com/~fweimer/rsa-crt-leaks.pdf
