### PR TITLE
add ltc_rng function pointer

### DIFF
--- a/libtomcrypt_VS2005.vcproj
+++ b/libtomcrypt_VS2005.vcproj
@@ -1098,6 +1098,10 @@
 					>
 				</File>
 				<File
+					RelativePath="src\misc\crypt\crypt_prng_rng_descriptor.c"
+					>
+				</File>
+				<File
 					RelativePath="src\misc\crypt\crypt_register_cipher.c"
 					>
 				</File>

--- a/libtomcrypt_VS2008.vcproj
+++ b/libtomcrypt_VS2008.vcproj
@@ -1100,6 +1100,10 @@
 					>
 				</File>
 				<File
+					RelativePath="src\misc\crypt\crypt_prng_rng_descriptor.c"
+					>
+				</File>
+				<File
 					RelativePath="src\misc\crypt\crypt_register_cipher.c"
 					>
 				</File>

--- a/makefile
+++ b/makefile
@@ -95,8 +95,8 @@ src/misc/crypt/crypt_find_hash_oid.o src/misc/crypt/crypt_find_prng.o src/misc/c
 src/misc/crypt/crypt_hash_descriptor.o src/misc/crypt/crypt_hash_is_valid.o \
 src/misc/crypt/crypt_inits.o src/misc/crypt/crypt_ltc_mp_descriptor.o \
 src/misc/crypt/crypt_prng_descriptor.o src/misc/crypt/crypt_prng_is_valid.o \
-src/misc/crypt/crypt_register_cipher.o src/misc/crypt/crypt_register_hash.o \
-src/misc/crypt/crypt_register_prng.o src/misc/crypt/crypt_sizes.o \
+src/misc/crypt/crypt_prng_rng_descriptor.o src/misc/crypt/crypt_register_cipher.o \
+src/misc/crypt/crypt_register_hash.o src/misc/crypt/crypt_register_prng.o src/misc/crypt/crypt_sizes.o \
 src/misc/crypt/crypt_unregister_cipher.o src/misc/crypt/crypt_unregister_hash.o \
 src/misc/crypt/crypt_unregister_prng.o src/misc/error_to_string.o src/misc/hkdf/hkdf.o \
 src/misc/hkdf/hkdf_test.o src/misc/mem_neq.o src/misc/pk_get_oid.o src/misc/pkcs5/pkcs_5_1.o \

--- a/makefile.icc
+++ b/makefile.icc
@@ -152,8 +152,8 @@ src/misc/crypt/crypt_find_hash_oid.o src/misc/crypt/crypt_find_prng.o src/misc/c
 src/misc/crypt/crypt_hash_descriptor.o src/misc/crypt/crypt_hash_is_valid.o \
 src/misc/crypt/crypt_inits.o src/misc/crypt/crypt_ltc_mp_descriptor.o \
 src/misc/crypt/crypt_prng_descriptor.o src/misc/crypt/crypt_prng_is_valid.o \
-src/misc/crypt/crypt_register_cipher.o src/misc/crypt/crypt_register_hash.o \
-src/misc/crypt/crypt_register_prng.o src/misc/crypt/crypt_sizes.o \
+src/misc/crypt/crypt_prng_rng_descriptor.o src/misc/crypt/crypt_register_cipher.o \
+src/misc/crypt/crypt_register_hash.o src/misc/crypt/crypt_register_prng.o src/misc/crypt/crypt_sizes.o \
 src/misc/crypt/crypt_unregister_cipher.o src/misc/crypt/crypt_unregister_hash.o \
 src/misc/crypt/crypt_unregister_prng.o src/misc/error_to_string.o src/misc/hkdf/hkdf.o \
 src/misc/hkdf/hkdf_test.o src/misc/mem_neq.o src/misc/pk_get_oid.o src/misc/pkcs5/pkcs_5_1.o \

--- a/makefile.mingw
+++ b/makefile.mingw
@@ -99,8 +99,8 @@ src/misc/crypt/crypt_find_hash_oid.o src/misc/crypt/crypt_find_prng.o src/misc/c
 src/misc/crypt/crypt_hash_descriptor.o src/misc/crypt/crypt_hash_is_valid.o \
 src/misc/crypt/crypt_inits.o src/misc/crypt/crypt_ltc_mp_descriptor.o \
 src/misc/crypt/crypt_prng_descriptor.o src/misc/crypt/crypt_prng_is_valid.o \
-src/misc/crypt/crypt_register_cipher.o src/misc/crypt/crypt_register_hash.o \
-src/misc/crypt/crypt_register_prng.o src/misc/crypt/crypt_sizes.o \
+src/misc/crypt/crypt_prng_rng_descriptor.o src/misc/crypt/crypt_register_cipher.o \
+src/misc/crypt/crypt_register_hash.o src/misc/crypt/crypt_register_prng.o src/misc/crypt/crypt_sizes.o \
 src/misc/crypt/crypt_unregister_cipher.o src/misc/crypt/crypt_unregister_hash.o \
 src/misc/crypt/crypt_unregister_prng.o src/misc/error_to_string.o src/misc/hkdf/hkdf.o \
 src/misc/hkdf/hkdf_test.o src/misc/mem_neq.o src/misc/pk_get_oid.o src/misc/pkcs5/pkcs_5_1.o \

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -57,8 +57,8 @@ src/misc/crypt/crypt_find_hash_oid.obj src/misc/crypt/crypt_find_prng.obj src/mi
 src/misc/crypt/crypt_hash_descriptor.obj src/misc/crypt/crypt_hash_is_valid.obj \
 src/misc/crypt/crypt_inits.obj src/misc/crypt/crypt_ltc_mp_descriptor.obj \
 src/misc/crypt/crypt_prng_descriptor.obj src/misc/crypt/crypt_prng_is_valid.obj \
-src/misc/crypt/crypt_register_cipher.obj src/misc/crypt/crypt_register_hash.obj \
-src/misc/crypt/crypt_register_prng.obj src/misc/crypt/crypt_sizes.obj \
+src/misc/crypt/crypt_prng_rng_descriptor.obj src/misc/crypt/crypt_register_cipher.obj \
+src/misc/crypt/crypt_register_hash.obj src/misc/crypt/crypt_register_prng.obj src/misc/crypt/crypt_sizes.obj \
 src/misc/crypt/crypt_unregister_cipher.obj src/misc/crypt/crypt_unregister_hash.obj \
 src/misc/crypt/crypt_unregister_prng.obj src/misc/error_to_string.obj src/misc/hkdf/hkdf.obj \
 src/misc/hkdf/hkdf_test.obj src/misc/mem_neq.obj src/misc/pk_get_oid.obj src/misc/pkcs5/pkcs_5_1.obj \

--- a/makefile.shared
+++ b/makefile.shared
@@ -85,8 +85,8 @@ src/misc/crypt/crypt_find_hash_oid.o src/misc/crypt/crypt_find_prng.o src/misc/c
 src/misc/crypt/crypt_hash_descriptor.o src/misc/crypt/crypt_hash_is_valid.o \
 src/misc/crypt/crypt_inits.o src/misc/crypt/crypt_ltc_mp_descriptor.o \
 src/misc/crypt/crypt_prng_descriptor.o src/misc/crypt/crypt_prng_is_valid.o \
-src/misc/crypt/crypt_register_cipher.o src/misc/crypt/crypt_register_hash.o \
-src/misc/crypt/crypt_register_prng.o src/misc/crypt/crypt_sizes.o \
+src/misc/crypt/crypt_prng_rng_descriptor.o src/misc/crypt/crypt_register_cipher.o \
+src/misc/crypt/crypt_register_hash.o src/misc/crypt/crypt_register_prng.o src/misc/crypt/crypt_sizes.o \
 src/misc/crypt/crypt_unregister_cipher.o src/misc/crypt/crypt_unregister_hash.o \
 src/misc/crypt/crypt_unregister_prng.o src/misc/error_to_string.o src/misc/hkdf/hkdf.o \
 src/misc/hkdf/hkdf_test.o src/misc/mem_neq.o src/misc/pk_get_oid.o src/misc/pkcs5/pkcs_5_1.o \

--- a/makefile.unix
+++ b/makefile.unix
@@ -93,8 +93,8 @@ src/misc/crypt/crypt_find_hash_oid.o src/misc/crypt/crypt_find_prng.o src/misc/c
 src/misc/crypt/crypt_hash_descriptor.o src/misc/crypt/crypt_hash_is_valid.o \
 src/misc/crypt/crypt_inits.o src/misc/crypt/crypt_ltc_mp_descriptor.o \
 src/misc/crypt/crypt_prng_descriptor.o src/misc/crypt/crypt_prng_is_valid.o \
-src/misc/crypt/crypt_register_cipher.o src/misc/crypt/crypt_register_hash.o \
-src/misc/crypt/crypt_register_prng.o src/misc/crypt/crypt_sizes.o \
+src/misc/crypt/crypt_prng_rng_descriptor.o src/misc/crypt/crypt_register_cipher.o \
+src/misc/crypt/crypt_register_hash.o src/misc/crypt/crypt_register_prng.o src/misc/crypt/crypt_sizes.o \
 src/misc/crypt/crypt_unregister_cipher.o src/misc/crypt/crypt_unregister_hash.o \
 src/misc/crypt/crypt_unregister_prng.o src/misc/error_to_string.o src/misc/hkdf/hkdf.o \
 src/misc/hkdf/hkdf_test.o src/misc/mem_neq.o src/misc/pk_get_oid.o src/misc/pkcs5/pkcs_5_1.o \

--- a/src/headers/tomcrypt_custom.h
+++ b/src/headers/tomcrypt_custom.h
@@ -304,6 +304,9 @@
 /* rng_make_prng() */
 #define LTC_RNG_MAKE_PRNG
 
+/* enable the ltc_rng hook to integrate e.g. embedded hardware RNG's easily */
+/* #define LTC_PRNG_ENABLE_LTC_RNG */
+
 #endif /* LTC_NO_PRNGS */
 
 #ifdef LTC_YARROW

--- a/src/headers/tomcrypt_prng.h
+++ b/src/headers/tomcrypt_prng.h
@@ -193,8 +193,10 @@ unsigned long rng_get_bytes(unsigned char *out,
 
 int rng_make_prng(int bits, int wprng, prng_state *prng, void (*callback)(void));
 
+#ifdef LTC_PRNG_ENABLE_LTC_RNG
 extern unsigned long (*ltc_rng)(unsigned char *out, unsigned long outlen,
       void (*callback)(void));
+#endif
 
 
 /* $Source$ */

--- a/src/headers/tomcrypt_prng.h
+++ b/src/headers/tomcrypt_prng.h
@@ -193,6 +193,9 @@ unsigned long rng_get_bytes(unsigned char *out,
 
 int rng_make_prng(int bits, int wprng, prng_state *prng, void (*callback)(void));
 
+extern unsigned long (*ltc_rng)(unsigned char *out, unsigned long outlen,
+      void (*callback)(void));
+
 
 /* $Source$ */
 /* $Revision$ */

--- a/src/misc/crypt/crypt.c
+++ b/src/misc/crypt/crypt.c
@@ -371,6 +371,9 @@ const char *crypt_build_settings =
 #if defined(LTC_RNG_MAKE_PRNG)
     " LTC_RNG_MAKE_PRNG "
 #endif
+#if defined(LTC_PRNG_ENABLE_LTC_RNG)
+    " LTC_PRNG_ENABLE_LTC_RNG "
+#endif
 #if defined(LTC_HASH_HELPERS)
     " LTC_HASH_HELPERS "
 #endif

--- a/src/misc/crypt/crypt_prng_rng_descriptor.c
+++ b/src/misc/crypt/crypt_prng_rng_descriptor.c
@@ -1,0 +1,13 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ *
+ * Tom St Denis, tomstdenis@gmail.com, http://libtom.org
+ */
+#include "tomcrypt.h"
+
+unsigned long (*ltc_rng)(unsigned char *out, unsigned long outlen, void (*callback)(void));

--- a/src/misc/crypt/crypt_prng_rng_descriptor.c
+++ b/src/misc/crypt/crypt_prng_rng_descriptor.c
@@ -10,4 +10,6 @@
  */
 #include "tomcrypt.h"
 
+#ifdef LTC_PRNG_ENABLE_LTC_RNG
 unsigned long (*ltc_rng)(unsigned char *out, unsigned long outlen, void (*callback)(void));
+#endif

--- a/src/prngs/rng_get_bytes.c
+++ b/src/prngs/rng_get_bytes.c
@@ -135,12 +135,14 @@ unsigned long rng_get_bytes(unsigned char *out, unsigned long outlen,
 
    LTC_ARGCHK(out != NULL);
 
+#ifdef LTC_PRNG_ENABLE_LTC_RNG
    if (ltc_rng) {
       x = ltc_rng(out, outlen, callback);
       if (x != 0) {
          return x;
       }
    }
+#endif
 
 #if defined(_WIN32) || defined(_WIN32_WCE)
    x = rng_win32(out, outlen, callback); if (x != 0) { return x; }

--- a/src/prngs/rng_get_bytes.c
+++ b/src/prngs/rng_get_bytes.c
@@ -135,6 +135,13 @@ unsigned long rng_get_bytes(unsigned char *out, unsigned long outlen,
 
    LTC_ARGCHK(out != NULL);
 
+   if (ltc_rng) {
+      x = ltc_rng(out, outlen, callback);
+      if (x != 0) {
+         return x;
+      }
+   }
+
 #if defined(_WIN32) || defined(_WIN32_WCE)
    x = rng_win32(out, outlen, callback); if (x != 0) { return x; }
 #elif defined(LTC_DEVRANDOM)

--- a/testprof/x86_prof.c
+++ b/testprof/x86_prof.c
@@ -322,7 +322,9 @@ static unsigned long my_test_rng(unsigned char *buf, unsigned long len,
 
 void reg_algs(void)
 {
+#ifdef LTC_PRNG_ENABLE_LTC_RNG
   unsigned long before;
+#endif
   int err;
 
   atexit(_unregister_all);

--- a/testprof/x86_prof.c
+++ b/testprof/x86_prof.c
@@ -302,6 +302,8 @@ static void _unregister_all(void)
 #endif
 } /* _cleanup() */
 
+#ifdef LTC_PRNG_ENABLE_LTC_RNG
+
 static unsigned long my_test_rng_read;
 
 static unsigned long my_test_rng(unsigned char *buf, unsigned long len,
@@ -315,6 +317,8 @@ static unsigned long my_test_rng(unsigned char *buf, unsigned long len,
    my_test_rng_read += n;
    return n;
 }
+
+#endif
 
 void reg_algs(void)
 {
@@ -456,6 +460,7 @@ register_prng(&rc4_desc);
 register_prng(&sober128_desc);
 #endif
 
+#ifdef LTC_PRNG_ENABLE_LTC_RNG
    ltc_rng = my_test_rng;
 
    before = my_test_rng_read;
@@ -470,6 +475,7 @@ register_prng(&sober128_desc);
    }
 
    ltc_rng = NULL;
+#endif
 
    if ((err = rng_make_prng(128, find_prng("yarrow"), &yarrow_prng, NULL)) != CRYPT_OK) {
       fprintf(stderr, "rng_make_prng failed: %s\n", error_to_string(err));


### PR DESCRIPTION
the idea is to be able to easily provide a plug-in rng for a specific
platform without the need to touch the library.

any comments/ideas?
