### PR TITLE
bug in hkdf code

### DIFF
--- a/src/misc/hkdf/hkdf.c
+++ b/src/misc/hkdf/hkdf.c
@@ -61,7 +61,9 @@ int hkdf_expand(int hash_idx, const unsigned char *info, unsigned long infolen,
    if (T == NULL) {
       return CRYPT_MEM;
    }
-   XMEMCPY(T + hashsize, info, infolen);
+   if (info != NULL) {
+      XMEMCPY(T + hashsize, info, infolen);
+   }
 
    /* HMAC data T(1) doesn't include a previous hash value */
    dat    = T    + hashsize;


### PR DESCRIPTION
At 

https://github.com/libtom/libtomcrypt/blob/develop/src/misc/hkdf/hkdf.c#L55

That should be an || not && comparison.  Now if the pointer is null but the length is not the XMEMCPY later will dereference a NULL pointer.