### PR TITLE
HP-UX related fixes

### DIFF
--- a/src/headers/tomcrypt_cfg.h
+++ b/src/headers/tomcrypt_cfg.h
@@ -43,6 +43,15 @@ LTC_EXPORT int   LTC_CALL XSTRCMP(const char *s1, const char *s2);
 
 #endif
 
+/* some compilers do not like "inline" */
+#if defined(__HP_cc)
+   #define LTC_INLINE
+#elif defined(_MSC_VER)
+   #define LTC_INLINE __inline
+#else
+   #define LTC_INLINE inline
+#endif
+
 /* type of argument checking, 0=default, 1=fatal and 2=error+continue, 3=nothing */
 #ifndef ARGTYPE
    #define ARGTYPE  0

--- a/src/pk/dh/dh_static.h
+++ b/src/pk/dh/dh_static.h
@@ -69,7 +69,7 @@
      y += x;                                                     \
 }
 
-static inline void packet_store_header (unsigned char *dst, int section, int subsection)
+static LTC_INLINE void packet_store_header (unsigned char *dst, int section, int subsection)
 {
    LTC_ARGCHKVD(dst != NULL);
 
@@ -83,7 +83,7 @@ static inline void packet_store_header (unsigned char *dst, int section, int sub
 
 }
 
-static inline int packet_valid_header (unsigned char *src, int section, int subsection)
+static LTC_INLINE int packet_valid_header (unsigned char *src, int section, int subsection)
 {
    unsigned long ver;
 


### PR DESCRIPTION
Hi,

please find enclosed patch that is neccessary to compile libtomcrypt on HP-UX.

There are two parts:
- some more or less expected stuff in `tomcrypt_cfg.h`
- a workaround for HP C compiler that does not like `static inline int func_name(...)` (the `inline` part is the problem)

--Karel
