### PR TITLE
fixing GCM troubles at HP-UX/IA64

### DIFF
--- a/src/encauth/gcm/gcm_gf_mult.c
+++ b/src/encauth/gcm/gcm_gf_mult.c
@@ -83,7 +83,7 @@ static const unsigned char poly[] = { 0x00, 0xE1 };
 void gcm_gf_mult(const unsigned char *a, const unsigned char *b, unsigned char *c)
 {
    unsigned char Z[16], V[16];
-   unsigned x, y, z;
+   unsigned char x, y, z;
 
    zeromem(Z, 16);
    XMEMCPY(V, a, 16);


### PR DESCRIPTION
I have experienced GCM failures on:
* HP-UX 11.31 / 64bit
* CPU: Itanium 2 / IA64
* Compiler: HP C/aC++ B3910B A.06.26 [Apr 12 2011]

It compiled fine but GCM gives wrong results. Interesting is that all other test vectors (for hashes, ciphers, macs, rsa, dsa, ecc ..) passed, just GCM was failing.

After some experimenting I have come to the enclosed patch. I admit that it seems a bit unbelievable that this might be the cause of the failure. But according my empirical observations this change fixed it.