### PR TITLE
avoid using declaration after statements

### DIFF
--- a/src/prngs/rng_get_bytes.c
+++ b/src/prngs/rng_get_bytes.c
@@ -21,14 +21,15 @@
 static unsigned long rng_nix(unsigned char *buf, unsigned long len,
                              void (*callback)(void))
 {
-    LTC_UNUSED_PARAM(callback);
 #ifdef LTC_NO_FILE
+    LTC_UNUSED_PARAM(callback);
     LTC_UNUSED_PARAM(buf);
     LTC_UNUSED_PARAM(len);
     return 0;
 #else
     FILE *f;
     unsigned long x;
+    LTC_UNUSED_PARAM(callback);
 #ifdef LTC_TRY_URANDOM_FIRST
     f = fopen("/dev/urandom", "rb");
     if (f == NULL)

--- a/src/prngs/rng_get_bytes.c
+++ b/src/prngs/rng_get_bytes.c
@@ -108,8 +108,8 @@ static unsigned long rng_ansic(unsigned char *buf, unsigned long len,
 static unsigned long rng_win32(unsigned char *buf, unsigned long len,
                                void (*callback)(void))
 {
-   LTC_UNUSED_PARAM(callback);
    HCRYPTPROV hProv = 0;
+   LTC_UNUSED_PARAM(callback);
    if (!CryptAcquireContext(&hProv, NULL, MS_DEF_PROV, PROV_RSA_FULL,
                             (CRYPT_VERIFYCONTEXT | CRYPT_MACHINE_KEYSET)) &&
        !CryptAcquireContext (&hProv, NULL, MS_DEF_PROV, PROV_RSA_FULL,


### PR DESCRIPTION
With an quite old compiler (probably only ANSI C89) at HP-UX:
```
LINT A.10.32.30 CXREF  A.10.32.30
HP92453-01 A.10.32.30 HP C Compiler
/usr/lib/libc: $Revision: 76.3 $
```

I have experienced the following compiler error:
```
cc: "src/ltc/prngs/rng_get_bytes.c", line 30: error 1000: Unexpected symbol: "FILE".
```

The fix is attached.