### PR TITLE
Fix all warnings from -Wcast-align

### DIFF
--- a/src/encauth/ccm/ccm_memory.c
+++ b/src/encauth/ccm/ccm_memory.c
@@ -256,8 +256,8 @@ int ccm_memory(int cipher,
 
                 /* xor the PT against the pad first */
                 for (z = 0; z < 16; z += sizeof(LTC_FAST_TYPE)) {
-                    *((LTC_FAST_TYPE*)(&PAD[z]))  ^= *((LTC_FAST_TYPE*)(&pt[y+z]));
-                    *((LTC_FAST_TYPE*)(&ct[y+z])) = *((LTC_FAST_TYPE*)(&pt[y+z])) ^ *((LTC_FAST_TYPE*)(&CTRPAD[z]));
+                    *(LTC_FAST_TYPE_PTR_CAST(&PAD[z]))  ^= *(LTC_FAST_TYPE_PTR_CAST(&pt[y+z]));
+                    *(LTC_FAST_TYPE_PTR_CAST(&ct[y+z])) = *(LTC_FAST_TYPE_PTR_CAST(&pt[y+z])) ^ *(LTC_FAST_TYPE_PTR_CAST(&CTRPAD[z]));
                 }
                 if ((err = cipher_descriptor[cipher].ecb_encrypt(PAD, PAD, skey)) != CRYPT_OK) {
                    goto error;
@@ -276,8 +276,8 @@ int ccm_memory(int cipher,
 
                 /* xor the PT against the pad last */
                 for (z = 0; z < 16; z += sizeof(LTC_FAST_TYPE)) {
-                    *((LTC_FAST_TYPE*)(&pt[y+z])) = *((LTC_FAST_TYPE*)(&ct[y+z])) ^ *((LTC_FAST_TYPE*)(&CTRPAD[z]));
-                    *((LTC_FAST_TYPE*)(&PAD[z]))  ^= *((LTC_FAST_TYPE*)(&pt[y+z]));
+                    *(LTC_FAST_TYPE_PTR_CAST(&pt[y+z])) = *(LTC_FAST_TYPE_PTR_CAST(&ct[y+z])) ^ *(LTC_FAST_TYPE_PTR_CAST(&CTRPAD[z]));
+                    *(LTC_FAST_TYPE_PTR_CAST(&PAD[z]))  ^= *(LTC_FAST_TYPE_PTR_CAST(&pt[y+z]));
                 }
                 if ((err = cipher_descriptor[cipher].ecb_encrypt(PAD, PAD, skey)) != CRYPT_OK) {
                    goto error;
@@ -366,7 +366,7 @@ int ccm_memory(int cipher,
          if (ptlen & ~15) {
             for (; y < (ptlen & ~15); y += 16) {
               for (z = 0; z < 16; z += sizeof(LTC_FAST_TYPE)) {
-                *((LTC_FAST_TYPE*)(&pt_real[y+z])) = *((LTC_FAST_TYPE*)(&pt[y+z])) & fastMask;
+                *(LTC_FAST_TYPE_PTR_CAST(&pt_real[y+z])) = *(LTC_FAST_TYPE_PTR_CAST(&pt[y+z])) & fastMask;
               }
             }
          }

--- a/src/encauth/ccm/ccm_memory_ex.c
+++ b/src/encauth/ccm/ccm_memory_ex.c
@@ -260,8 +260,8 @@ if (CTR == NULL) {
 
                 /* xor the PT against the pad first */
                 for (z = 0; z < 16; z += sizeof(LTC_FAST_TYPE)) {
-                    *((LTC_FAST_TYPE*)(&PAD[z]))  ^= *((LTC_FAST_TYPE*)(&pt[y+z]));
-                    *((LTC_FAST_TYPE*)(&ct[y+z])) = *((LTC_FAST_TYPE*)(&pt[y+z])) ^ *((LTC_FAST_TYPE*)(&CTRPAD[z]));
+                    *(LTC_FAST_TYPE_PTR_CAST(&PAD[z]))  ^= *(LTC_FAST_TYPE_PTR_CAST(&pt[y+z]));
+                    *(LTC_FAST_TYPE_PTR_CAST(&ct[y+z])) = *(LTC_FAST_TYPE_PTR_CAST(&pt[y+z])) ^ *(LTC_FAST_TYPE_PTR_CAST(&CTRPAD[z]));
                 }
                 if ((err = cipher_descriptor[cipher].ecb_encrypt(PAD, PAD, skey)) != CRYPT_OK) {
                    goto error;
@@ -280,8 +280,8 @@ if (CTR == NULL) {
 
                 /* xor the PT against the pad last */
                 for (z = 0; z < 16; z += sizeof(LTC_FAST_TYPE)) {
-                    *((LTC_FAST_TYPE*)(&pt[y+z])) = *((LTC_FAST_TYPE*)(&ct[y+z])) ^ *((LTC_FAST_TYPE*)(&CTRPAD[z]));
-                    *((LTC_FAST_TYPE*)(&PAD[z]))  ^= *((LTC_FAST_TYPE*)(&pt[y+z]));
+                    *(LTC_FAST_TYPE_PTR_CAST(&pt[y+z])) = *(LTC_FAST_TYPE_PTR_CAST(&ct[y+z])) ^ *(LTC_FAST_TYPE_PTR_CAST(&CTRPAD[z]));
+                    *(LTC_FAST_TYPE_PTR_CAST(&PAD[z]))  ^= *(LTC_FAST_TYPE_PTR_CAST(&pt[y+z]));
                 }
                 if ((err = cipher_descriptor[cipher].ecb_encrypt(PAD, PAD, skey)) != CRYPT_OK) {
                    goto error;

--- a/src/encauth/gcm/gcm_add_aad.c
+++ b/src/encauth/gcm/gcm_add_aad.c
@@ -92,7 +92,7 @@ int gcm_add_aad(gcm_state *gcm,
    if (gcm->buflen == 0) {
       for (x = 0; x < (adatalen & ~15); x += 16) {
           for (y = 0; y < 16; y += sizeof(LTC_FAST_TYPE)) {
-              *((LTC_FAST_TYPE*)(&gcm->X[y])) ^= *((LTC_FAST_TYPE*)(&adata[x + y]));
+              *(LTC_FAST_TYPE_PTR_CAST(&gcm->X[y])) ^= *(LTC_FAST_TYPE_PTR_CAST(&adata[x + y]));
           }
           gcm_mult_h(gcm, gcm->X);
           gcm->totlen += 128;

--- a/src/encauth/gcm/gcm_add_iv.c
+++ b/src/encauth/gcm/gcm_add_iv.c
@@ -59,7 +59,7 @@ int gcm_add_iv(gcm_state *gcm,
    if (gcm->buflen == 0) {
       for (x = 0; x < (IVlen & ~15); x += 16) {
           for (y = 0; y < 16; y += sizeof(LTC_FAST_TYPE)) {
-              *((LTC_FAST_TYPE*)(&gcm->X[y])) ^= *((LTC_FAST_TYPE*)(&IV[x + y]));
+              *(LTC_FAST_TYPE_PTR_CAST(&gcm->X[y])) ^= *(LTC_FAST_TYPE_PTR_CAST(&IV[x + y]));
           }
           gcm_mult_h(gcm, gcm->X);
           gcm->totlen += 128;

--- a/src/encauth/gcm/gcm_mult_h.c
+++ b/src/encauth/gcm/gcm_mult_h.c
@@ -38,7 +38,7 @@ void gcm_mult_h(gcm_state *gcm, unsigned char *I)
    for (x = 1; x < 16; x++) {
 #ifdef LTC_FAST
        for (y = 0; y < 16; y += sizeof(LTC_FAST_TYPE)) {
-           *((LTC_FAST_TYPE *)(T + y)) ^= *((LTC_FAST_TYPE *)(&gcm->PC[x][I[x]][y]));
+           *(LTC_FAST_TYPE_PTR_CAST(T + y)) ^= *(LTC_FAST_TYPE_PTR_CAST(&gcm->PC[x][I[x]][y]));
        }
 #else
        for (y = 0; y < 16; y++) {

--- a/src/encauth/gcm/gcm_process.c
+++ b/src/encauth/gcm/gcm_process.c
@@ -86,8 +86,8 @@ int gcm_process(gcm_state *gcm,
          for (x = 0; x < (ptlen & ~15); x += 16) {
              /* ctr encrypt */
              for (y = 0; y < 16; y += sizeof(LTC_FAST_TYPE)) {
-                 *((LTC_FAST_TYPE*)(&ct[x + y])) = *((LTC_FAST_TYPE*)(&pt[x+y])) ^ *((LTC_FAST_TYPE*)(&gcm->buf[y]));
-                 *((LTC_FAST_TYPE*)(&gcm->X[y])) ^= *((LTC_FAST_TYPE*)(&ct[x+y]));
+                 *(LTC_FAST_TYPE_PTR_CAST(&ct[x + y])) = *(LTC_FAST_TYPE_PTR_CAST(&pt[x+y])) ^ *(LTC_FAST_TYPE_PTR_CAST(&gcm->buf[y]));
+                 *(LTC_FAST_TYPE_PTR_CAST(&gcm->X[y])) ^= *(LTC_FAST_TYPE_PTR_CAST(&ct[x+y]));
              }
              /* GMAC it */
              gcm->pttotlen += 128;
@@ -104,8 +104,8 @@ int gcm_process(gcm_state *gcm,
          for (x = 0; x < (ptlen & ~15); x += 16) {
              /* ctr encrypt */
              for (y = 0; y < 16; y += sizeof(LTC_FAST_TYPE)) {
-                 *((LTC_FAST_TYPE*)(&gcm->X[y])) ^= *((LTC_FAST_TYPE*)(&ct[x+y]));
-                 *((LTC_FAST_TYPE*)(&pt[x + y])) = *((LTC_FAST_TYPE*)(&ct[x+y])) ^ *((LTC_FAST_TYPE*)(&gcm->buf[y]));
+                 *(LTC_FAST_TYPE_PTR_CAST(&gcm->X[y])) ^= *(LTC_FAST_TYPE_PTR_CAST(&ct[x+y]));
+                 *(LTC_FAST_TYPE_PTR_CAST(&pt[x + y])) = *(LTC_FAST_TYPE_PTR_CAST(&ct[x+y])) ^ *(LTC_FAST_TYPE_PTR_CAST(&gcm->buf[y]));
              }
              /* GMAC it */
              gcm->pttotlen += 128;

--- a/src/headers/tomcrypt_cfg.h
+++ b/src/headers/tomcrypt_cfg.h
@@ -122,6 +122,7 @@ typedef ulong64 __attribute__((__may_alias__)) LTC_FAST_TYPE;
 #else
 typedef ulong32 __attribute__((__may_alias__)) LTC_FAST_TYPE;
 #endif
+#define LTC_FAST_TYPE_PTR_CAST(x) ((LTC_FAST_TYPE*)(void*)(x))
 #endif
 #endif /* LTC_FAST */
 

--- a/src/mac/f9/f9_process.c
+++ b/src/mac/f9/f9_process.c
@@ -44,11 +44,11 @@ int f9_process(f9_state *f9, const unsigned char *in, unsigned long inlen)
    if (f9->buflen == 0) {
        while (inlen >= (unsigned long)f9->blocksize) {
            for (x = 0; x < f9->blocksize; x += sizeof(LTC_FAST_TYPE)) {
-              *((LTC_FAST_TYPE*)&(f9->IV[x])) ^= *((LTC_FAST_TYPE*)&(in[x]));
+              *(LTC_FAST_TYPE_PTR_CAST(&(f9->IV[x]))) ^= *(LTC_FAST_TYPE_PTR_CAST(&(in[x])));
            }
            cipher_descriptor[f9->cipher].ecb_encrypt(f9->IV, f9->IV, &f9->key);
            for (x = 0; x < f9->blocksize; x += sizeof(LTC_FAST_TYPE)) {
-              *((LTC_FAST_TYPE*)&(f9->ACC[x])) ^= *((LTC_FAST_TYPE*)&(f9->IV[x]));
+              *(LTC_FAST_TYPE_PTR_CAST(&(f9->ACC[x]))) ^= *(LTC_FAST_TYPE_PTR_CAST(&(f9->IV[x])));
            }
            in    += f9->blocksize;
            inlen -= f9->blocksize;

--- a/src/mac/omac/omac_process.c
+++ b/src/mac/omac/omac_process.c
@@ -49,7 +49,7 @@ int omac_process(omac_state *omac, const unsigned char *in, unsigned long inlen)
         unsigned long y;
         for (x = 0; x < (inlen - blklen); x += blklen) {
             for (y = 0; y < blklen; y += sizeof(LTC_FAST_TYPE)) {
-                *((LTC_FAST_TYPE*)(&omac->prev[y])) ^= *((LTC_FAST_TYPE*)(&in[y]));
+                *(LTC_FAST_TYPE_PTR_CAST(&omac->prev[y])) ^= *(LTC_FAST_TYPE_PTR_CAST(&in[y]));
             }
             in += blklen;
             if ((err = cipher_descriptor[omac->cipher_idx].ecb_encrypt(omac->prev, omac->prev, &omac->key)) != CRYPT_OK) {

--- a/src/mac/pelican/pelican.c
+++ b/src/mac/pelican/pelican.c
@@ -114,7 +114,7 @@ int pelican_process(pelican_state *pelmac, const unsigned char *in, unsigned lon
       while (inlen & ~15) {
          int x;
          for (x = 0; x < 16; x += sizeof(LTC_FAST_TYPE)) {
-            *((LTC_FAST_TYPE*)((unsigned char *)pelmac->state + x)) ^= *((LTC_FAST_TYPE*)((unsigned char *)in + x));
+            *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)pelmac->state + x)) ^= *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)in + x));
          }
          four_rounds(pelmac);
          in    += 16;

--- a/src/mac/pmac/pmac_process.c
+++ b/src/mac/pmac/pmac_process.c
@@ -48,13 +48,13 @@ int pmac_process(pmac_state *pmac, const unsigned char *in, unsigned long inlen)
       for (x = 0; x < (inlen - 16); x += 16) {
           pmac_shift_xor(pmac);
           for (y = 0; y < 16; y += sizeof(LTC_FAST_TYPE)) {
-              *((LTC_FAST_TYPE*)(&Z[y])) = *((LTC_FAST_TYPE*)(&in[y])) ^ *((LTC_FAST_TYPE*)(&pmac->Li[y]));
+              *(LTC_FAST_TYPE_PTR_CAST(&Z[y])) = *(LTC_FAST_TYPE_PTR_CAST(&in[y])) ^ *(LTC_FAST_TYPE_PTR_CAST(&pmac->Li[y]));
           }
           if ((err = cipher_descriptor[pmac->cipher_idx].ecb_encrypt(Z, Z, &pmac->key)) != CRYPT_OK) {
              return err;
           }
           for (y = 0; y < 16; y += sizeof(LTC_FAST_TYPE)) {
-              *((LTC_FAST_TYPE*)(&pmac->checksum[y])) ^= *((LTC_FAST_TYPE*)(&Z[y]));
+              *(LTC_FAST_TYPE_PTR_CAST(&pmac->checksum[y])) ^= *(LTC_FAST_TYPE_PTR_CAST(&Z[y]));
           }
           in += 16;
       }

--- a/src/mac/pmac/pmac_shift_xor.c
+++ b/src/mac/pmac/pmac_shift_xor.c
@@ -27,8 +27,8 @@ void pmac_shift_xor(pmac_state *pmac)
    y = pmac_ntz(pmac->block_index++);
 #ifdef LTC_FAST
    for (x = 0; x < pmac->block_len; x += sizeof(LTC_FAST_TYPE)) {
-       *((LTC_FAST_TYPE*)((unsigned char *)pmac->Li + x)) ^=
-       *((LTC_FAST_TYPE*)((unsigned char *)pmac->Ls[y] + x));
+       *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)pmac->Li + x)) ^=
+       *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)pmac->Ls[y] + x));
    }
 #else
    for (x = 0; x < pmac->block_len; x++) {

--- a/src/mac/xcbc/xcbc_process.c
+++ b/src/mac/xcbc/xcbc_process.c
@@ -47,7 +47,7 @@ int xcbc_process(xcbc_state *xcbc, const unsigned char *in, unsigned long inlen)
    if (xcbc->buflen == 0) {
        while (inlen > (unsigned long)xcbc->blocksize) {
            for (x = 0; x < xcbc->blocksize; x += sizeof(LTC_FAST_TYPE)) {
-              *((LTC_FAST_TYPE*)&(xcbc->IV[x])) ^= *((LTC_FAST_TYPE*)&(in[x]));
+              *(LTC_FAST_TYPE_PTR_CAST(&(xcbc->IV[x]))) ^= *(LTC_FAST_TYPE_PTR_CAST(&(in[x])));
            }
            cipher_descriptor[xcbc->cipher].ecb_encrypt(xcbc->IV, xcbc->IV, &xcbc->key);
            in    += xcbc->blocksize;

--- a/src/modes/cbc/cbc_decrypt.c
+++ b/src/modes/cbc/cbc_decrypt.c
@@ -70,9 +70,9 @@ int cbc_decrypt(const unsigned char *ct, unsigned char *pt, unsigned long len, s
          /* xor IV against plaintext */
          #if defined(LTC_FAST)
          for (x = 0; x < cbc->blocklen; x += sizeof(LTC_FAST_TYPE)) {
-            tmpy = *((LTC_FAST_TYPE*)((unsigned char *)cbc->IV + x)) ^ *((LTC_FAST_TYPE*)((unsigned char *)tmp + x));
-            *((LTC_FAST_TYPE*)((unsigned char *)cbc->IV + x)) = *((LTC_FAST_TYPE*)((unsigned char *)ct + x));
-            *((LTC_FAST_TYPE*)((unsigned char *)pt + x)) = tmpy;
+            tmpy = *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)cbc->IV + x)) ^ *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)tmp + x));
+            *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)cbc->IV + x)) = *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)ct + x));
+            *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)pt + x)) = tmpy;
          }
     #else
          for (x = 0; x < cbc->blocklen; x++) {

--- a/src/modes/cbc/cbc_encrypt.c
+++ b/src/modes/cbc/cbc_encrypt.c
@@ -59,7 +59,7 @@ int cbc_encrypt(const unsigned char *pt, unsigned char *ct, unsigned long len, s
          /* xor IV against plaintext */
          #if defined(LTC_FAST)
          for (x = 0; x < cbc->blocklen; x += sizeof(LTC_FAST_TYPE)) {
-            *((LTC_FAST_TYPE*)((unsigned char *)cbc->IV + x)) ^= *((LTC_FAST_TYPE*)((unsigned char *)pt + x));
+            *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)cbc->IV + x)) ^= *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)pt + x));
          }
     #else
          for (x = 0; x < cbc->blocklen; x++) {
@@ -75,7 +75,7 @@ int cbc_encrypt(const unsigned char *pt, unsigned char *ct, unsigned long len, s
          /* store IV [ciphertext] for a future block */
          #if defined(LTC_FAST)
          for (x = 0; x < cbc->blocklen; x += sizeof(LTC_FAST_TYPE)) {
-            *((LTC_FAST_TYPE*)((unsigned char *)cbc->IV + x)) = *((LTC_FAST_TYPE*)((unsigned char *)ct + x));
+            *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)cbc->IV + x)) = *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)ct + x));
          }
     #else
          for (x = 0; x < cbc->blocklen; x++) {

--- a/src/modes/ctr/ctr_encrypt.c
+++ b/src/modes/ctr/ctr_encrypt.c
@@ -89,8 +89,8 @@ int ctr_encrypt(const unsigned char *pt, unsigned char *ct, unsigned long len, s
 #ifdef LTC_FAST
       if (ctr->padlen == 0 && len >= (unsigned long)ctr->blocklen) {
          for (x = 0; x < ctr->blocklen; x += sizeof(LTC_FAST_TYPE)) {
-            *((LTC_FAST_TYPE*)((unsigned char *)ct + x)) = *((LTC_FAST_TYPE*)((unsigned char *)pt + x)) ^
-                                                           *((LTC_FAST_TYPE*)((unsigned char *)ctr->pad + x));
+            *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)ct + x)) = *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)pt + x)) ^
+                                                           *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)ctr->pad + x));
          }
        pt         += ctr->blocklen;
        ct         += ctr->blocklen;

--- a/src/modes/f8/f8_encrypt.c
+++ b/src/modes/f8/f8_encrypt.c
@@ -64,8 +64,8 @@ int f8_encrypt(const unsigned char *pt, unsigned char *ct, unsigned long len, sy
          STORE32H(f8->blockcnt, (buf+(f8->blocklen-4)));
          ++(f8->blockcnt);
          for (x = 0; x < f8->blocklen; x += sizeof(LTC_FAST_TYPE)) {
-             *((LTC_FAST_TYPE*)(&ct[x])) = *((LTC_FAST_TYPE*)(&pt[x])) ^ *((LTC_FAST_TYPE*)(&f8->IV[x]));
-             *((LTC_FAST_TYPE*)(&f8->IV[x])) ^= *((LTC_FAST_TYPE*)(&f8->MIV[x])) ^ *((LTC_FAST_TYPE*)(&buf[x]));
+             *(LTC_FAST_TYPE_PTR_CAST(&ct[x])) = *(LTC_FAST_TYPE_PTR_CAST(&pt[x])) ^ *(LTC_FAST_TYPE_PTR_CAST(&f8->IV[x]));
+             *(LTC_FAST_TYPE_PTR_CAST(&f8->IV[x])) ^= *(LTC_FAST_TYPE_PTR_CAST(&f8->MIV[x])) ^ *(LTC_FAST_TYPE_PTR_CAST(&buf[x]));
          }
          if ((err = cipher_descriptor[f8->cipher].ecb_encrypt(f8->IV, f8->IV, &f8->key)) != CRYPT_OK) {
             return err;

--- a/src/modes/lrw/lrw_process.c
+++ b/src/modes/lrw/lrw_process.c
@@ -60,7 +60,7 @@ int lrw_process(const unsigned char *pt, unsigned char *ct, unsigned long len, i
       for (; x < 16; x++) {
 #ifdef LTC_FAST
           for (y = 0; y < 16; y += sizeof(LTC_FAST_TYPE)) {
-              *((LTC_FAST_TYPE *)(lrw->pad + y)) ^= *((LTC_FAST_TYPE *)(&lrw->PC[x][lrw->IV[x]][y])) ^ *((LTC_FAST_TYPE *)(&lrw->PC[x][(lrw->IV[x]-1)&255][y]));
+              *(LTC_FAST_TYPE_PTR_CAST(lrw->pad + y)) ^= *(LTC_FAST_TYPE_PTR_CAST(&lrw->PC[x][lrw->IV[x]][y])) ^ *(LTC_FAST_TYPE_PTR_CAST(&lrw->PC[x][(lrw->IV[x]-1)&255][y]));
           }
 #else
           for (y = 0; y < 16; y++) {
@@ -75,7 +75,7 @@ int lrw_process(const unsigned char *pt, unsigned char *ct, unsigned long len, i
       /* xor prod */
 #ifdef LTC_FAST
       for (x = 0; x < 16; x += sizeof(LTC_FAST_TYPE)) {
-           *((LTC_FAST_TYPE *)(ct + x)) = *((LTC_FAST_TYPE *)(pt + x)) ^ *((LTC_FAST_TYPE *)(prod + x));
+           *(LTC_FAST_TYPE_PTR_CAST(ct + x)) = *(LTC_FAST_TYPE_PTR_CAST(pt + x)) ^ *(LTC_FAST_TYPE_PTR_CAST(prod + x));
       }
 #else
       for (x = 0; x < 16; x++) {
@@ -97,7 +97,7 @@ int lrw_process(const unsigned char *pt, unsigned char *ct, unsigned long len, i
       /* xor prod */
 #ifdef LTC_FAST
       for (x = 0; x < 16; x += sizeof(LTC_FAST_TYPE)) {
-           *((LTC_FAST_TYPE *)(ct + x)) = *((LTC_FAST_TYPE *)(ct + x)) ^ *((LTC_FAST_TYPE *)(prod + x));
+           *(LTC_FAST_TYPE_PTR_CAST(ct + x)) = *(LTC_FAST_TYPE_PTR_CAST(ct + x)) ^ *(LTC_FAST_TYPE_PTR_CAST(prod + x));
       }
 #else
       for (x = 0; x < 16; x++) {

--- a/src/modes/lrw/lrw_setiv.c
+++ b/src/modes/lrw/lrw_setiv.c
@@ -56,7 +56,7 @@ int lrw_setiv(const unsigned char *IV, unsigned long len, symmetric_LRW *lrw)
    for (x = 1; x < 16; x++) {
 #ifdef LTC_FAST
        for (y = 0; y < 16; y += sizeof(LTC_FAST_TYPE)) {
-           *((LTC_FAST_TYPE *)(T + y)) ^= *((LTC_FAST_TYPE *)(&lrw->PC[x][IV[x]][y]));
+           *(LTC_FAST_TYPE_PTR_CAST(T + y)) ^= *(LTC_FAST_TYPE_PTR_CAST(&lrw->PC[x][IV[x]][y]));
        }
 #else
        for (y = 0; y < 16; y++) {

--- a/src/modes/xts/xts_decrypt.c
+++ b/src/modes/xts/xts_decrypt.c
@@ -24,7 +24,7 @@ static int tweak_uncrypt(const unsigned char *C, unsigned char *P, unsigned char
    /* tweak encrypt block i */
 #ifdef LTC_FAST
    for (x = 0; x < 16; x += sizeof(LTC_FAST_TYPE)) {
-      *((LTC_FAST_TYPE *)&P[x]) = *((LTC_FAST_TYPE *)&C[x]) ^ *((LTC_FAST_TYPE *)&T[x]);
+      *(LTC_FAST_TYPE_PTR_CAST(&P[x])) = *(LTC_FAST_TYPE_PTR_CAST(&C[x])) ^ *(LTC_FAST_TYPE_PTR_CAST(&T[x]));
    }
 #else
    for (x = 0; x < 16; x++) {
@@ -36,7 +36,7 @@ static int tweak_uncrypt(const unsigned char *C, unsigned char *P, unsigned char
 
 #ifdef LTC_FAST
    for (x = 0; x < 16; x += sizeof(LTC_FAST_TYPE)) {
-      *((LTC_FAST_TYPE *)&P[x]) ^= *((LTC_FAST_TYPE *)&T[x]);
+      *(LTC_FAST_TYPE_PTR_CAST(&P[x])) ^= *(LTC_FAST_TYPE_PTR_CAST(&T[x]));
    }
 #else
    for (x = 0; x < 16; x++) {

--- a/src/modes/xts/xts_encrypt.c
+++ b/src/modes/xts/xts_encrypt.c
@@ -24,7 +24,7 @@ static int tweak_crypt(const unsigned char *P, unsigned char *C, unsigned char *
    /* tweak encrypt block i */
 #ifdef LTC_FAST
    for (x = 0; x < 16; x += sizeof(LTC_FAST_TYPE)) {
-      *((LTC_FAST_TYPE *)&C[x]) = *((LTC_FAST_TYPE *)&P[x]) ^ *((LTC_FAST_TYPE *)&T[x]);
+      *(LTC_FAST_TYPE_PTR_CAST(&C[x])) = *(LTC_FAST_TYPE_PTR_CAST(&P[x])) ^ *(LTC_FAST_TYPE_PTR_CAST(&T[x]));
    }
 #else
    for (x = 0; x < 16; x++) {
@@ -38,7 +38,7 @@ static int tweak_crypt(const unsigned char *P, unsigned char *C, unsigned char *
 
 #ifdef LTC_FAST
    for (x = 0; x < 16; x += sizeof(LTC_FAST_TYPE)) {
-      *((LTC_FAST_TYPE *)&C[x]) ^= *((LTC_FAST_TYPE *)&T[x]);
+      *(LTC_FAST_TYPE_PTR_CAST(&C[x])) ^= *(LTC_FAST_TYPE_PTR_CAST(&T[x]));
    }
 #else
    for (x = 0; x < 16; x++) {

--- a/testprof/store_test.c
+++ b/testprof/store_test.c
@@ -61,7 +61,7 @@ int store_test(void)
 
      /* now XOR it word for word */
      for (x = 0; x < y; x += sizeof(LTC_FAST_TYPE)) {
-        *((LTC_FAST_TYPE*)(&buf[3*y+z+x])) = *((LTC_FAST_TYPE*)(&buf[z+x])) ^ *((LTC_FAST_TYPE*)(&buf[z+y+x]));
+        *(LTC_FAST_TYPE_PTR_CAST(&buf[3*y+z+x])) = *(LTC_FAST_TYPE_PTR_CAST(&buf[z+x])) ^ *(LTC_FAST_TYPE_PTR_CAST(&buf[z+y+x]));
      }
 
      if (memcmp(&buf[2*y+z], &buf[3*y+z], y)) {


### PR DESCRIPTION
This fixes a very large amount of annoying warnings generated by -Wcast-align. Building with clang-207.0.31 on OS X.

Example of warnings that are fixed in ccm_memory.c:

```
src/encauth/ccm/ccm_memory.c:259:23: warning: cast from 'unsigned char *' to 'LTC_FAST_TYPE *' (aka 'unsigned long long *') increases required
      alignment from 1 to 8 [-Wcast-align]
                    *((LTC_FAST_TYPE*)(&PAD[z]))  ^= *((LTC_FAST_TYPE*)(&pt[y+z]));
                      ^~~~~~~~~~~~~~~~~~~~~~~~~
src/encauth/ccm/ccm_memory.c:259:56: warning: cast from 'unsigned char *' to 'LTC_FAST_TYPE *' (aka 'unsigned long long *') increases required
      alignment from 1 to 8 [-Wcast-align]
                    *((LTC_FAST_TYPE*)(&PAD[z]))  ^= *((LTC_FAST_TYPE*)(&pt[y+z]));
                                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~
src/encauth/ccm/ccm_memory.c:260:23: warning: cast from 'unsigned char *' to 'LTC_FAST_TYPE *' (aka 'unsigned long long *') increases required
      alignment from 1 to 8 [-Wcast-align]
                    *((LTC_FAST_TYPE*)(&ct[y+z])) = *((LTC_FAST_TYPE*)(&pt[y+z])) ^ *((LTC_FAST_TYPE*)(&CTRPAD[z]));
                      ^~~~~~~~~~~~~~~~~~~~~~~~~~
src/encauth/ccm/ccm_memory.c:260:55: warning: cast from 'unsigned char *' to 'LTC_FAST_TYPE *' (aka 'unsigned long long *') increases required
      alignment from 1 to 8 [-Wcast-align]
                    *((LTC_FAST_TYPE*)(&ct[y+z])) = *((LTC_FAST_TYPE*)(&pt[y+z])) ^ *((LTC_FAST_TYPE*)(&CTRPAD[z]));
                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~
src/encauth/ccm/ccm_memory.c:260:87: warning: cast from 'unsigned char *' to 'LTC_FAST_TYPE *' (aka 'unsigned long long *') increases required
      alignment from 1 to 8 [-Wcast-align]
                    *((LTC_FAST_TYPE*)(&ct[y+z])) = *((LTC_FAST_TYPE*)(&pt[y+z])) ^ *((LTC_FAST_TYPE*)(&CTRPAD[z]));
                                                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/encauth/ccm/ccm_memory.c:279:23: warning: cast from 'unsigned char *' to 'LTC_FAST_TYPE *' (aka 'unsigned long long *') increases required
      alignment from 1 to 8 [-Wcast-align]
                    *((LTC_FAST_TYPE*)(&pt[y+z])) = *((LTC_FAST_TYPE*)(&ct[y+z])) ^ *((LTC_FAST_TYPE*)(&CTRPAD[z]));
                      ^~~~~~~~~~~~~~~~~~~~~~~~~~
src/encauth/ccm/ccm_memory.c:279:55: warning: cast from 'unsigned char *' to 'LTC_FAST_TYPE *' (aka 'unsigned long long *') increases required
      alignment from 1 to 8 [-Wcast-align]
                    *((LTC_FAST_TYPE*)(&pt[y+z])) = *((LTC_FAST_TYPE*)(&ct[y+z])) ^ *((LTC_FAST_TYPE*)(&CTRPAD[z]));
                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~
src/encauth/ccm/ccm_memory.c:279:87: warning: cast from 'unsigned char *' to 'LTC_FAST_TYPE *' (aka 'unsigned long long *') increases required
      alignment from 1 to 8 [-Wcast-align]
                    *((LTC_FAST_TYPE*)(&pt[y+z])) = *((LTC_FAST_TYPE*)(&ct[y+z])) ^ *((LTC_FAST_TYPE*)(&CTRPAD[z]));
                                                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/encauth/ccm/ccm_memory.c:280:23: warning: cast from 'unsigned char *' to 'LTC_FAST_TYPE *' (aka 'unsigned long long *') increases required
      alignment from 1 to 8 [-Wcast-align]
                    *((LTC_FAST_TYPE*)(&PAD[z]))  ^= *((LTC_FAST_TYPE*)(&pt[y+z]));
                      ^~~~~~~~~~~~~~~~~~~~~~~~~
src/encauth/ccm/ccm_memory.c:280:56: warning: cast from 'unsigned char *' to 'LTC_FAST_TYPE *' (aka 'unsigned long long *') increases required
      alignment from 1 to 8 [-Wcast-align]
                    *((LTC_FAST_TYPE*)(&PAD[z]))  ^= *((LTC_FAST_TYPE*)(&pt[y+z]));
                                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~
src/encauth/ccm/ccm_memory.c:369:19: warning: cast from 'unsigned char *' to 'LTC_FAST_TYPE *' (aka 'unsigned long long *') increases required
      alignment from 1 to 8 [-Wcast-align]
                *((LTC_FAST_TYPE*)(&pt_real[y+z])) = *((LTC_FAST_TYPE*)(&pt[y+z])) & fastMask;
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/encauth/ccm/ccm_memory.c:369:56: warning: cast from 'unsigned char *' to 'LTC_FAST_TYPE *' (aka 'unsigned long long *') increases required
      alignment from 1 to 8 [-Wcast-align]
                *((LTC_FAST_TYPE*)(&pt_real[y+z])) = *((LTC_FAST_TYPE*)(&pt[y+z])) & fastMask;
                                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~

```

This is the cleanest trick I could think of to get it to work. Suggestions welcome.
