### PR TITLE
fix tiny compile error in tomcrypt_pk.h macro

### DIFF
--- a/src/headers/tomcrypt_pk.h
+++ b/src/headers/tomcrypt_pk.h
@@ -487,7 +487,7 @@ typedef struct ltc_asn1_list_ {
    do {                                              \
       int LTC_MACRO_temp            = (index);       \
       ltc_asn1_list *LTC_MACRO_list = (list);        \
-      LTC_MACRO_list[LTC_MACRO_temp].type = (Type);  \
+      LTC_MACRO_list[LTC_MACRO_temp].type = (ltc_asn1_type)(Type);  \
       LTC_MACRO_list[LTC_MACRO_temp].data = (void*)(Data);  \
       LTC_MACRO_list[LTC_MACRO_temp].size = (Size);  \
       LTC_MACRO_list[LTC_MACRO_temp].used = 0;       \

--- a/src/headers/tomcrypt_pk.h
+++ b/src/headers/tomcrypt_pk.h
@@ -487,7 +487,7 @@ typedef struct ltc_asn1_list_ {
    do {                                              \
       int LTC_MACRO_temp            = (index);       \
       ltc_asn1_list *LTC_MACRO_list = (list);        \
-      LTC_MACRO_list[LTC_MACRO_temp].type = (ltc_asn1_type)(Type);  \
+      LTC_MACRO_list[LTC_MACRO_temp].type = (Type);  \
       LTC_MACRO_list[LTC_MACRO_temp].data = (void*)(Data);  \
       LTC_MACRO_list[LTC_MACRO_temp].size = (Size);  \
       LTC_MACRO_list[LTC_MACRO_temp].used = 0;       \

--- a/src/pk/asn1/der/sequence/der_decode_subject_public_key_info.c
+++ b/src/pk/asn1/der/sequence/der_decode_subject_public_key_info.c
@@ -62,7 +62,7 @@ int der_decode_subject_public_key_info(const unsigned char *in, unsigned long in
 
    /* this includes the internal hash ID and optional params (NULL in this case) */
    LTC_SET_ASN1(alg_id, 0, LTC_ASN1_OBJECT_IDENTIFIER, tmpoid, sizeof(tmpoid)/sizeof(tmpoid[0]));
-   LTC_SET_ASN1(alg_id, 1, parameters_type, parameters, parameters_len);
+   LTC_SET_ASN1(alg_id, 1, (ltc_asn1_type)parameters_type, parameters, parameters_len);
 
    /* the actual format of the SSL DER key is odd, it stores a RSAPublicKey
     * in a **BIT** string ... so we have to extract it then proceed to convert bit to octet

--- a/src/pk/asn1/der/sequence/der_encode_subject_public_key_info.c
+++ b/src/pk/asn1/der/sequence/der_encode_subject_public_key_info.c
@@ -50,7 +50,7 @@ int der_encode_subject_public_key_info(unsigned char *out, unsigned long *outlen
    }
 
    LTC_SET_ASN1(alg_id, 0, LTC_ASN1_OBJECT_IDENTIFIER, oid.OID,    oid.OIDlen);
-   LTC_SET_ASN1(alg_id, 1, parameters_type,            parameters, parameters_len);
+   LTC_SET_ASN1(alg_id, 1, (ltc_asn1_type)parameters_type,            parameters, parameters_len);
 
    return der_encode_sequence_multi(out, outlen,
         LTC_ASN1_SEQUENCE, (unsigned long)sizeof(alg_id)/sizeof(alg_id[0]), alg_id,


### PR DESCRIPTION
An ARM compiler gives me this: 

libtomcrypt\pk\asn1\der\sequence\der_decode_subject_public_key_info.c(65,4): error #188-D: enumerated type mixed with another type

Since der_decode_subject_public_key_info's parameters_type is of type 'unsigned long', an attempt to assign it to ltc_asn1_list's member 'ltc_asn1_type type' fails.

My fix solves this in a simple way by casting it at the point of assignment.

But while studying this I noticed there's no use of enum in the codebase other than a few PK-related things.  Perhaps a more appropriate solution would be to remove these enums. I mean, enums seem like an OK enough idea, but I don't know anything about the practicality of using enums in archaic C dialects like libtomcrypt conforms (thankfully!) to...
