### PR TITLE
Fix to make xcode toolchain happy.

### DIFF
--- a/src/headers/tomcrypt_macros.h
+++ b/src/headers/tomcrypt_macros.h
@@ -264,17 +264,17 @@ static inline unsigned ROR(unsigned word, int i)
 
 static inline unsigned ROLc(unsigned word, const int i)
 {
-   asm ("roll %2,%0"
+   asm ("roll %%cl,%0"
       :"=r" (word)
-      :"0" (word),"I" (i));
+      :"0" (word),"c" (i));
    return word;
 }
 
 static inline unsigned RORc(unsigned word, const int i)
 {
-   asm ("rorl %2,%0"
+   asm ("rorl %%cl,%0"
       :"=r" (word)
-      :"0" (word),"I" (i));
+      :"0" (word),"c" (i));
    return word;
 }
 
@@ -363,17 +363,17 @@ static inline unsigned long ROR64(unsigned long word, int i)
 
 static inline unsigned long ROL64c(unsigned long word, const int i)
 {
-   asm("rolq %2,%0"
+   asm("rolq %%cl,%0"
       :"=r" (word)
-      :"0" (word),"J" (i));
+      :"0" (word),"c" (i));
    return word;
 }
 
 static inline unsigned long ROR64c(unsigned long word, const int i)
 {
-   asm("rorq %2,%0"
+   asm("rorq %%cl,%0"
       :"=r" (word)
-      :"0" (word),"J" (i));
+      :"0" (word),"c" (i));
    return word;
 }
 


### PR DESCRIPTION
[Housekeeping from open-sourcing BitKeeper]

BitKeeper developers on Macs using current xcode compilers would see things like:

```
/usr/include/tomcrypt_macros.h: In function 'RORc':
/usr/include/tomcrypt_macros.h:275: error impossible contraint in 'asm' 
```

In the BitKeeper copy of the code, we have been carrying around a change c/o wscott@bitkeeper.com, with the following comment:

   x86 only allows variable shifts and rotates with the CL register.
  Change the inline asm to use CL explicitly and update the constraints to
  reflect that.

N.B. This problem seems to have been fixed in a different way in the develop branch.