### PR TITLE
Add function declarations to remove compile warning

### DIFF
--- a/src/headers/tomcrypt_cipher.h
+++ b/src/headers/tomcrypt_cipher.h
@@ -336,6 +336,35 @@ typedef struct {
 } symmetric_F8;
 #endif
 
+/** Accelerated XTS encryption definition
+    @param pt      Plaintext
+    @param ct      Ciphertext
+    @param blocks  The number of complete blocks to process
+    @param tweak   The 128-bit encryption tweak (input/output).
+                   The tweak should not be encrypted on input, but
+                   next tweak will be copied encrypted on output.
+    @param skey1   The first scheduled key context
+    @param skey2   The second scheduled key context
+    @return CRYPT_OK if successful
+ */
+typedef int (*accel_xts_encrypt_func_)(const unsigned char *pt, unsigned char *ct,
+        unsigned long blocks, unsigned char *tweak, symmetric_key *skey1,
+        symmetric_key *skey2);
+
+/** Accelerated XTS decryption definition
+    @param ct      Ciphertext
+    @param pt      Plaintext
+    @param blocks  The number of complete blocks to process
+    @param tweak   The 128-bit encryption tweak (input/output).
+                   The tweak should not be encrypted on input, but
+                   next tweak will be copied encrypted on output.
+    @param skey1   The first scheduled key context
+    @param skey2   The second scheduled key context
+    @return CRYPT_OK if successful
+ */
+typedef int (*accel_xts_decrypt_func_)(const unsigned char *ct, unsigned char *pt,
+         unsigned long blocks, unsigned char *tweak, symmetric_key *skey1,
+         symmetric_key *skey2);
 
 /** cipher descriptor table, last entry has "name == NULL" to mark the end of table */
 extern struct ltc_cipher_descriptor {
@@ -565,9 +594,7 @@ extern struct ltc_cipher_descriptor {
        @param skey2   The second scheduled key context
        @return CRYPT_OK if successful
     */
-    int (*accel_xts_encrypt)(const unsigned char *pt, unsigned char *ct,
-        unsigned long blocks, unsigned char *tweak, symmetric_key *skey1,
-        symmetric_key *skey2);
+    accel_xts_encrypt_func_ accel_xts_encrypt;
 
     /** Accelerated XTS decryption
         @param ct      Ciphertext
@@ -580,9 +607,8 @@ extern struct ltc_cipher_descriptor {
         @param skey2   The second scheduled key context
         @return CRYPT_OK if successful
      */
-     int (*accel_xts_decrypt)(const unsigned char *ct, unsigned char *pt,
-         unsigned long blocks, unsigned char *tweak, symmetric_key *skey1,
-         symmetric_key *skey2);
+    accel_xts_decrypt_func_ accel_xts_decrypt;
+
 } cipher_descriptor[];
 
 #ifdef LTC_BLOWFISH

--- a/src/modes/xts/xts_test.c
+++ b/src/modes/xts/xts_test.c
@@ -24,7 +24,7 @@ static int _xts_test_accel_xts_encrypt(const unsigned char *pt, unsigned char *c
          return CRYPT_NOP;
       }
    }
-   void *orig = cipher_descriptor[xts.cipher].accel_xts_encrypt;
+   accel_xts_encrypt_func_ orig = cipher_descriptor[xts.cipher].accel_xts_encrypt;
    cipher_descriptor[xts.cipher].accel_xts_encrypt = NULL;
 
    XMEMCPY(&xts.key1, skey1, sizeof(symmetric_key));
@@ -48,7 +48,7 @@ static int _xts_test_accel_xts_decrypt(const unsigned char *ct, unsigned char *p
          return CRYPT_NOP;
       }
    }
-   void *orig = cipher_descriptor[xts.cipher].accel_xts_decrypt;
+   accel_xts_decrypt_func_ orig = cipher_descriptor[xts.cipher].accel_xts_decrypt;
    cipher_descriptor[xts.cipher].accel_xts_decrypt = NULL;
 
    XMEMCPY(&xts.key1, skey1, sizeof(symmetric_key));


### PR DESCRIPTION
Current tomcrypt generates the following compile warning

`/xxx/tomcrypt/src/modes/xts/xts_test.c:27:17: warning: ISO C forbids initialization between function pointer and ‘void *’ [-Wpedantic]
    void *orig = cipher_descriptor[xts.cipher].accel_xts_encrypt;
                 ^
/xxx/tomcrypt/src/modes/xts/xts_test.c:34:52: warning: ISO C forbids assignment between function pointer and ‘void *’ [-Wpedantic]
    cipher_descriptor[xts.cipher].accel_xts_encrypt = orig;
                                                    ^
/xxx/tomcrypt/src/modes/xts/xts_test.c: In function ‘_xts_test_accel_xts_decrypt’:
/xxx/tomcrypt/src/modes/xts/xts_test.c:51:17: warning: ISO C forbids initialization between function pointer and ‘void *’ [-Wpedantic]
    void *orig = cipher_descriptor[xts.cipher].accel_xts_decrypt;
                 ^
/xxx/tomcrypt/src/modes/xts/xts_test.c:58:52: warning: ISO C forbids assignment between function pointer and ‘void *’ [-Wpedantic]
    cipher_descriptor[xts.cipher].accel_xts_decrypt = orig;
                                                    ^`

accel_xts_encrypt and accel_xts_decrypt needs a proper function definition to eliminate this warning which is needed to get a clean compile