### PR TITLE
Serious bug in rng_get_bytes @ MS Windows

### DIFF
--- a/src/prngs/rng_get_bytes.c
+++ b/src/prngs/rng_get_bytes.c
@@ -141,11 +141,10 @@ unsigned long rng_get_bytes(unsigned char *out, unsigned long outlen,
 
    LTC_ARGCHK(out != NULL);
 
-#if defined(LTC_DEVRANDOM)
-   x = rng_nix(out, outlen, callback);   if (x != 0) { return x; }
-#endif
 #if defined(_WIN32) || defined(_WIN32_WCE)
    x = rng_win32(out, outlen, callback); if (x != 0) { return x; }
+#elif defined(LTC_DEVRANDOM)
+   x = rng_nix(out, outlen, callback);   if (x != 0) { return x; }
 #endif
 #ifdef ANSI_RNG
    x = rng_ansic(out, outlen, callback); if (x != 0) { return x; }

--- a/src/prngs/rng_get_bytes.c
+++ b/src/prngs/rng_get_bytes.c
@@ -55,7 +55,7 @@ static unsigned long rng_nix(unsigned char *buf, unsigned long len,
 #endif /* LTC_DEVRANDOM */
 
 /* on ANSI C platforms with 100 < CLOCKS_PER_SEC < 10000 */
-#if defined(CLOCKS_PER_SEC) && !defined(WINCE)
+#if defined(CLOCKS_PER_SEC) && !defined(_WIN32_WCE)
 
 #define ANSI_RNG
 
@@ -92,11 +92,11 @@ static unsigned long rng_ansic(unsigned char *buf, unsigned long len,
 #endif
 
 /* Try the Microsoft CSP */
-#if defined(WIN32) || defined(_WIN32) || defined(WINCE)
+#if defined(_WIN32) || defined(_WIN32_WCE)
 #ifndef _WIN32_WINNT
   #define _WIN32_WINNT 0x0400
 #endif
-#ifdef WINCE
+#ifdef _WIN32_WCE
    #define UNDER_CE
    #define ARM
 #endif
@@ -144,7 +144,7 @@ unsigned long rng_get_bytes(unsigned char *out, unsigned long outlen,
 #if defined(LTC_DEVRANDOM)
    x = rng_nix(out, outlen, callback);   if (x != 0) { return x; }
 #endif
-#if defined(WIN32) || defined(_WIN32) || defined(WINCE)
+#if defined(_WIN32) || defined(_WIN32_WCE)
    x = rng_win32(out, outlen, callback); if (x != 0) { return x; }
 #endif
 #ifdef ANSI_RNG


### PR DESCRIPTION
In `rng_get_bytes.c` we have:

``` c
#if defined(LTC_DEVRANDOM)
   x = rng_nix(out, outlen, callback);   if (x != 0) { return x; }
#endif
#if defined(WIN32) || defined(_WIN32) || defined(WINCE)
   x = rng_win32(out, outlen, callback); if (x != 0) { return x; }
#endif
#ifdef ANSI_RNG
   x = rng_ansic(out, outlen, callback); if (x != 0) { return x; }
#endif
   return 0;
```

On MS Windows unfortunately `LTC_DEVRANDOM` is defined which means that even if we are on MS Windows we will try to open/read `/dev/random` file first and after it fails we will try Windows' `CryptGenRandom` call.

It seems OK unless an evil adversary creates on your disk a file `c:\dev\random` (e.g. full of zeroes). I have tested libtomcrypt built with mingw-w64 compiler and it happily opens/reads from `c:\dev\random` - which, well, is not that random as one would expect.

My proposal is changing the above mentioned section like this:

``` c
#if defined(WIN32) || defined(_WIN32) || defined(WINCE)
   x = rng_win32(out, outlen, callback); if (x != 0) { return x; }
#elif defined(LTC_DEVRANDOM)
   x = rng_nix(out, outlen, callback);   if (x != 0) { return x; }
#endif
#ifdef ANSI_RNG
   x = rng_ansic(out, outlen, callback); if (x != 0) { return x; }
#endif
   return 0;
```

Other options are forcefully undefine `LTC_DEVRANDOM` (perhaps somewhere in `tomcrypt_custom.h`) when on MS Windows. Or maybe somebody might have another proposal.
