### PR TITLE
GCM counter incrementation isn't stopped at 2^32 blocks, which breaks GCM

### DIFF
--- a/src/encauth/gcm/gcm_process.c
+++ b/src/encauth/gcm/gcm_process.c
@@ -49,6 +49,11 @@ int gcm_process(gcm_state *gcm,
       return err;
    }
 
+   /* 0xFFFFFFFE0 = ((2^39)-256)/8 */
+   if (gcm->pttotlen / 8 + (ulong64)gcm->buflen + (ulong64)ptlen >= CONST64(0xFFFFFFFE0)) {
+      return CRYPT_INVALID_ARG;
+   }
+
    /* in AAD mode? */
    if (gcm->mode == LTC_GCM_MODE_AAD) {
       /* let's process the AAD */


### PR DESCRIPTION
As reported privately by @rjamet

> https://github.com/libtom/libtomcrypt_p/blob/develop/src/encauth/gcm/gcm_process.c#L60
> 
> I haven't found a check that the encrypted plaintext is shorter than 2^32 blocks? If there's one, then it's fine. Otherwise, the counter will continue, and that causes IV reuse. In CTR or so it isn't so bad (the attacker can get a xor of plaintexts), but in GCM, if the plaintext is controlled by the attacker, this allows forging authentication tags: see 3. in http://csrc.nist.gov/groups/ST/toolkit/BCM/documents/Joux_comments.
> 
> Instead, GCM should just throw after (2^32)-1 blocks / (2^39)-256 bits as per http://csrc.nist.gov/groups/ST/toolkit/BCM/documents/proposedmodes/gcm/gcm-spec.pdf p18.