### PR TITLE
Fix compile warning on free build

### DIFF
--- a/src/headers/tomcrypt_custom.h
+++ b/src/headers/tomcrypt_custom.h
@@ -4,44 +4,51 @@
 /* macros for various libc functions you can change for embedded targets */
 #ifndef XMALLOC
    #ifdef malloc
-   #define LTC_NO_PROTOTYPES
+      #undef  LTC_NO_PROTOTYPES
+      #define LTC_NO_PROTOTYPES
    #endif
 #define XMALLOC  malloc
 #endif
 #ifndef XREALLOC
    #ifdef realloc
-   #define LTC_NO_PROTOTYPES
+      #undef  LTC_NO_PROTOTYPES
+      #define LTC_NO_PROTOTYPES
    #endif
 #define XREALLOC realloc
 #endif
 #ifndef XCALLOC
    #ifdef calloc
-   #define LTC_NO_PROTOTYPES
+      #undef  LTC_NO_PROTOTYPES
+      #define LTC_NO_PROTOTYPES
    #endif
 #define XCALLOC  calloc
 #endif
 #ifndef XFREE
    #ifdef free
-   #define LTC_NO_PROTOTYPES
+      #undef  LTC_NO_PROTOTYPES
+      #define LTC_NO_PROTOTYPES
    #endif
 #define XFREE    free
 #endif
 
 #ifndef XMEMSET
    #ifdef memset
-   #define LTC_NO_PROTOTYPES
+      #undef  LTC_NO_PROTOTYPES
+      #define LTC_NO_PROTOTYPES
    #endif
 #define XMEMSET  memset
 #endif
 #ifndef XMEMCPY
    #ifdef memcpy
-   #define LTC_NO_PROTOTYPES
+      #undef  LTC_NO_PROTOTYPES
+      #define LTC_NO_PROTOTYPES
    #endif
 #define XMEMCPY  memcpy
 #endif
 #ifndef XMEMCMP
    #ifdef memcmp
-   #define LTC_NO_PROTOTYPES
+      #undef  LTC_NO_PROTOTYPES
+      #define LTC_NO_PROTOTYPES
    #endif
 #define XMEMCMP  memcmp
 #endif
@@ -50,7 +57,8 @@
 #endif
 #ifndef XSTRCMP
    #ifdef strcmp
-   #define LTC_NO_PROTOTYPES
+      #undef  LTC_NO_PROTOTYPES
+      #define LTC_NO_PROTOTYPES
    #endif
 #define XSTRCMP strcmp
 #endif
@@ -64,7 +72,9 @@
 
 #ifndef XQSORT
    #ifdef qsort
-   #define LTC_NO_PROTOTYPES
+      #ifndef LTC_NO_PROTOTYPES
+      #define LTC_NO_PROTOTYPES
+      #endif
    #endif
 #define XQSORT qsort
 #endif


### PR DESCRIPTION
The definition of LTC_NO_PROTOTYPES in tomcrypt_custom.h will generate warnings if more than one of XMALLOC, XREALLOC, ... is defined. LTC_NO_PROTOTYPES must be undefined before it is redefined.
