### PR TITLE
DSA: properly handle FIPS 186-4 (4.6 + 4.7)

### DIFF
--- a/src/pk/dsa/dsa_sign_hash.c
+++ b/src/pk/dsa/dsa_sign_hash.c
@@ -84,8 +84,8 @@ retry:
 
    if (mp_iszero(r) == LTC_MP_YES)                                                     { goto retry; }
 
-   /* FIPS 186-4 4.6: use leftmost min(bitlen(q), bitlen(hash)) */
-   if (inlen > (unsigned long)(key->qord)) inlen = (unsigned long)(key->qord);
+   /* FIPS 186-4 4.6: use leftmost min(bitlen(q), bitlen(hash)) bits of 'hash'*/
+   inlen = MIN(inlen, (unsigned long)(key->qord));
 
    /* now find s = (in + xr)/k mod q */
    if ((err = mp_read_unsigned_bin(tmp, (unsigned char *)in, inlen)) != CRYPT_OK)      { goto error; }

--- a/src/pk/dsa/dsa_sign_hash.c
+++ b/src/pk/dsa/dsa_sign_hash.c
@@ -84,6 +84,9 @@ retry:
 
    if (mp_iszero(r) == LTC_MP_YES)                                                     { goto retry; }
 
+   /* FIPS 186-4 4.6: use leftmost min(bitlen(q), bitlen(hash)) */
+   if (inlen > (unsigned long)(key->qord)) inlen = (unsigned long)(key->qord);
+
    /* now find s = (in + xr)/k mod q */
    if ((err = mp_read_unsigned_bin(tmp, (unsigned char *)in, inlen)) != CRYPT_OK)      { goto error; }
    if ((err = mp_mul(key->x, r, s)) != CRYPT_OK)                                       { goto error; }

--- a/src/pk/dsa/dsa_verify_hash.c
+++ b/src/pk/dsa/dsa_verify_hash.c
@@ -54,6 +54,9 @@ int dsa_verify_hash_raw(         void   *r,          void   *s,
       goto error;
    }
    
+   /* FIPS 186-4 4.7: use leftmost min(bitlen(q), bitlen(hash)) bits of 'hash' */
+   if (hashlen > (unsigned long)(key->qord)) hashlen = (unsigned long)(key->qord);
+
    /* w = 1/s mod q */
    if ((err = mp_invmod(s, key->q, w)) != CRYPT_OK)                                       { goto error; }
 

--- a/src/pk/dsa/dsa_verify_hash.c
+++ b/src/pk/dsa/dsa_verify_hash.c
@@ -55,7 +55,7 @@ int dsa_verify_hash_raw(         void   *r,          void   *s,
    }
    
    /* FIPS 186-4 4.7: use leftmost min(bitlen(q), bitlen(hash)) bits of 'hash' */
-   if (hashlen > (unsigned long)(key->qord)) hashlen = (unsigned long)(key->qord);
+   hashlen = MIN(hashlen, (unsigned long)(key->qord));
 
    /* w = 1/s mod q */
    if ((err = mp_invmod(s, key->q, w)) != CRYPT_OK)                                       { goto error; }


### PR DESCRIPTION
DSA code does not use min(N,outlen) as required by FIPS 186-4 4.7 (for verify) and similarly 4.7 (for sign).

Credits: originally reported by Eberhard Mattes in private e-mail conversation
