### PR TITLE
crc32 test fails on ppc64 BE (tomcrypt_cfg.h facelift)

### DIFF
--- a/src/headers/tomcrypt_cfg.h
+++ b/src/headers/tomcrypt_cfg.h
@@ -8,15 +8,13 @@
 #define TOMCRYPT_CFG_H
 
 #if defined(_WIN32) || defined(_MSC_VER)
-#define LTC_CALL __cdecl
-#else
-#ifndef LTC_CALL
+   #define LTC_CALL __cdecl
+#elif !defined(LTC_CALL)
    #define LTC_CALL
-#endif
 #endif
 
 #ifndef LTC_EXPORT
-#define LTC_EXPORT
+   #define LTC_EXPORT
 #endif
 
 /* certain platforms use macros for these, making the prototypes broken */
@@ -63,35 +61,122 @@ LTC_EXPORT int   LTC_CALL XSTRCMP(const char *s1, const char *s2);
  * The x86 platforms allow this but some others [ARM for instance] do not.  On those platforms you **MUST**
  * use the portable [slower] macros.
  */
-
-/* detect x86-32 machines somewhat */
-#if !defined(__STRICT_ANSI__) && !defined(__x86_64__) && !defined(_WIN64) && ((defined(_MSC_VER) && defined(WIN32)) || (defined(__GNUC__) && (defined(__DJGPP__) || defined(__CYGWIN__) || defined(__MINGW32__) || defined(__i386__))))
+/* detect x86/i386 32bit */
+#if defined(__i386__) || defined(__i386) || defined(_M_IX86)
    #define ENDIAN_LITTLE
    #define ENDIAN_32BITWORD
    #define LTC_FAST
 #endif
 
-/* detects MIPS R5900 processors (PS2) */
-#if (defined(__R5900) || defined(R5900) || defined(__R5900__)) && (defined(_mips) || defined(__mips__) || defined(mips))
-   #define ENDIAN_LITTLE
-   #define ENDIAN_64BITWORD
-#endif
-
-/* detect amd64 */
-#if !defined(__STRICT_ANSI__) && defined(__x86_64__)
+/* detect amd64/x64 */
+#if defined(__x86_64__) || defined(_M_X64) || defined(_M_AMD64)
    #define ENDIAN_LITTLE
    #define ENDIAN_64BITWORD
    #define LTC_FAST
 #endif
 
 /* detect PPC32 */
-#if !defined(__STRICT_ANSI__) && defined(LTC_PPC32)
+#if defined(LTC_PPC32)
    #define ENDIAN_BIG
    #define ENDIAN_32BITWORD
    #define LTC_FAST
 #endif
 
-/* fix for MSVC ...evil! */
+/* detects MIPS R5900 processors (PS2) */
+#if (defined(__R5900) || defined(R5900) || defined(__R5900__)) && (defined(_mips) || defined(__mips__) || defined(mips))
+   #define ENDIAN_64BITWORD
+   #if defined(_MIPSEB) || defined(__MIPSEB) || defined(__MIPSEB__)
+     #define ENDIAN_BIG
+   #endif
+     #define ENDIAN_LITTLE
+   #endif
+#endif
+
+/* detect AIX */
+#if defined(_AIX) && defined(_BIG_ENDIAN)
+  #define ENDIAN_BIG
+  #if defined(__LP64__) || defined(_ARCH_PPC64)
+    #define ENDIAN_64BITWORD
+  #else
+    #define ENDIAN_32BITWORD
+  #endif
+#endif
+
+/* detect HP-UX */
+#if defined(__hpux) || defined(__hpux__)
+  #define ENDIAN_BIG
+  #if defined(__ia64) || defined(__ia64__) || defined(__LP64__)
+    #define ENDIAN_64BITWORD
+  #else
+    #define ENDIAN_32BITWORD
+  #endif
+#endif
+
+/* detect Apple OS X */
+#if defined(__APPLE__) && defined(__MACH__)
+  #if defined(__LITTLE_ENDIAN__) || defined(__x86_64__)
+    #define ENDIAN_LITTLE
+  #else
+    #define ENDIAN_BIG
+  #endif
+  #if defined(__LP64__) || defined(__x86_64__)
+    #define ENDIAN_64BITWORD
+  #else
+    #define ENDIAN_32BITWORD
+  #endif
+#endif
+
+/* detect SPARC and SPARC64 */
+#if defined(__sparc__) || defined(__sparc)
+  #define ENDIAN_BIG
+  #if defined(__arch64__) || defined(__sparcv9) || defined(__sparc_v9__)
+    #define ENDIAN_64BITWORD
+  #else
+    #define ENDIAN_32BITWORD
+  #endif
+#endif
+
+/* detect IBM S390(x) */
+#if defined(__s390x__) || defined(__s390__)
+  #define ENDIAN_BIG
+  #if defined(__s390x__)
+    #define ENDIAN_64BITWORD
+  #else
+    #define ENDIAN_32BITWORD
+  #endif
+#endif
+
+/* detect PPC64 */
+#if defined(__powerpc64__) || defined(__ppc64__) || defined(__PPC64__)
+   #define ENDIAN_64BITWORD
+   #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+      #define ENDIAN_BIG
+   #elif  __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+      #define ENDIAN_LITTLE
+   #endif
+   #define LTC_FAST
+#endif
+
+/* endianness fallback */
+#if !defined(ENDIAN_BIG) && !defined(ENDIAN_LITTLE)
+  #if defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN || \
+      defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__ || \
+      defined(__BIG_ENDIAN__) || defined(_BIG_ENDIAN) || \
+      defined(__ARMEB__) || defined(__THUMBEB__) || defined(__AARCH64EB__) || \
+      defined(_MIPSEB) || defined(__MIPSEB) || defined(__MIPSEB__)
+    #define ENDIAN_BIG
+  #elif defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN || \
+      defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__ || \
+      defined(__LITTLE_ENDIAN__) || defined(_LITTLE_ENDIAN) || \
+      defined(__ARMEL__) || defined(__THUMBEL__) || defined(__AARCH64EL__) || \
+      defined(_MIPSEL) || defined(__MIPSEL) || defined(__MIPSEL__)
+    #define ENDIAN_LITTLE
+  #else
+    #error Cannot detect endianness
+  #endif
+#endif
+
+/* ulong64: 64-bit data type */
 #ifdef _MSC_VER
    #define CONST64(n) n ## ui64
    typedef unsigned __int64 ulong64;
@@ -100,40 +185,36 @@ LTC_EXPORT int   LTC_CALL XSTRCMP(const char *s1, const char *s2);
    typedef unsigned long long ulong64;
 #endif
 
-/* this is the "32-bit at least" data type
- * Re-define it to suit your platform but it must be at least 32-bits
- */
-#if defined(__x86_64__) || (defined(__sparc__) && defined(__arch64__))
+/* ulong32: "32-bit at least" data type */
+#if defined(__x86_64__) || defined(_M_X64) || defined(_M_AMD64) || \
+    defined(__powerpc64__) || defined(__ppc64__) || defined(__PPC64__) || \
+    defined(__s390x__) || defined(__arch64__) || defined(__aarch64__) || \
+    defined(__sparcv9) || defined(__sparc_v9__) || defined(__sparc64__) || \
+    defined(__ia64) || defined(__ia64__) || defined(__itanium__) || defined(_M_IA64) || \
+    defined(__LP64__) || defined(_LP64) || defined(__64BIT__)
    typedef unsigned ulong32;
+   #if !defined(ENDIAN_64BITWORD) && !defined(ENDIAN_32BITWORD)
+     #define ENDIAN_64BITWORD
+   #endif
 #else
    typedef unsigned long ulong32;
+   #if !defined(ENDIAN_64BITWORD) && !defined(ENDIAN_32BITWORD)
+     #define ENDIAN_32BITWORD
+   #endif
 #endif
 
-#ifdef LTC_NO_FAST
+/* No LTC_FAST if: explicitly disabled OR non-gcc/non-clang compiler OR old gcc OR using -ansi -std=c99 */
+#if defined(LTC_NO_FAST) || (__GNUC__ < 4) || defined(__STRICT_ANSI__)
    #undef LTC_FAST
 #endif
 
 #ifdef LTC_FAST
-#if __GNUC__ < 4 /* if the compiler does not support gnu extensions, i.e. its neither clang nor gcc nor icc */
-#error the LTC_FAST hack is only available on compilers that support __attribute__((may_alias)) - disable it for your compiler, and dont worry, it won`t buy you much anyway
-#else
-#ifdef ENDIAN_64BITWORD
-typedef ulong64 __attribute__((__may_alias__)) LTC_FAST_TYPE;
-#else
-typedef ulong32 __attribute__((__may_alias__)) LTC_FAST_TYPE;
-#endif
-#define LTC_FAST_TYPE_PTR_CAST(x) ((LTC_FAST_TYPE*)(void*)(x))
-#endif
-#endif /* LTC_FAST */
-
-/* detect sparc and sparc64 */
-#if defined(__sparc__)
-  #define ENDIAN_BIG
-  #if defined(__arch64__)
-    #define ENDIAN_64BITWORD
-  #else
-    #define ENDIAN_32BITWORD
-  #endif
+   #define LTC_FAST_TYPE_PTR_CAST(x) ((LTC_FAST_TYPE*)(void*)(x))
+   #ifdef ENDIAN_64BITWORD
+   typedef ulong64 __attribute__((__may_alias__)) LTC_FAST_TYPE;
+   #else
+   typedef ulong32 __attribute__((__may_alias__)) LTC_FAST_TYPE;
+   #endif
 #endif
 
 #ifdef ENDIAN_64BITWORD
@@ -144,8 +225,7 @@ typedef ulong32 ltc_mp_digit;
 
 /* No asm is a quick way to disable anything "not portable" */
 #ifdef LTC_NO_ASM
-   #undef ENDIAN_LITTLE
-   #undef ENDIAN_BIG
+   #define ENDIAN_NEUTRAL
    #undef ENDIAN_32BITWORD
    #undef ENDIAN_64BITWORD
    #undef LTC_FAST
@@ -154,13 +234,7 @@ typedef ulong32 ltc_mp_digit;
    #define LTC_NO_BSWAP
 #endif
 
-/* #define ENDIAN_LITTLE */
-/* #define ENDIAN_BIG */
-
-/* #define ENDIAN_32BITWORD */
-/* #define ENDIAN_64BITWORD */
-
-#if (defined(ENDIAN_BIG) || defined(ENDIAN_LITTLE)) && !(defined(ENDIAN_32BITWORD) || defined(ENDIAN_64BITWORD))
+#if !defined(ENDIAN_NEUTRAL) && (defined(ENDIAN_BIG) || defined(ENDIAN_LITTLE)) && !(defined(ENDIAN_32BITWORD) || defined(ENDIAN_64BITWORD))
     #error You must specify a word size as well as endianess in tomcrypt_cfg.h
 #endif
 
@@ -169,7 +243,7 @@ typedef ulong32 ltc_mp_digit;
 #endif
 
 #if (defined(ENDIAN_32BITWORD) && defined(ENDIAN_64BITWORD))
-    #error Can not be 32 and 64 bit words...
+    #error Cannot be 32 and 64 bit words...
 #endif
 
 /* gcc 4.3 and up has a bswap builtin; detect it by gcc version.
@@ -186,8 +260,6 @@ typedef ulong32 ltc_mp_digit;
    ((__GNUC__ * 100 + __GNUC_MINOR__ >= 403) ||                         \
     (__has_builtin(__builtin_bswap32) && __has_builtin(__builtin_bswap64)))
    #define LTC_HAVE_BSWAP_BUILTIN
-#endif
-
 #endif
 
 

--- a/src/headers/tomcrypt_macros.h
+++ b/src/headers/tomcrypt_macros.h
@@ -46,9 +46,8 @@ do { x = (((ulong64)((y)[0] & 255))<<56)|(((ulong64)((y)[1] & 255))<<48) | \
          (((ulong64)((y)[4] & 255))<<24)|(((ulong64)((y)[5] & 255))<<16) | \
          (((ulong64)((y)[6] & 255))<<8)|(((ulong64)((y)[7] & 255))); } while(0)
 
-#endif /* ENDIAN_NEUTRAL */
 
-#ifdef ENDIAN_LITTLE
+#elif defined(ENDIAN_LITTLE)
 
 #ifdef LTC_HAVE_BSWAP_BUILTIN
 
@@ -167,9 +166,8 @@ do { x = (((ulong64)((y)[0] & 255))<<56)|(((ulong64)((y)[1] & 255))<<48) | \
 
 #endif /* ENDIAN_64BITWORD */
 
-#endif /* ENDIAN_LITTLE */
+#elif defined(ENDIAN_BIG)
 
-#ifdef ENDIAN_BIG
 #define STORE32L(x, y)                                                                     \
   do { (y)[3] = (unsigned char)(((x)>>24)&255); (y)[2] = (unsigned char)(((x)>>16)&255);   \
        (y)[1] = (unsigned char)(((x)>>8)&255); (y)[0] = (unsigned char)((x)&255); } while(0)

--- a/src/misc/crc32.c
+++ b/src/misc/crc32.c
@@ -20,19 +20,20 @@
 
 static const ulong32 _CRC32_NEGL = 0xffffffffUL;
 
-#if defined(ENDIAN_LITTLE) || defined(ENDIAN_NEUTRAL)
+#if defined(ENDIAN_LITTLE)
 #define CRC32_INDEX(c) (c & 0xff)
 #define CRC32_SHIFTED(c) (c >> 8)
-#else
+#elif defined(ENDIAN_BIG)
 #define CRC32_INDEX(c) (c >> 24)
 #define CRC32_SHIFTED(c) (c << 8)
+#else
+#error The existing CRC32 implementation only works properly when the endianness of the target platform is known.
 #endif
-
 
 /* Table of CRC-32's of all single byte values (made by makecrc.c) */
 static const ulong32 crc32_m_tab[] =
 {
-#if defined(ENDIAN_LITTLE) || defined(ENDIAN_NEUTRAL)
+#if defined(ENDIAN_LITTLE)
       0x00000000L, 0x77073096L, 0xee0e612cL, 0x990951baL, 0x076dc419L,
       0x706af48fL, 0xe963a535L, 0x9e6495a3L, 0x0edb8832L, 0x79dcb8a4L,
       0xe0d5e91eL, 0x97d2d988L, 0x09b64c2bL, 0x7eb17cbdL, 0xe7b82d07L,
@@ -162,10 +163,9 @@ void crc32_update(crc32_state *ctx, const unsigned char *input, unsigned long le
 
 void crc32_finish(crc32_state *ctx, void *hash, unsigned long size)
 {
-   unsigned char* h;
    unsigned long i;
+   unsigned char* h;
    ulong32 crc;
-
    LTC_ARGCHKVD(ctx != NULL);
    LTC_ARGCHKVD(hash != NULL);
 

--- a/src/misc/crypt/crypt.c
+++ b/src/misc/crypt/crypt.c
@@ -25,8 +25,8 @@ const char *crypt_build_settings =
 #endif
    "\n\nEndianness: "
 #if defined(ENDIAN_NEUTRAL)
-   "neutral\n"
-#else
+   "neutral/"
+#endif
 #if defined(ENDIAN_LITTLE)
    "little"
 #elif defined(ENDIAN_BIG)
@@ -34,10 +34,11 @@ const char *crypt_build_settings =
 #endif
    #if defined(ENDIAN_32BITWORD)
    " (32-bit words)\n"
-   #else
+   #elif defined(ENDIAN_64BITWORD)
    " (64-bit words)\n"
+   #else
+   " (no wordsize defined)\n"
    #endif
-#endif
    "Clean stack: "
 #if defined(LTC_CLEAN_STACK)
    "enabled\n"


### PR DESCRIPTION
When compiling libtomcrypt on ppc64 big-endian, I get the following result below when running the tests. It might be an endianness-related issue.

 ./test
build == 
LibTomCrypt 1.17 (Tom St Denis, tomstdenis@gmail.com)
LibTomCrypt is public domain software.

Endianness: neutral
Clean stack: disabled
Ciphers built-in:
   Blowfish
   RC2
   RC5
   RC6
   Safer+
   Safer
   Rijndael
   XTEA
   Twofish (tables)
   DES
   CAST5
   Noekeon
   Skipjack
   Khazad
   Anubis  (tweaked)
   KSEED
   KASUMI
   MULTI2
   Camellia

Hashes built-in:
   SHA-512
   SHA-384
   SHA-512/256
   SHA-256
   SHA-512/224
   SHA-224
   TIGER
   SHA1
   MD5
   MD4
   MD2
   RIPEMD128
   RIPEMD160
   RIPEMD256
   RIPEMD320
   WHIRLPOOL
   CHC_HASH

Block Chaining Modes:
   CFB
   OFB
   ECB
   CBC
   CTR
   LRW (tables) 
   F8
   XTS

MACs:
   HMAC
   OMAC
   PMAC
   PELICAN
   XCBC
   F9

ENC + AUTH modes:
   EAX
   OCB
   OCB3
   CCM
   GCM (tables) 

PRNG:
   Yarrow (LTC_YARROW_AES=2)
   SPRNG
   RC4
   Fortuna (LTC_FORTUNA_POOLS=32, LTC_FORTUNA_WD=10)
   SOBER128

PK Algs:
   RSA (with blinding and CRT hardening)
   DH
   ECC (with blinding)
   DSA

Compiler:
   GCC compiler 6.0.0 20160227 (Red Hat 6.0.0-0.13).

Various others:  ADLER32  BASE64  BASE64-URL-SAFE  CRC32  DER  LTC_DER_MAX_PUBKEY_SIZE=4096  PKCS#1  PKCS#5  HKDF  LTC_DEVRANDOM  LTC_TRY_URANDOM_FIRST  LTC_RNG_GET_BYTES  LTC_RNG_MAKE_PRNG  LTC_HASH_HELPERS  LTC_TEST  LTM_DESC  LTC_ECC_SHAMIR 

MP_DIGIT_BIT = 28

store_test....passed
misc_test.....crc32 fail! Is: 0x0 Should: 0xef7673b3
Algorithm failed test vectors. (5)
misc_test.c:18:crc32_test()
