### PR TITLE
conversion related troubles (int, size_t, ptrdiff_t ..)

### DIFF
--- a/src/hashes/helper/hash_filehandle.c
+++ b/src/hashes/helper/hash_filehandle.c
@@ -50,7 +50,7 @@ int hash_filehandle(int hash, FILE *in, unsigned char *out, unsigned long *outle
     *outlen = hash_descriptor[hash].hashsize;
     do {
         x = fread(buf, 1, sizeof(buf), in);
-        if ((err = hash_descriptor[hash].process(&md, buf, x)) != CRYPT_OK) {
+        if ((err = hash_descriptor[hash].process(&md, buf, (unsigned long)x)) != CRYPT_OK) {
            return err;
         }
     } while (x == sizeof(buf));

--- a/src/mac/f9/f9_file.c
+++ b/src/mac/f9/f9_file.c
@@ -35,7 +35,8 @@ int f9_file(int cipher,
 #ifdef LTC_NO_FILE
    return CRYPT_NOP;
 #else
-   int err, x;
+   size_t x;
+   int err;
    f9_state f9;
    FILE *in;
    unsigned char buf[512];
@@ -57,7 +58,7 @@ int f9_file(int cipher,
 
    do {
       x = fread(buf, 1, sizeof(buf), in);
-      if ((err = f9_process(&f9, buf, x)) != CRYPT_OK) {
+      if ((err = f9_process(&f9, buf, (unsigned long)x)) != CRYPT_OK) {
          fclose(in);
          return err;
       }

--- a/src/mac/omac/omac_file.c
+++ b/src/mac/omac/omac_file.c
@@ -35,7 +35,8 @@ int omac_file(int cipher,
 #ifdef LTC_NO_FILE
    return CRYPT_NOP;
 #else
-   int err, x;
+   size_t x;
+   int err;
    omac_state omac;
    FILE *in;
    unsigned char buf[512];
@@ -57,7 +58,7 @@ int omac_file(int cipher,
 
    do {
       x = fread(buf, 1, sizeof(buf), in);
-      if ((err = omac_process(&omac, buf, x)) != CRYPT_OK) {
+      if ((err = omac_process(&omac, buf, (unsigned long)x)) != CRYPT_OK) {
          fclose(in);
          return err;
       }

--- a/src/mac/pmac/pmac_file.c
+++ b/src/mac/pmac/pmac_file.c
@@ -35,7 +35,8 @@ int pmac_file(int cipher,
 #ifdef LTC_NO_FILE
    return CRYPT_NOP;
 #else
-   int err, x;
+   size_t x;
+   int err;
    pmac_state pmac;
    FILE *in;
    unsigned char buf[512];
@@ -58,7 +59,7 @@ int pmac_file(int cipher,
 
    do {
       x = fread(buf, 1, sizeof(buf), in);
-      if ((err = pmac_process(&pmac, buf, x)) != CRYPT_OK) {
+      if ((err = pmac_process(&pmac, buf, (unsigned long)x)) != CRYPT_OK) {
          fclose(in);
          return err;
       }

--- a/src/mac/xcbc/xcbc_file.c
+++ b/src/mac/xcbc/xcbc_file.c
@@ -35,7 +35,8 @@ int xcbc_file(int cipher,
 #ifdef LTC_NO_FILE
    return CRYPT_NOP;
 #else
-   int err, x;
+   size_t x;
+   int err;
    xcbc_state xcbc;
    FILE *in;
    unsigned char buf[512];
@@ -57,7 +58,7 @@ int xcbc_file(int cipher,
 
    do {
       x = fread(buf, 1, sizeof(buf), in);
-      if ((err = xcbc_process(&xcbc, buf, x)) != CRYPT_OK) {
+      if ((err = xcbc_process(&xcbc, buf, (unsigned long)x)) != CRYPT_OK) {
          fclose(in);
          return err;
       }

--- a/src/misc/base64/base64_encode.c
+++ b/src/misc/base64/base64_encode.c
@@ -75,7 +75,7 @@ static int _base64_encode_internal(const unsigned char *in,  unsigned long inlen
    *p = '\0';
 
    /* return ok */
-   *outlen = p - out;
+   *outlen = (unsigned long)(p - out);
    return CRYPT_OK;
 }
 

--- a/src/pk/asn1/der/set/der_encode_setof.c
+++ b/src/pk/asn1/der/set/der_encode_setof.c
@@ -140,7 +140,7 @@ int der_encode_setof(ltc_asn1_list *list, unsigned long inlen,
    XMEMCPY(out, buf, hdrlen);
 
    /* copy+sort using edges+indecies to output from buffer */
-   for (y = hdrlen, x = 0; x < inlen; x++) {
+   for (y = (unsigned long)hdrlen, x = 0; x < inlen; x++) {
       XMEMCPY(out+y, edges[x].start, edges[x].size);
       y += edges[x].size;
    }


### PR DESCRIPTION
The warnings fixed by this PR:
```
src\hashes\helper\hash_filehandle.c(53) : warning C4267: 'function' : conversion from 'size_t' to 'unsigned long', possible loss of data
src\mac\f9\f9_file.c(59) : warning C4267: '=' : conversion from 'size_t' to 'int', possible loss of data
src\mac\omac\omac_file.c(59) : warning C4267: '=' : conversion from 'size_t' to 'int', possible loss of data
src\mac\pmac\pmac_file.c(60) : warning C4267: '=' : conversion from 'size_t' to 'int', possible loss of data
src\mac\xcbc\xcbc_file.c(59) : warning C4267: '=' : conversion from 'size_t' to 'int', possible loss of data
src\misc\base64\base64_encode.c(78) : warning C4244: '=' : conversion from '__int64' to 'unsigned long', possible loss of data
src\pk\asn1\der\set\der_encode_setof.c(143) : warning C4244: '=' : conversion from 'ptrdiff_t' to 'unsigned long', possible loss of data
```