### PR TITLE
better handling wchar_t when __WCHAR_MAX__ is 0xFFFF (2 bytes only)

### DIFF
--- a/src/headers/tomcrypt_pk.h
+++ b/src/headers/tomcrypt_pk.h
@@ -619,6 +619,7 @@ int der_encode_utf8_string(const wchar_t *in,  unsigned long inlen,
 int der_decode_utf8_string(const unsigned char *in,  unsigned long inlen,
                                        wchar_t *out, unsigned long *outlen);
 unsigned long der_utf8_charsize(const wchar_t c);
+int der_utf8_valid_char(const wchar_t c);
 int der_length_utf8_string(const wchar_t *in, unsigned long noctets, unsigned long *outlen);
 
 

--- a/src/pk/asn1/der/utf8/der_encode_utf8_string.c
+++ b/src/pk/asn1/der/utf8/der_encode_utf8_string.c
@@ -37,9 +37,7 @@ int der_encode_utf8_string(const wchar_t *in,  unsigned long inlen,
 
    /* get the size */
    for (x = len = 0; x < inlen; x++) {
-       if (in[x] < 0 || in[x] > 0x1FFFF) {
-          return CRYPT_INVALID_ARG;
-       }
+       if (!der_utf8_valid_char(in[x])) return CRYPT_INVALID_ARG;
        len += der_utf8_charsize(in[x]);
    }
 

--- a/src/pk/asn1/der/utf8/der_length_utf8_string.c
+++ b/src/pk/asn1/der/utf8/der_length_utf8_string.c
@@ -27,11 +27,33 @@ unsigned long der_utf8_charsize(const wchar_t c)
       return 1;
    } else if (c <= 0x7FF) {
       return 2;
+#if __WCHAR_MAX__ == 0xFFFF
+   } else {
+      return 3;
+   }
+#else
    } else if (c <= 0xFFFF) {
       return 3;
    } else {
       return 4;
    }
+#endif
+}
+
+/**
+  Test whether the given code point is valid character
+  @param c   The UTF-8 character to test
+  @return    1 - valid, 0 - invalid
+*/
+int der_utf8_valid_char(const wchar_t c)
+{
+#if !defined(__WCHAR_MAX__) || __WCHAR_MAX__ > 0xFFFF
+   if (in[x] > 0x10FFFF) return 0;
+#endif
+#if !defined(__WCHAR_MAX__) || __WCHAR_MAX__ != 0xFFFF && __WCHAR_MAX__ != 0xFFFFFFFF
+   if (in[x] < 0) return 0;
+#endif
+   return 1;
 }
 
 /**
@@ -50,9 +72,7 @@ int der_length_utf8_string(const wchar_t *in, unsigned long noctets, unsigned lo
 
    len = 0;
    for (x = 0; x < noctets; x++) {
-      if (in[x] < 0 || in[x] > 0x10FFFF) {
-         return CRYPT_INVALID_ARG;
-      }
+      if (!der_utf8_valid_char(in[x])) return CRYPT_INVALID_ARG;
       len += der_utf8_charsize(in[x]);
    }
 


### PR DESCRIPTION
On platforms with 2byte only wchar_t (0x0000 .. 0xFFFF) the current version emits the following warnings:
```
clang -Wall -Wcast-align -Wextra -DUSE_LTM -DLTM_DESC -I../libtommath -I./testprof/ -I./src/headers/ -Wall -Wsign-compare -Wshadow -DLTC_SOURCE -Wextra -Wsystem-headers -Wbad-function-cast -Wcast-align -Wstrict-prototypes -Wpointer-arith -Wno-type-limits -O3 -funroll-loops -fomit-frame-pointer -c src/pk/asn1/der/utf8/der_encode_utf8_string.c -o src/pk/asn1/der/utf8/der_encode_utf8_string.o
src/pk/asn1/der/utf8/der_encode_utf8_string.c:40:31: warning: comparison of constant 131071 with expression of type 'const wchar_t' (aka 'const unsigned short') is always false [-Wtautological-constant-out-of-range-compare]
       if (in[x] < 0 || in[x] > 0x1FFFF) {
                        ~~~~~ ^ ~~~~~~~
1 warning generated.
   * clang src/pk/asn1/der/utf8/der_length_utf8_string.o
clang -Wall -Wcast-align -Wextra -DUSE_LTM -DLTM_DESC -I../libtommath -I./testprof/ -I./src/headers/ -Wall -Wsign-compare -Wshadow -DLTC_SOURCE -Wextra -Wsystem-headers -Wbad-function-cast -Wcast-align -Wstrict-prototypes -Wpointer-arith -Wno-type-limits -O3 -funroll-loops -fomit-frame-pointer -c src/pk/asn1/der/utf8/der_length_utf8_string.c -o src/pk/asn1/der/utf8/der_length_utf8_string.o
src/pk/asn1/der/utf8/der_length_utf8_string.c:53:30: warning: comparison of constant 1114111 with expression of type 'const wchar_t' (aka 'const unsigned short') is always false [-Wtautological-constant-out-of-range-compare]
      if (in[x] < 0 || in[x] > 0x10FFFF) {
                       ~~~~~ ^ ~~~~~~~~
1 warning generated.
```

Or with older gcc:
```
pk/asn1/der/utf8/der_encode_utf8_string.c: In function `der_encode_utf8_string':
pk/asn1/der/utf8/der_encode_utf8_string.c:40: warning: comparison is always false due to limited range of data type
pk/asn1/der/utf8/der_encode_utf8_string.c:40: warning: comparison is always false due to limited range of data type
pk/asn1/der/utf8/der_length_utf8_string.c: In function `der_utf8_charsize':
pk/asn1/der/utf8/der_length_utf8_string.c:30: warning: comparison is always true due to limited range of data type
pk/asn1/der/utf8/der_length_utf8_string.c: In function `der_length_utf8_string':
pk/asn1/der/utf8/der_length_utf8_string.c:53: warning: comparison is always false due to limited range of data type
pk/asn1/der/utf8/der_length_utf8_string.c:53: warning: comparison is always false due to limited range of data type
```

Please also note that in the original code there was an inconsistency:
```
if (in[x] < 0 || in[x] > 0x1FFFF)
vs.
if (in[x] < 0 || in[x] > 0x10FFFF)
```

IMO `0x10FFFF` is correct.