### PR TITLE
travis - we need the latest libtommath

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 compiler:
   - gcc
   - clang
-script: bash "${BUILDSCRIPT}" "${BUILDNAME}" "${BUILDOPTIONS}" "makefile" "-DUSE_LTM -DLTM_DESC -I/usr/include" "/usr/lib/libtommath.a"
+script: bash "${BUILDSCRIPT}" "${BUILDNAME}" "${BUILDOPTIONS}" "makefile" "-DUSE_LTM -DLTM_DESC -I/usr/include" "/usr/lib/x86_64-linux-gnu/libtommath.a"
 env:
   - |
     BUILDSCRIPT="check_source.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,9 +81,14 @@ matrix:
 branches:
   only:
     - develop
+addons:
+  apt:
+    sources:
+    - debian-sid
+    packages:
+    - libtommath-dev
 before_script:
   - sudo apt-get update -qq
-  - sudo apt-get install libtommath-dev
   - sudo pip install cpp-coveralls
 after_failure:
   - cat test_std.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,7 @@ addons:
     sources:
     - debian-sid
     packages:
+    - binutils
     - libtommath-dev
 before_script:
   - sudo apt-get update -qq


### PR DESCRIPTION
I was trying to rebase my branch with ECC enhancements (which more or less went fine).

The troubles appear with Travis-CI https://travis-ci.org/libtom/libtomcrypt/jobs/206820906

All travis builds fail as my ECC enhancements require `mp_sqrtmod_prime` introduced in libtommath v1.0.