### PR TITLE
fix wchar_t related warnings on Visual Studio 2008

### DIFF
--- a/src/headers/tomcrypt_pk.h
+++ b/src/headers/tomcrypt_pk.h
@@ -619,6 +619,7 @@ int der_printable_value_decode(int v);
 #elif defined(WCHAR_MAX)
 #define LTC_WCHAR_MAX WCHAR_MAX
 #endif
+/* please note that it might happen that LTC_WCHAR_MAX is undefined */
 #else
 typedef ulong32 wchar_t;
 #define LTC_WCHAR_MAX 0xFFFFFFFF

--- a/src/headers/tomcrypt_pk.h
+++ b/src/headers/tomcrypt_pk.h
@@ -612,10 +612,16 @@ int der_printable_char_encode(int c);
 int der_printable_value_decode(int v);
 
 /* UTF-8 */
-#if (defined(SIZE_MAX) || __STDC_VERSION__ >= 199901L || defined(WCHAR_MAX) || defined(_WCHAR_T) || defined(_WCHAR_T_DEFINED) || defined (__WCHAR_TYPE__)) && !defined(LTC_NO_WCHAR)
+#if (defined(SIZE_MAX) || __STDC_VERSION__ >= 199901L || defined(WCHAR_MAX) || defined(__WCHAR_MAX__) || defined(_WCHAR_T) || defined(_WCHAR_T_DEFINED) || defined (__WCHAR_TYPE__)) && !defined(LTC_NO_WCHAR)
 #include <wchar.h>
+#if defined(__WCHAR_MAX__)
+#define LTC_WCHAR_MAX __WCHAR_MAX__
+#elif defined(WCHAR_MAX)
+#define LTC_WCHAR_MAX WCHAR_MAX
+#endif
 #else
 typedef ulong32 wchar_t;
+#define LTC_WCHAR_MAX 0xFFFFFFFF
 #endif
 
 int der_encode_utf8_string(const wchar_t *in,  unsigned long inlen,

--- a/src/pk/asn1/der/utf8/der_encode_utf8_string.c
+++ b/src/pk/asn1/der/utf8/der_encode_utf8_string.c
@@ -87,7 +87,7 @@ int der_encode_utf8_string(const wchar_t *in,  unsigned long inlen,
           case 1: out[x++] = (unsigned char)in[y]; break;
           case 2: out[x++] = 0xC0 | ((in[y] >> 6) & 0x1F);  out[x++] = 0x80 | (in[y] & 0x3F); break;
           case 3: out[x++] = 0xE0 | ((in[y] >> 12) & 0x0F); out[x++] = 0x80 | ((in[y] >> 6) & 0x3F); out[x++] = 0x80 | (in[y] & 0x3F); break;
-#if !defined(__WCHAR_MAX__) && !defined(WCHAR_MAX) || __WCHAR_MAX__ > 0xFFFF || WCHAR_MAX > 0xFFFF
+#if !defined(LTC_WCHAR_MAX) || LTC_WCHAR_MAX > 0xFFFF
           case 4: out[x++] = 0xF0 | ((in[y] >> 18) & 0x07); out[x++] = 0x80 | ((in[y] >> 12) & 0x3F); out[x++] = 0x80 | ((in[y] >> 6) & 0x3F); out[x++] = 0x80 | (in[y] & 0x3F); break;
 #endif
        }

--- a/src/pk/asn1/der/utf8/der_encode_utf8_string.c
+++ b/src/pk/asn1/der/utf8/der_encode_utf8_string.c
@@ -87,7 +87,9 @@ int der_encode_utf8_string(const wchar_t *in,  unsigned long inlen,
           case 1: out[x++] = (unsigned char)in[y]; break;
           case 2: out[x++] = 0xC0 | ((in[y] >> 6) & 0x1F);  out[x++] = 0x80 | (in[y] & 0x3F); break;
           case 3: out[x++] = 0xE0 | ((in[y] >> 12) & 0x0F); out[x++] = 0x80 | ((in[y] >> 6) & 0x3F); out[x++] = 0x80 | (in[y] & 0x3F); break;
+#if !defined(__WCHAR_MAX__) && !defined(WCHAR_MAX) || __WCHAR_MAX__ > 0xFFFF || WCHAR_MAX > 0xFFFF
           case 4: out[x++] = 0xF0 | ((in[y] >> 18) & 0x07); out[x++] = 0x80 | ((in[y] >> 12) & 0x3F); out[x++] = 0x80 | ((in[y] >> 6) & 0x3F); out[x++] = 0x80 | (in[y] & 0x3F); break;
+#endif
        }
    }
 

--- a/src/pk/asn1/der/utf8/der_length_utf8_string.c
+++ b/src/pk/asn1/der/utf8/der_length_utf8_string.c
@@ -27,7 +27,7 @@ unsigned long der_utf8_charsize(const wchar_t c)
       return 1;
    } else if (c <= 0x7FF) {
       return 2;
-#if __WCHAR_MAX__ == 0xFFFF || WCHAR_MAX == 0xFFFF
+#if LTC_WCHAR_MAX == 0xFFFF
    } else {
       return 3;
    }
@@ -48,10 +48,10 @@ unsigned long der_utf8_charsize(const wchar_t c)
 int der_utf8_valid_char(const wchar_t c)
 {
    LTC_UNUSED_PARAM(c);
-#if !defined(__WCHAR_MAX__) && !defined(WCHAR_MAX) || __WCHAR_MAX__ > 0xFFFF || WCHAR_MAX > 0xFFFF
+#if !defined(LTC_WCHAR_MAX) || LTC_WCHAR_MAX > 0xFFFF
    if (c > 0x10FFFF) return 0;
 #endif
-#if !defined(__WCHAR_MAX__) && !defined(WCHAR_MAX) || __WCHAR_MAX__ != 0xFFFF && __WCHAR_MAX__ != 0xFFFFFFFF && WCHAR_MAX != 0xFFFF && WCHAR_MAX != 0xFFFFFFFF
+#if !defined(LTC_WCHAR_MAX) || LTC_WCHAR_MAX != 0xFFFF && LTC_WCHAR_MAX != 0xFFFFFFFF
    if (c < 0) return 0;
 #endif
    return 1;

--- a/src/pk/asn1/der/utf8/der_length_utf8_string.c
+++ b/src/pk/asn1/der/utf8/der_length_utf8_string.c
@@ -51,7 +51,7 @@ int der_utf8_valid_char(const wchar_t c)
 #if !defined(LTC_WCHAR_MAX) || LTC_WCHAR_MAX > 0xFFFF
    if (c > 0x10FFFF) return 0;
 #endif
-#if !defined(LTC_WCHAR_MAX) || LTC_WCHAR_MAX != 0xFFFF && LTC_WCHAR_MAX != 0xFFFFFFFF
+#if LTC_WCHAR_MAX != 0xFFFF && LTC_WCHAR_MAX != 0xFFFFFFFF
    if (c < 0) return 0;
 #endif
    return 1;

--- a/src/pk/asn1/der/utf8/der_length_utf8_string.c
+++ b/src/pk/asn1/der/utf8/der_length_utf8_string.c
@@ -27,7 +27,7 @@ unsigned long der_utf8_charsize(const wchar_t c)
       return 1;
    } else if (c <= 0x7FF) {
       return 2;
-#if __WCHAR_MAX__ == 0xFFFF
+#if __WCHAR_MAX__ == 0xFFFF || WCHAR_MAX == 0xFFFF
    } else {
       return 3;
    }
@@ -48,10 +48,10 @@ unsigned long der_utf8_charsize(const wchar_t c)
 int der_utf8_valid_char(const wchar_t c)
 {
    LTC_UNUSED_PARAM(c);
-#if !defined(__WCHAR_MAX__) || __WCHAR_MAX__ > 0xFFFF
+#if !defined(__WCHAR_MAX__) && !defined(WCHAR_MAX) || __WCHAR_MAX__ > 0xFFFF || WCHAR_MAX > 0xFFFF
    if (c > 0x10FFFF) return 0;
 #endif
-#if !defined(__WCHAR_MAX__) || __WCHAR_MAX__ != 0xFFFF && __WCHAR_MAX__ != 0xFFFFFFFF
+#if !defined(__WCHAR_MAX__) && !defined(WCHAR_MAX) || __WCHAR_MAX__ != 0xFFFF && __WCHAR_MAX__ != 0xFFFFFFFF && WCHAR_MAX != 0xFFFF && WCHAR_MAX != 0xFFFFFFFF
    if (c < 0) return 0;
 #endif
    return 1;


### PR DESCRIPTION
Visual Studio 2008 has `WCHAR_MAX` but not `__WCHAR_MAX__`