### PR TITLE
adler32 vs. crc32 inconsistency

### DIFF
--- a/src/misc/crc32.c
+++ b/src/misc/crc32.c
@@ -175,7 +175,7 @@ void crc32_finish(crc32_state *ctx, void *hash, unsigned long size)
 
    if (size > 4) size = 4;
    for (i = 0; i < size; i++) {
-      h[i] = ((unsigned char*)&(crc))[i];
+      h[i] = ((unsigned char*)&(crc))[size-i-1];
    }
 }
 
@@ -185,7 +185,7 @@ int crc32_test(void)
    return CRYPT_NOP;
 #else
    const void* in = "libtomcrypt";
-   const unsigned char crc32[] = { 0xef, 0x76, 0x73, 0xb3 };
+   const unsigned char crc32[] = { 0xb3, 0x73, 0x76, 0xef };
    unsigned char out[4];
    crc32_state ctx;
    crc32_init(&ctx);


### PR DESCRIPTION
in `crc32_test` we have:

``` c
{
   const void* in = "libtomcrypt";
   const unsigned char crc32[] = { 0xef, 0x76, 0x73, 0xb3 };
   ....
}
```

However the correct CRC32 from "libtomcrypt" string is IMHO `b37376ef` not `ef7673b3`.

By which I mean the actual CRC32 implementation seems to be somehow incorrect not `crc32_test`.
