### PR TITLE
misuse of compare_testvector

### DIFF
--- a/src/ciphers/rc2.c
+++ b/src/ciphers/rc2.c
@@ -370,8 +370,8 @@ int rc2_test(void)
         rc2_ecb_encrypt(tests[x].pt, tmp[0], &skey);
         rc2_ecb_decrypt(tmp[0], tmp[1], &skey);
 
-        if (compare_testvector(tmp[0], 8, tests[x].ct, 8, "RC2 CT", x) != 0 ||
-              compare_testvector(tmp[1], 8, tests[x].pt, 8, "RC2 PT", x) != 0) {
+        if (compare_testvector(tmp[0], 8, tests[x].ct, 8, "RC2 CT", x) ||
+              compare_testvector(tmp[1], 8, tests[x].pt, 8, "RC2 PT", x)) {
            return CRYPT_FAIL_TESTVECTOR;
         }
 

--- a/src/prngs/chacha20.c
+++ b/src/prngs/chacha20.c
@@ -195,21 +195,21 @@ int chacha20_prng_test(void)
    chacha20_prng_add_entropy(en, sizeof(en), &st); /* add entropy to uninitialized prng */
    chacha20_prng_ready(&st);
    chacha20_prng_read(out, 10, &st);  /* 10 bytes for testing */
-   if (compare_testvector(out, 10, t1, sizeof(t1), "CHACHA-PRNG", 1) != 0) return CRYPT_FAIL_TESTVECTOR;
+   if (compare_testvector(out, 10, t1, sizeof(t1), "CHACHA-PRNG", 1)) return CRYPT_FAIL_TESTVECTOR;
    chacha20_prng_read(out, 500, &st);
    chacha20_prng_add_entropy(en, sizeof(en), &st); /* add entropy to already initialized prng */
    chacha20_prng_read(out, 500, &st);
    chacha20_prng_export(dmp, &dmplen, &st);
    chacha20_prng_read(out, 500, &st); /* skip 500 bytes */
    chacha20_prng_read(out, 10, &st);  /* 10 bytes for testing */
-   if (compare_testvector(out, 10, t2, sizeof(t2), "CHACHA-PRNG", 2) != 0) return CRYPT_FAIL_TESTVECTOR;
+   if (compare_testvector(out, 10, t2, sizeof(t2), "CHACHA-PRNG", 2)) return CRYPT_FAIL_TESTVECTOR;
    chacha20_prng_done(&st);
 
    XMEMSET(&st, 0xFF, sizeof(st)); /* just to be sure */
    chacha20_prng_import(dmp, dmplen, &st);
    chacha20_prng_read(out, 500, &st); /* skip 500 bytes */
    chacha20_prng_read(out, 10, &st);  /* 10 bytes for testing */
-   if (compare_testvector(out, 10, t2, sizeof(t2), "CHACHA-PRNG", 3) != 0) return CRYPT_FAIL_TESTVECTOR;
+   if (compare_testvector(out, 10, t2, sizeof(t2), "CHACHA-PRNG", 3)) return CRYPT_FAIL_TESTVECTOR;
    chacha20_prng_done(&st);
 
    return CRYPT_OK;

--- a/src/stream/chacha/chacha_test.c
+++ b/src/stream/chacha/chacha_test.c
@@ -47,17 +47,17 @@ int chacha_test(void)
    chacha_crypt(&st, (unsigned char*)pt + 70,  5,       out + 70);
    chacha_crypt(&st, (unsigned char*)pt + 75,  5,       out + 75);
    chacha_crypt(&st, (unsigned char*)pt + 80, len - 80, out + 80);
-   if (compare_testvector(out, len, ct, sizeof(ct), "CHACHA-TV1", 1) != 0) return CRYPT_FAIL_TESTVECTOR;
+   if (compare_testvector(out, len, ct, sizeof(ct), "CHACHA-TV1", 1)) return CRYPT_FAIL_TESTVECTOR;
    /* crypt in one go */
    chacha_setup(&st, k, sizeof(k), 20);
    chacha_ivctr32(&st, n, sizeof(n), 1);
    chacha_crypt(&st, (unsigned char*)pt, len, out);
-   if (compare_testvector(out, len, ct, sizeof(ct), "CHACHA-TV2", 1) != 0) return CRYPT_FAIL_TESTVECTOR;
+   if (compare_testvector(out, len, ct, sizeof(ct), "CHACHA-TV2", 1)) return CRYPT_FAIL_TESTVECTOR;
    /* crypt in one go - using chacha_ivctr64() */
    chacha_setup(&st, k, sizeof(k), 20);
    chacha_ivctr64(&st, n + 4, sizeof(n) - 4, 1);
    chacha_crypt(&st, (unsigned char*)pt, len, out);
-   if (compare_testvector(out, len, ct, sizeof(ct), "CHACHA-TV3", 1) != 0) return CRYPT_FAIL_TESTVECTOR;
+   if (compare_testvector(out, len, ct, sizeof(ct), "CHACHA-TV3", 1)) return CRYPT_FAIL_TESTVECTOR;
 
    return CRYPT_OK;
 #endif


### PR DESCRIPTION
`compare_testvector` has two different definitions see https://github.com/libtom/libtomcrypt/blob/develop/src/headers/tomcrypt_misc.h#L102-L109
When the macro definition is used, the comparison `compare_testvector() != 0` is wrong.
When the function definition is used, the comparison is useless.
So, this commit removes the comparison.
