### PR TITLE
LTC_PTHREAD: some linting

### DIFF
--- a/src/headers/tomcrypt_prng.h
+++ b/src/headers/tomcrypt_prng.h
@@ -66,7 +66,7 @@ typedef struct {
 #endif
    };
    short ready;            /* ready flag 0-1 */
-   LTC_MUTEX_TYPE(lock);   /* lock */
+   LTC_MUTEX_TYPE(lock)    /* lock */
 } prng_state;
 
 /** PRNG descriptor */


### PR DESCRIPTION
the macro LTC_MUTEX_TYPE already contains a semicolon
see https://github.com/libtom/libtomcrypt/blob/develop/src/headers/tomcrypt_custom.h#L552