### PR TITLE
fix MSVC compile errors

### DIFF
--- a/src/headers/tomcrypt_prng.h
+++ b/src/headers/tomcrypt_prng.h
@@ -66,7 +66,7 @@ typedef struct {
 #endif
    };
    short ready;            /* ready flag 0-1 */
-   LTC_MUTEX_TYPE(lock);   /* lock */
+   LTC_MUTEX_TYPE(lock)    /* lock */
 } prng_state;
 
 /** PRNG descriptor */


### PR DESCRIPTION
The semicolon after the LTC_MUTEX_TYPE macro causes compile errors if LTC_PTHREAD is not defined