### PR TITLE
echo -n portability

### DIFF
--- a/makefile_include.mk
+++ b/makefile_include.mk
@@ -92,7 +92,7 @@ CFLAGS += -Wno-typedef-redefinition -Wno-tautological-compare
 endif
 
 
-GIT_VERSION := $(shell [ -e .git ] && { echo -n git- ; git describe --tags --always --dirty ; } || echo $(VERSION))
+GIT_VERSION := $(shell [ -e .git ] && { printf git- ; git describe --tags --always --dirty ; } || echo $(VERSION))
 ifneq ($(GIT_VERSION),)
 CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
 endif


### PR DESCRIPTION
There seem to be two theories on  preventing `echo` from printing a trailing newline; `-n` or `\c` embedded at the end of the text (possibly with a `-e` to activate it).

* OS X sh: `\c` (sh is actually bash, but behavior is different due to compile time configuration and the `POSIXLY_CORRECT` environment variable
* OS X bash: `-e` `\c` or `-n`
* OS X /bin/echo: `-n` 
* AIX sh: `\c`
* AIX /bin/echo: `\c`
* Linux sh: `-e` `\c` or `-n`
* Linux /bin/echo `-e` `\c` or `-n`

The OS X/BSD man page recommends using `printf` (which is available on AIX, OS X, and Linux) to avoid newlines.