### PR TITLE
Travis-CI: clang static analyzer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,10 @@ env:
     BUILDNAME="CHECK_SOURCES"
     BUILDOPTIONS=" "
   - |
+    BUILDSCRIPT="scan_build.sh"
+    BUILDNAME="SCAN_BUILD"
+    BUILDOPTIONS=" "
+  - |
     BUILDSCRIPT="coverage.sh"
     BUILDNAME="COVERAGE"
     BUILDOPTIONS=" "

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,14 @@ addons:
   apt:
     sources:
     - debian-sid
+    - ubuntu-toolchain-r-test
+    - llvm-toolchain-precise-3.7
     packages:
     - binutils
+    - clang-3.7
+    - cloud-utils
     - libtommath-dev
+    - util-linux
 
 before_script:
   - gem install coveralls-lcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,16 @@ addons:
     packages:
     - clang-3.8
 
+install:
+    - sudo apt-get update -qq
+    - sudo apt-get install libtommath-dev
+
 before_script:
   - gem install coveralls-lcov
   - curl http://ftp.de.debian.org/debian/pool/main/l/lcov/lcov_1.11.orig.tar.gz | tar xz
   - export PATH=$PATH:`pwd`/lcov-1.11/bin
   - curl -s https://packagecloud.io/install/repositories/libtom/packages/script.deb.sh | sudo bash
-  - sudo apt-get install libtfm-dev=0.13-5 libtommath-dev=1.0-4
+  - sudo apt-get install libtfm-dev=0.13-5
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,16 @@ language: c
 addons:
   apt:
     sources:
-    - debian-sid
     - llvm-toolchain-trusty-4.0
     packages:
-    - binutils
     - clang-4.0
-    - libtommath-dev
 
 before_script:
   - gem install coveralls-lcov
   - curl http://ftp.de.debian.org/debian/pool/main/l/lcov/lcov_1.11.orig.tar.gz | tar xz
   - export PATH=$PATH:`pwd`/lcov-1.11/bin
-  - curl -s https://packagecloud.io/install/repositories/libtom/tomsfastmath/script.deb.sh | sudo bash
-  - sudo apt-get install libtfm-dev=0.13-5
+  - curl -s https://packagecloud.io/install/repositories/libtom/packages/script.deb.sh | sudo bash
+  - sudo apt-get install libtfm-dev=0.13-5 libtommath-dev=1.0-5
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ compiler:
   - gcc
   - clang
 script:
-  - bash "${BUILDSCRIPT}" "${BUILDNAME}" "${BUILDOPTIONS}" "makefile V=1"        "-DUSE_LTM -DLTM_DESC" "/usr/lib/x86_64-linux-gnu/libtommath.a"
+  - bash "${BUILDSCRIPT}" "${BUILDNAME}" "${BUILDOPTIONS}" "makefile V=1"        "-DUSE_LTM -DLTM_DESC" "-ltommath"
   - bash "${BUILDSCRIPT}" "${BUILDNAME}" "${BUILDOPTIONS}" "makefile.shared V=1" "-DUSE_TFM -DTFM_DESC" "-ltfm"
 env:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,10 @@ language: c
 addons:
   apt:
     sources:
-    - llvm-toolchain-trusty-4.0
+    - ubuntu-toolchain-r-test
+    - llvm-toolchain-precise-3.8
     packages:
-    - clang-4.0
+    - clang-3.8
 
 before_script:
   - gem install coveralls-lcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - curl http://ftp.de.debian.org/debian/pool/main/l/lcov/lcov_1.11.orig.tar.gz | tar xz
   - export PATH=$PATH:`pwd`/lcov-1.11/bin
   - curl -s https://packagecloud.io/install/repositories/libtom/packages/script.deb.sh | sudo bash
-  - sudo apt-get install libtfm-dev=0.13-5 libtommath-dev=1.0-5
+  - sudo apt-get install libtfm-dev=0.13-5 libtommath-dev=1.0-4
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
+dist: trusty
+sudo: required
+
 language: c
 
 addons:
   apt:
     sources:
     - debian-sid
-    - ubuntu-toolchain-r-test
-    - llvm-toolchain-precise-3.7
+    - llvm-toolchain-trusty-4.0
     packages:
     - binutils
-    - clang-3.7
-    - cloud-utils
+    - clang-4.0
     - libtommath-dev
-    - util-linux
 
 before_script:
   - gem install coveralls-lcov

--- a/coverage.sh
+++ b/coverage.sh
@@ -17,8 +17,8 @@ if [ -z "$(echo $CC | grep "gcc")" ]; then
     exit 0
 fi
 
-if [ "$(echo $2 | grep -v 'makefile[.]')" == "" ]; then
-    echo "only run coverage for the regular makefile, early exit success"
+if [ "$(echo $3 | grep -v 'makefile[.]')" == "" ]; then
+    echo "only run $0 for the regular makefile, early exit success"
     exit 0
 fi
 

--- a/scan_build.sh
+++ b/scan_build.sh
@@ -13,5 +13,7 @@ make clean > /dev/null
 
 scan_build=$(which scan-build)
 [ -z "$scan_build" ] && scan_build=$(find /usr/bin/ -name 'scan-build-*' | sort -nr | head -n1) || true
-[ -z "$scan_build" ] && { echo "couldn't find clang scan-build"; exit 1; } || true
-CFLAGS="" EXTRALIBS="" $scan_build make -f makefile.unix all CFLAGS="" EXTRALIBS=""
+[ -z "$scan_build" ] && { echo "couldn't find clang scan-build"; exit 1; } || echo "run $scan_build"
+export CFLAGS="-DUSE_LTM -DLTM_DESC -I/usr/include"
+export EXTRALIBS="-ltommath"
+$scan_build make -f makefile.unix all CFLAGS="$CFLAGS" EXTRALIBS="$EXTRALIBS"

--- a/scan_build.sh
+++ b/scan_build.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
-[ "$TRAVIS_CI" != "" ] && sudo apt-get install clang -y -qq || true
+[ "$TRAVIS_CI" != "" ] && { [ -z "$(which scan-build)" ] && { echo "installing clang"; sudo apt-get install clang -y -qq; }; } || true
 
 # output version
 bash printinfo.sh
 
 make clean > /dev/null
 
-scan-build make -f makefile.unix all
+scan_build=$(which scan-build)
+[ -z "$scan_build" ] && scan_build=$(find /usr/bin/ -name 'scan-build-*' | sort -nr | head -n1) || true
+[ -z "$scan_build" ] && { echo "couldn't find clang scan-build"; exit 1; } || true
+$scan_build make -f makefile.unix all

--- a/scan_build.sh
+++ b/scan_build.sh
@@ -9,4 +9,4 @@ make clean > /dev/null
 scan_build=$(which scan-build)
 [ -z "$scan_build" ] && scan_build=$(find /usr/bin/ -name 'scan-build-*' | sort -nr | head -n1) || true
 [ -z "$scan_build" ] && { echo "couldn't find clang scan-build"; exit 1; } || true
-$scan_build make -f makefile.unix all
+$scan_build make -f makefile.unix all CFLAGS="" EXTRALIBS=""

--- a/scan_build.sh
+++ b/scan_build.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 [ "$TRAVIS_CI" != "" ] && { [ -z "$(which scan-build)" ] && { echo "installing clang"; sudo apt-get install clang -y -qq; }; } || true
 
+if [ "$#" = "5" -a "$(echo $3 | grep -v 'makefile[.]')" = "" ]; then
+    echo "only run $0 for the regular makefile, early exit success"
+    exit 0
+fi
+
 # output version
 bash printinfo.sh
 
@@ -9,4 +14,4 @@ make clean > /dev/null
 scan_build=$(which scan-build)
 [ -z "$scan_build" ] && scan_build=$(find /usr/bin/ -name 'scan-build-*' | sort -nr | head -n1) || true
 [ -z "$scan_build" ] && { echo "couldn't find clang scan-build"; exit 1; } || true
-$scan_build make -f makefile.unix all CFLAGS="" EXTRALIBS=""
+CFLAGS="" EXTRALIBS="" $scan_build make -f makefile.unix all CFLAGS="" EXTRALIBS=""

--- a/scan_build.sh
+++ b/scan_build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+[ "$TRAVIS_CI" != "" ] && sudo apt-get install clang -y -qq || true
+
+# output version
+bash printinfo.sh
+
+make clean > /dev/null
+
+scan-build make -f makefile.unix all


### PR DESCRIPTION
lulz @ the conversion from issue to PR
-------
... it changes the author of the initial comment... @karel-m wrote all this...

`------------------`

Although I am not sure how to do it I believe that it might be possible to utilize clang static analyzer in our automated travis builds.

Manually you can start it like:
```
scan-build make -f makefile.unix all
```

Current develop throws following warnings
```
/usr/bin/../libexec/ccc-analyzer -c -I./testprof/ -I./src/headers/ -DLTC_SOURCE -O2  -o src/ciphers/anubis.o   -c -o src/ciphers/anubis.o src/ciphers/anubis.c
src/ciphers/anubis.c:1001:27: warning: The left operand of '^' is a garbage value
      kappa[0] = inter[0] ^ rc[r];
                 ~~~~~~~~ ^
1 warning generated.

/usr/bin/../libexec/ccc-analyzer -c -I./testprof/ -I./src/headers/ -DLTC_SOURCE -O2  -o src/encauth/ccm/ccm_memory.o   -c -o src/encauth/ccm/ccm_memory.o src/encauth/ccm/ccm_memory.c
src/encauth/ccm/ccm_memory.c:148:17: warning: Call to 'malloc' has an allocation size of 0 bytes
      pt_work = XMALLOC(ptlen);
                ^~~~~~~~~~~~~~
./src/headers/tomcrypt_custom.h:6:18: note: expanded from macro 'XMALLOC'
#define XMALLOC  malloc
                 ^
1 warning generated.

/usr/bin/../libexec/ccc-analyzer -c -I./testprof/ -I./src/headers/ -DLTC_SOURCE -O2  -o src/pk/asn1/der/utctime/der_decode_utctime.o   -c -o src/pk/asn1/der/utctime/der_decode_utctime.o src/pk/asn1/der/utctime/der_decode_utctime.c
src/pk/asn1/der/utctime/der_decode_utctime.c:88:5: warning: Function call argument is an uninitialized value
    DECODE_V(out->YY, 100);
    ^~~~~~~~~~~~~~~~~~~~~~
src/pk/asn1/der/utctime/der_decode_utctime.c:38:9: note: expanded from macro 'DECODE_V'
   y  = char_to_int(buf[x])*10 + char_to_int(buf[x+1]); \
        ^~~~~~~~~~~~~~~~~~~
src/pk/asn1/der/utctime/der_decode_utctime.c:88:5: warning: Function call argument is an uninitialized value
    DECODE_V(out->YY, 100);
    ^~~~~~~~~~~~~~~~~~~~~~
src/pk/asn1/der/utctime/der_decode_utctime.c:38:34: note: expanded from macro 'DECODE_V'
   y  = char_to_int(buf[x])*10 + char_to_int(buf[x+1]); \
                                 ^~~~~~~~~~~~~~~~~~~~~
src/pk/asn1/der/utctime/der_decode_utctime.c:89:5: warning: Function call argument is an uninitialized value
    DECODE_V(out->MM, 13);
    ^~~~~~~~~~~~~~~~~~~~~
src/pk/asn1/der/utctime/der_decode_utctime.c:38:9: note: expanded from macro 'DECODE_V'
   y  = char_to_int(buf[x])*10 + char_to_int(buf[x+1]); \
        ^~~~~~~~~~~~~~~~~~~
src/pk/asn1/der/utctime/der_decode_utctime.c:89:5: warning: Function call argument is an uninitialized value
    DECODE_V(out->MM, 13);
    ^~~~~~~~~~~~~~~~~~~~~
src/pk/asn1/der/utctime/der_decode_utctime.c:38:34: note: expanded from macro 'DECODE_V'
   y  = char_to_int(buf[x])*10 + char_to_int(buf[x+1]); \
                                 ^~~~~~~~~~~~~~~~~~~~~
4 warnings generated.
```