### PR TITLE
Fix number of Miller-Rabin rounds

### DIFF
--- a/src/headers/tomcrypt_math.h
+++ b/src/headers/tomcrypt_math.h
@@ -24,6 +24,12 @@
    typedef void rsa_key;
 #endif
 
+#ifndef LTC_MILLER_RABIN_REPS
+   /* Number of rounds of the Miller-Rabin test
+    * "Reasonable values of reps are between 15 and 50." c.f. gmp doc of mpz_probab_prime_p() */
+   #define LTC_MILLER_RABIN_REPS    35
+#endif
+
 /** math descriptor */
 typedef struct {
    /** Name of the math provider */
@@ -345,7 +351,7 @@ typedef struct {
 
    /** Primality testing
        @param a     The integer to test
-       @param b     The number of tests that shall be executed
+       @param b     The number of Miller-Rabin tests that shall be executed
        @param c     The destination of the result (FP_YES if prime)
        @return CRYPT_OK on success
    */
@@ -472,13 +478,13 @@ typedef struct {
    int (*submod)(void *a, void *b, void *c, void *d);
 
 /* ---- misc stuff ---- */
+
    /** Make a pseudo-random mpi
       @param  a     The mpi to make random
       @param  size  The desired length
       @return CRYPT_OK on success
    */
    int (*rand)(void *a, int size);
-
 } ltc_math_descriptor;
 
 extern ltc_math_descriptor ltc_mp;

--- a/src/math/gmp_desc.c
+++ b/src/math/gmp_desc.c
@@ -446,7 +446,7 @@ static int isprime(void *a, int b, int *c)
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(c != NULL);
    if (b == 0) {
-       b = 8;
+       b = LTC_MILLER_RABIN_REPS;
    } /* if */
    *c = mpz_probab_prime_p(a, b) > 0 ? LTC_MP_YES : LTC_MP_NO;
    return CRYPT_OK;

--- a/src/math/ltm_desc.c
+++ b/src/math/ltm_desc.c
@@ -404,7 +404,7 @@ static int isprime(void *a, int b, int *c)
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(c != NULL);
    if (b == 0) {
-       b = 8;
+       b = LTC_MILLER_RABIN_REPS;
    } /* if */
    err = mpi_to_ltc_error(mp_prime_is_prime(a, b, c));
    *c = (*c == MP_YES) ? LTC_MP_YES : LTC_MP_NO;

--- a/src/math/rand_prime.c
+++ b/src/math/rand_prime.c
@@ -66,7 +66,7 @@ int rand_prime(void *N, long len, prng_state *prng, int wprng)
       }
 
       /* test */
-      if ((err = mp_prime_is_prime(N, 8, &res)) != CRYPT_OK) {
+      if ((err = mp_prime_is_prime(N, LTC_MILLER_RABIN_REPS, &res)) != CRYPT_OK) {
          XFREE(buf);
          return err;
       }

--- a/src/math/tfm_desc.c
+++ b/src/math/tfm_desc.c
@@ -415,8 +415,10 @@ static int isprime(void *a, int b, int *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(c != NULL);
-   (void)b;
-   *c = (fp_isprime(a) == FP_YES) ? LTC_MP_YES : LTC_MP_NO;
+   if (b == 0) {
+       b = LTC_MILLER_RABIN_REPS;
+   } /* if */
+   *c = (fp_isprime_ex(a, b) == FP_YES) ? LTC_MP_YES : LTC_MP_NO;
    return CRYPT_OK;
 }
 


### PR DESCRIPTION
FIPS 180-4 defines a specific number of rounds of MR for DSA primes, c.f. FIPS-186-4 - Appendix C.3 - table C.1.

gmp also has an estimation which number is appropriate, c.f. doc of `mpz_probab_prime_p()` [here](https://gmplib.org/manual/Number-Theoretic-Functions.html)

This PR implements these recommendations.