### PR TITLE
Third general clean-up

### DIFF
--- a/doc/crypt.tex
+++ b/doc/crypt.tex
@@ -83,7 +83,6 @@
 
 
 \begin{tabular}{c}
-Tom St Denis \\
 LibTom Projects
 \end{tabular}
 \end{center}
@@ -98,6 +97,12 @@ Open Source.  Open Academia.  Open Minds.
 ~
 
 \begin{flushright}
+LibTom Projects
+~
+
+\& originally
+~
+
 Tom St Denis
 ~
 

--- a/helper.pl
+++ b/helper.pl
@@ -50,6 +50,7 @@ sub check_source {
       push @{$troubles->{unwanted_free}},    $lineno if $file =~ /^src\/.*\.c$/ && $l =~ /\bfree\s*\(/;
       push @{$troubles->{unwanted_memset}},  $lineno if $file =~ /^src\/.*\.c$/ && $l =~ /\bmemset\s*\(/;
       push @{$troubles->{unwanted_memcpy}},  $lineno if $file =~ /^src\/.*\.c$/ && $l =~ /\bmemcpy\s*\(/;
+      push @{$troubles->{unwanted_memmove}}, $lineno if $file =~ /^src\/.*\.c$/ && $l =~ /\bmemmove\s*\(/;
       push @{$troubles->{unwanted_memcmp}},  $lineno if $file =~ /^src\/.*\.c$/ && $l =~ /\bmemcmp\s*\(/;
       push @{$troubles->{unwanted_strcmp}},  $lineno if $file =~ /^src\/.*\.c$/ && $l =~ /\bstrcmp\s*\(/;
       push @{$troubles->{unwanted_clock}},   $lineno if $file =~ /^src\/.*\.c$/ && $l =~ /\bclock\s*\(/;

--- a/helper.pl
+++ b/helper.pl
@@ -54,6 +54,11 @@ sub check_source {
       push @{$troubles->{unwanted_strcmp}},  $lineno if $file =~ /^src\/.*\.c$/ && $l =~ /\bstrcmp\s*\(/;
       push @{$troubles->{unwanted_clock}},   $lineno if $file =~ /^src\/.*\.c$/ && $l =~ /\bclock\s*\(/;
       push @{$troubles->{unwanted_qsort}},   $lineno if $file =~ /^src\/.*\.c$/ && $l =~ /\bqsort\s*\(/;
+      if ($file =~ m|src/.*\.c$| &&
+          $file !~ m|src/math/.+_desc.c$| &&
+          $l =~ /^static\s+\S+\s+([^_][a-zA-Z0-9_]+)\s*\(/) {
+        push @{$troubles->{staticfunc_name}}, "$lineno($1)";
+      }
       $lineno++;
     }
     for my $k (sort keys %$troubles) {

--- a/helper.pl
+++ b/helper.pl
@@ -55,7 +55,10 @@ sub check_source {
       push @{$troubles->{unwanted_clock}},   $lineno if $file =~ /^src\/.*\.c$/ && $l =~ /\bclock\s*\(/;
       push @{$troubles->{unwanted_qsort}},   $lineno if $file =~ /^src\/.*\.c$/ && $l =~ /\bqsort\s*\(/;
       if ($file =~ m|src/.*\.c$| &&
+          $file !~ m|src/ciphers/.*\.c$| &&
+          $file !~ m|src/hashes/.*\.c$| &&
           $file !~ m|src/math/.+_desc.c$| &&
+          $file !~ m|src/stream/sober128/sober128.c$| &&
           $l =~ /^static\s+\S+\s+([^_][a-zA-Z0-9_]+)\s*\(/) {
         push @{$troubles->{staticfunc_name}}, "$lineno($1)";
       }

--- a/makefile.mingw
+++ b/makefile.mingw
@@ -15,7 +15,6 @@
 #
 
 #The following can be overridden from command line e.g. make -f makefile.mingw CC=gcc ARFLAGS=rcs
-DESTDIR   =
 PREFIX    = c:\mingw
 CC        = gcc
 AR        = ar
@@ -264,20 +263,20 @@ clean:
 
 #Install the library + headers
 install: $(LIBMAIN_S) $(LIBMAIN_I) $(LIBMAIN_D)
-	cmd /c if not exist "$(DESTDIR)$(PREFIX)\bin" mkdir "$(DESTDIR)$(PREFIX)\bin"
-	cmd /c if not exist "$(DESTDIR)$(PREFIX)\lib" mkdir "$(DESTDIR)$(PREFIX)\lib"
-	cmd /c if not exist "$(DESTDIR)$(PREFIX)\include" mkdir "$(DESTDIR)$(PREFIX)\include"
-	copy /Y $(LIBMAIN_S) "$(DESTDIR)$(PREFIX)\lib"
-	copy /Y $(LIBMAIN_I) "$(DESTDIR)$(PREFIX)\lib"
-	copy /Y $(LIBMAIN_D) "$(DESTDIR)$(PREFIX)\bin"
-	copy /Y src\headers\tomcrypt*.h "$(DESTDIR)$(PREFIX)\include"
+	cmd /c if not exist "$(PREFIX)\bin" mkdir "$(PREFIX)\bin"
+	cmd /c if not exist "$(PREFIX)\lib" mkdir "$(PREFIX)\lib"
+	cmd /c if not exist "$(PREFIX)\include" mkdir "$(PREFIX)\include"
+	copy /Y $(LIBMAIN_S) "$(PREFIX)\lib"
+	copy /Y $(LIBMAIN_I) "$(PREFIX)\lib"
+	copy /Y $(LIBMAIN_D) "$(PREFIX)\bin"
+	copy /Y src\headers\tomcrypt*.h "$(PREFIX)\include"
 
 #Install useful tools
 install_bins: hashsum
-	cmd /c if not exist "$(DESTDIR)$(PREFIX)\bin" mkdir "$(DESTDIR)$(PREFIX)\bin"
-	copy /Y hashsum.exe "$(DESTDIR)$(PREFIX)\bin"
+	cmd /c if not exist "$(PREFIX)\bin" mkdir "$(PREFIX)\bin"
+	copy /Y hashsum.exe "$(PREFIX)\bin"
 
 #Install documentation
 install_docs: doc/crypt.pdf
-	cmd /c if not exist "$(DESTDIR)$(PREFIX)\doc" mkdir "$(DESTDIR)$(PREFIX)\doc"
-	copy /Y doc\crypt.pdf "$(DESTDIR)$(PREFIX)\doc"
+	cmd /c if not exist "$(PREFIX)\doc" mkdir "$(PREFIX)\doc"
+	copy /Y doc\crypt.pdf "$(PREFIX)\doc"

--- a/makefile.mingw
+++ b/makefile.mingw
@@ -15,6 +15,7 @@
 #
 
 #The following can be overridden from command line e.g. make -f makefile.mingw CC=gcc ARFLAGS=rcs
+DESTDIR   =
 PREFIX    = c:\mingw
 CC        = gcc
 AR        = ar
@@ -263,20 +264,20 @@ clean:
 
 #Install the library + headers
 install: $(LIBMAIN_S) $(LIBMAIN_I) $(LIBMAIN_D)
-	cmd /c if not exist "$(PREFIX)\bin" mkdir "$(PREFIX)\bin"
-	cmd /c if not exist "$(PREFIX)\lib" mkdir "$(PREFIX)\lib"
-	cmd /c if not exist "$(PREFIX)\include" mkdir "$(PREFIX)\include"
-	copy /Y $(LIBMAIN_S) "$(PREFIX)\lib"
-	copy /Y $(LIBMAIN_I) "$(PREFIX)\lib"
-	copy /Y $(LIBMAIN_D) "$(PREFIX)\bin"
-	copy /Y src\headers\tomcrypt*.h "$(PREFIX)\include"
+	cmd /c if not exist "$(DESTDIR)$(PREFIX)\bin" mkdir "$(DESTDIR)$(PREFIX)\bin"
+	cmd /c if not exist "$(DESTDIR)$(PREFIX)\lib" mkdir "$(DESTDIR)$(PREFIX)\lib"
+	cmd /c if not exist "$(DESTDIR)$(PREFIX)\include" mkdir "$(DESTDIR)$(PREFIX)\include"
+	copy /Y $(LIBMAIN_S) "$(DESTDIR)$(PREFIX)\lib"
+	copy /Y $(LIBMAIN_I) "$(DESTDIR)$(PREFIX)\lib"
+	copy /Y $(LIBMAIN_D) "$(DESTDIR)$(PREFIX)\bin"
+	copy /Y src\headers\tomcrypt*.h "$(DESTDIR)$(PREFIX)\include"
 
 #Install useful tools
 install_bins: hashsum
-	cmd /c if not exist "$(PREFIX)\bin" mkdir "$(PREFIX)\bin"
-	copy /Y hashsum.exe "$(PREFIX)\bin"
+	cmd /c if not exist "$(DESTDIR)$(PREFIX)\bin" mkdir "$(DESTDIR)$(PREFIX)\bin"
+	copy /Y hashsum.exe "$(DESTDIR)$(PREFIX)\bin"
 
 #Install documentation
 install_docs: doc/crypt.pdf
-	cmd /c if not exist "$(PREFIX)\doc" mkdir "$(PREFIX)\doc"
-	copy /Y doc\crypt.pdf "$(PREFIX)\doc"
+	cmd /c if not exist "$(DESTDIR)$(PREFIX)\doc" mkdir "$(DESTDIR)$(PREFIX)\doc"
+	copy /Y doc\crypt.pdf "$(DESTDIR)$(PREFIX)\doc"

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -15,6 +15,7 @@
 #
 
 #The following can be overridden from command line e.g. make -f makefile.msvc CC=gcc ARFLAGS=rcs
+DESTDIR   =
 PREFIX    = c:\devel
 CFLAGS    = /Ox /DUSE_LTM /DLTM_DESC /I../libtommath
 EXTRALIBS = ../libtommath/tommath.lib
@@ -250,18 +251,18 @@ clean:
 
 #Install the library + headers
 install: $(LIBMAIN_S)
-	cmd /c if not exist "$(PREFIX)\bin" mkdir "$(PREFIX)\bin"
-	cmd /c if not exist "$(PREFIX)\lib" mkdir "$(PREFIX)\lib"
-	cmd /c if not exist "$(PREFIX)\include" mkdir "$(PREFIX)\include"
-	copy /Y $(LIBMAIN_S) "$(PREFIX)\lib"
-	copy /Y src\headers\tomcrypt*.h "$(PREFIX)\include"
+	cmd /c if not exist "$(DESTDIR)$(PREFIX)\bin" mkdir "$(DESTDIR)$(PREFIX)\bin"
+	cmd /c if not exist "$(DESTDIR)$(PREFIX)\lib" mkdir "$(DESTDIR)$(PREFIX)\lib"
+	cmd /c if not exist "$(DESTDIR)$(PREFIX)\include" mkdir "$(DESTDIR)$(PREFIX)\include"
+	copy /Y $(LIBMAIN_S) "$(DESTDIR)$(PREFIX)\lib"
+	copy /Y src\headers\tomcrypt*.h "$(DESTDIR)$(PREFIX)\include"
 
 #Install useful tools
 install_bins: hashsum
-	cmd /c if not exist "$(PREFIX)\bin" mkdir "$(PREFIX)\bin"
-	copy /Y hashsum.exe "$(PREFIX)\bin"
+	cmd /c if not exist "$(DESTDIR)$(PREFIX)\bin" mkdir "$(DESTDIR)$(PREFIX)\bin"
+	copy /Y hashsum.exe "$(DESTDIR)$(PREFIX)\bin"
 
 #Install documentation
 install_docs: doc/crypt.pdf
-	cmd /c if not exist "$(PREFIX)\doc" mkdir "$(PREFIX)\doc"
-	copy /Y doc\crypt.pdf "$(PREFIX)\doc"
+	cmd /c if not exist "$(DESTDIR)$(PREFIX)\doc" mkdir "$(DESTDIR)$(PREFIX)\doc"
+	copy /Y doc\crypt.pdf "$(DESTDIR)$(PREFIX)\doc"

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -15,7 +15,6 @@
 #
 
 #The following can be overridden from command line e.g. make -f makefile.msvc CC=gcc ARFLAGS=rcs
-DESTDIR   =
 PREFIX    = c:\devel
 CFLAGS    = /Ox /DUSE_LTM /DLTM_DESC /I../libtommath
 EXTRALIBS = ../libtommath/tommath.lib
@@ -251,18 +250,18 @@ clean:
 
 #Install the library + headers
 install: $(LIBMAIN_S)
-	cmd /c if not exist "$(DESTDIR)$(PREFIX)\bin" mkdir "$(DESTDIR)$(PREFIX)\bin"
-	cmd /c if not exist "$(DESTDIR)$(PREFIX)\lib" mkdir "$(DESTDIR)$(PREFIX)\lib"
-	cmd /c if not exist "$(DESTDIR)$(PREFIX)\include" mkdir "$(DESTDIR)$(PREFIX)\include"
-	copy /Y $(LIBMAIN_S) "$(DESTDIR)$(PREFIX)\lib"
-	copy /Y src\headers\tomcrypt*.h "$(DESTDIR)$(PREFIX)\include"
+	cmd /c if not exist "$(PREFIX)\bin" mkdir "$(PREFIX)\bin"
+	cmd /c if not exist "$(PREFIX)\lib" mkdir "$(PREFIX)\lib"
+	cmd /c if not exist "$(PREFIX)\include" mkdir "$(PREFIX)\include"
+	copy /Y $(LIBMAIN_S) "$(PREFIX)\lib"
+	copy /Y src\headers\tomcrypt*.h "$(PREFIX)\include"
 
 #Install useful tools
 install_bins: hashsum
-	cmd /c if not exist "$(DESTDIR)$(PREFIX)\bin" mkdir "$(DESTDIR)$(PREFIX)\bin"
-	copy /Y hashsum.exe "$(DESTDIR)$(PREFIX)\bin"
+	cmd /c if not exist "$(PREFIX)\bin" mkdir "$(PREFIX)\bin"
+	copy /Y hashsum.exe "$(PREFIX)\bin"
 
 #Install documentation
 install_docs: doc/crypt.pdf
-	cmd /c if not exist "$(DESTDIR)$(PREFIX)\doc" mkdir "$(DESTDIR)$(PREFIX)\doc"
-	copy /Y doc\crypt.pdf "$(DESTDIR)$(PREFIX)\doc"
+	cmd /c if not exist "$(PREFIX)\doc" mkdir "$(PREFIX)\doc"
+	copy /Y doc\crypt.pdf "$(PREFIX)\doc"

--- a/makefile.shared
+++ b/makefile.shared
@@ -47,8 +47,8 @@ $(LIBNAME): $(OBJECTS)
 
 install: .common_install
 	sed -e 's,^prefix=.*,prefix=$(PREFIX),' -e 's,^Version:.*,Version: $(VERSION),' libtomcrypt.pc.in > libtomcrypt.pc
-	install -d $(LIBPATH)/pkgconfig
-	install -m 644 libtomcrypt.pc $(LIBPATH)/pkgconfig/
+	install -d $(DESTDIR)/$(LIBPATH)/pkgconfig
+	install -m 644 libtomcrypt.pc $(DESTDIR)/$(LIBPATH)/pkgconfig/
 
 install_bins: .common_install_bins
 

--- a/makefile.unix
+++ b/makefile.unix
@@ -25,10 +25,10 @@
 #The following can be overridden from command line e.g. "make -f makefile.unix CC=gcc ARFLAGS=rcs"
 DESTDIR   =
 PREFIX    = /usr/local
-LIBPATH   = $(DESTDIR)$(PREFIX)/lib
-INCPATH   = $(DESTDIR)$(PREFIX)/include
-DATAPATH  = $(DESTDIR)$(PREFIX)/share/doc/libtomcrypt/pdf
-BINPATH   = $(DESTDIR)$(PREFIX)/bin
+LIBPATH   = $(PREFIX)/lib
+INCPATH   = $(PREFIX)/include
+DATAPATH  = $(PREFIX)/share/doc/libtomcrypt/pdf
+BINPATH   = $(PREFIX)/bin
 CC        = cc
 AR        = ar
 ARFLAGS   = r
@@ -272,17 +272,17 @@ clean:
 
 #Install the library + headers
 install: $(LIBMAIN_S) $(HEADERS)
-	@mkdir -p $(INCPATH) $(LIBPATH)/pkgconfig
-	@cp $(LIBMAIN_S) $(LIBPATH)/
-	@cp $(HEADERS) $(INCPATH)/
-	@sed -e 's,^prefix=.*,prefix=$(PREFIX),' -e 's,^Version:.*,Version: $(VERSION),' libtomcrypt.pc.in > $(LIBPATH)/pkgconfig/libtomcrypt.pc
+	@mkdir -p $(DESTDIR)/$(INCPATH) $(DESTDIR)/$(LIBPATH)/pkgconfig
+	@cp $(LIBMAIN_S) $(DESTDIR)/$(LIBPATH)/
+	@cp $(HEADERS) $(DESTDIR)/$(INCPATH)/
+	@sed -e 's,^prefix=.*,prefix=$(PREFIX),' -e 's,^Version:.*,Version: $(VERSION),' libtomcrypt.pc.in > $(DESTDIR)/$(LIBPATH)/pkgconfig/libtomcrypt.pc
 
 #Install useful tools
 install_bins: hashsum
-	@mkdir -p $(BINPATH)
-	@cp hashsum $(BINPATH)/
+	@mkdir -p $(DESTDIR)/$(BINPATH)
+	@cp hashsum $(DESTDIR)/$(BINPATH)/
 
 #Install documentation
 install_docs: doc/crypt.pdf
-	@mkdir -p $(DATAPATH)
-	@cp doc/crypt.pdf $(DATAPATH)/
+	@mkdir -p $(DESTDIR)/$(DATAPATH)
+	@cp doc/crypt.pdf $(DESTDIR)/$(DATAPATH)/

--- a/makefile_include.mk
+++ b/makefile_include.mk
@@ -132,10 +132,10 @@ TIMINGS=demos/timing.o
 #BINPATH  The directory to install the binaries provided.
 DESTDIR  ?=
 PREFIX   ?= /usr/local
-LIBPATH  ?= $(DESTDIR)$(PREFIX)/lib
-INCPATH  ?= $(DESTDIR)$(PREFIX)/include
-DATAPATH ?= $(DESTDIR)$(PREFIX)/share/doc/libtomcrypt/pdf
-BINPATH  ?= $(DESTDIR)$(PREFIX)/bin
+LIBPATH  ?= $(PREFIX)/lib
+INCPATH  ?= $(PREFIX)/include
+DATAPATH ?= $(PREFIX)/share/doc/libtomcrypt/pdf
+BINPATH  ?= $(PREFIX)/bin
 
 #Who do we install as?
 ifdef INSTALL_USER
@@ -362,18 +362,18 @@ install_all: install install_bins install_docs install_test
 INSTALL_OPTS ?= -m 644
 
 .common_install: $(LIBNAME)
-	install -d $(INCPATH)
-	install -d $(LIBPATH)
-	$(INSTALL_CMD) $(INSTALL_OPTS) $(LIBNAME) $(LIBPATH)/$(LIBNAME)
-	install -m 644 $(HEADERS) $(INCPATH)
+	install -d $(DESTDIR)/$(INCPATH)
+	install -d $(DESTDIR)/$(LIBPATH)
+	$(INSTALL_CMD) $(INSTALL_OPTS) $(LIBNAME) $(DESTDIR)/$(LIBPATH)/$(LIBNAME)
+	install -m 644 $(HEADERS) $(DESTDIR)/$(INCPATH)
 
 .common_install_bins: $(USEFUL_DEMOS)
 	install -d $(BINPATH)
-	$(INSTALL_CMD) -m 775 $(USEFUL_DEMOS) $(BINPATH)
+	$(INSTALL_CMD) -m 775 $(USEFUL_DEMOS) $(DESTDIR)/$(BINPATH)
 
 install_docs: doc/crypt.pdf
 	install -d $(DATAPATH)
-	install -m 644 doc/crypt.pdf $(DATAPATH)
+	install -m 644 doc/crypt.pdf $(DESTDIR)/$(DATAPATH)
 
 install_hooks:
 	for s in `ls hooks/`; do ln -s ../../hooks/$$s .git/hooks/$$s; done

--- a/src/ciphers/aes/aes.c
+++ b/src/ciphers/aes/aes.c
@@ -685,23 +685,8 @@ int ECB_TEST(void)
 
     rijndael_ecb_encrypt(tests[i].pt, tmp[0], &key);
     rijndael_ecb_decrypt(tmp[0], tmp[1], &key);
-    if (XMEMCMP(tmp[0], tests[i].ct, 16) || XMEMCMP(tmp[1], tests[i].pt, 16)) {
-#if 0
-       printf("\n\nTest %d failed\n", i);
-       if (XMEMCMP(tmp[0], tests[i].ct, 16)) {
-          printf("CT: ");
-          for (i = 0; i < 16; i++) {
-             printf("%02x ", tmp[0][i]);
-          }
-          printf("\n");
-       } else {
-          printf("PT: ");
-          for (i = 0; i < 16; i++) {
-             printf("%02x ", tmp[1][i]);
-          }
-          printf("\n");
-       }
-#endif
+    if (compare_testvector(tmp[0], 16, tests[i].ct, 16, "AES Encrypt", i) ||
+          compare_testvector(tmp[1], 16, tests[i].pt, 16, "AES Decrypt", i)) {
         return CRYPT_FAIL_TESTVECTOR;
     }
 

--- a/src/ciphers/anubis.c
+++ b/src/ciphers/anubis.c
@@ -1498,13 +1498,14 @@ int anubis_test(void)
        anubis_setup(tests[x].key, tests[x].keylen, 0, &skey);
        anubis_ecb_encrypt(tests[x].pt, buf[0], &skey);
        anubis_ecb_decrypt(buf[0], buf[1], &skey);
-       if (XMEMCMP(buf[0], tests[x].ct, 16) || XMEMCMP(buf[1], tests[x].pt, 16)) {
+       if (compare_testvector(buf[0], 16, tests[x].ct, 16, "Anubis Encrypt", x) ||
+             compare_testvector(buf[1], 16, tests[x].pt, 16, "Anubis Decrypt", x)) {
           return CRYPT_FAIL_TESTVECTOR;
        }
 
        for (y = 0; y < 1000; y++) anubis_ecb_encrypt(buf[0], buf[0], &skey);
        for (y = 0; y < 1000; y++) anubis_ecb_decrypt(buf[0], buf[0], &skey);
-       if (XMEMCMP(buf[0], tests[x].ct, 16)) {
+       if (compare_testvector(buf[0], 16, tests[x].ct, 16, "Anubis 1000", 1000)) {
           return CRYPT_FAIL_TESTVECTOR;
        }
 

--- a/src/ciphers/blowfish.c
+++ b/src/ciphers/blowfish.c
@@ -546,7 +546,8 @@ int blowfish_test(void)
       blowfish_ecb_decrypt(tmp[0], tmp[1], &key);
 
       /* compare */
-      if ((XMEMCMP(tmp[0], tests[x].ct, 8) != 0) || (XMEMCMP(tmp[1], tests[x].pt, 8) != 0)) {
+      if ((compare_testvector(tmp[0], 8, tests[x].ct, 8, "Blowfish Encrypt", x) != 0) ||
+            (compare_testvector(tmp[1], 8, tests[x].pt, 8, "Blowfish Decrypt", x) != 0)) {
          return CRYPT_FAIL_TESTVECTOR;
       }
 

--- a/src/ciphers/camellia.c
+++ b/src/ciphers/camellia.c
@@ -697,22 +697,8 @@ int camellia_test(void)
          return err;
       }
       camellia_done(&skey);
-      if (XMEMCMP(tests[x].ct, buf[0], 16) || XMEMCMP(tests[x].pt, buf[1], 16)) {
-#if 0
-         int i, j;
-         printf ("\n\nLTC_CAMELLIA failed for x=%d, I got:\n", x);
-         for (i = 0; i < 2; i++) {
-            const unsigned char *expected, *actual;
-            expected = (i ? tests[x].pt : tests[x].ct);
-            actual = buf[i];
-            printf ("expected    actual   (%s)\n", (i ? "plaintext" : "ciphertext"));
-            for (j = 0; j < 16; j++) {
-               const char *eq = (expected[j] == actual[j] ? "==" : "!=");
-               printf ("     %02x  %s  %02x\n", expected[j], eq, actual[j]);
-            }
-            printf ("\n");
-         }
-#endif
+      if (compare_testvector(tests[x].ct, 16, buf[0], 16, "Camellia Encrypt", x) ||
+            compare_testvector(tests[x].pt, 16, buf[1], 16, "Camellia Decrypt", x)) {
          return CRYPT_FAIL_TESTVECTOR;
       }
    }

--- a/src/ciphers/cast5.c
+++ b/src/ciphers/cast5.c
@@ -674,7 +674,8 @@ int cast5_test(void)
        }
        cast5_ecb_encrypt(tests[i].pt, tmp[0], &key);
        cast5_ecb_decrypt(tmp[0], tmp[1], &key);
-       if ((XMEMCMP(tmp[0], tests[i].ct, 8) != 0) || (XMEMCMP(tmp[1], tests[i].pt, 8) != 0)) {
+       if ((compare_testvector(tmp[0], 8, tests[i].ct, 8, "CAST5 Encrypt", i) != 0) ||
+             (compare_testvector(tmp[1], 8, tests[i].pt, 8, "CAST5 Decrypt", i) != 0)) {
           return CRYPT_FAIL_TESTVECTOR;
        }
       /* now see if we can encrypt all zero bytes 1000 times, decrypt and come back where we started */

--- a/src/ciphers/des.c
+++ b/src/ciphers/des.c
@@ -1977,7 +1977,7 @@ int des_test(void)
            des_ecb_decrypt(cases[i].txt, tmp, &des);
         }
 
-        if (XMEMCMP(cases[i].out, tmp, sizeof(tmp)) != 0) {
+        if (compare_testvector(cases[i].out, sizeof(tmp), tmp, sizeof(tmp), "DES", i) != 0) {
            return CRYPT_FAIL_TESTVECTOR;
         }
 
@@ -2020,7 +2020,7 @@ int des3_test(void)
    des3_ecb_encrypt(pt, ct, &skey);
    des3_ecb_decrypt(ct, tmp, &skey);
 
-   if (XMEMCMP(pt, tmp, 8) != 0) {
+   if (compare_testvector(pt, 8, tmp, 8, "3DES", 0) != 0) {
       return CRYPT_FAIL_TESTVECTOR;
    }
 

--- a/src/ciphers/kasumi.c
+++ b/src/ciphers/kasumi.c
@@ -302,7 +302,8 @@ int kasumi_test(void)
        if ((err = kasumi_ecb_decrypt(tests[x].ct, buf[1], &key)) != CRYPT_OK) {
           return err;
        }
-       if (XMEMCMP(tests[x].pt, buf[1], 8) || XMEMCMP(tests[x].ct, buf[0], 8)) {
+       if (compare_testvector(buf[1], 8, tests[x].pt, 8, "Kasumi Decrypt", x) ||
+             compare_testvector(buf[0], 8, tests[x].ct, 8, "Kasumi Encrypt", x)) {
           return CRYPT_FAIL_TESTVECTOR;
        }
    }

--- a/src/ciphers/khazad.c
+++ b/src/ciphers/khazad.c
@@ -808,13 +808,14 @@ int khazad_test(void)
        khazad_setup(tests[x].key, 16, 0, &skey);
        khazad_ecb_encrypt(tests[x].pt, buf[0], &skey);
        khazad_ecb_decrypt(buf[0], buf[1], &skey);
-       if (XMEMCMP(buf[0], tests[x].ct, 8) || XMEMCMP(buf[1], tests[x].pt, 8)) {
+       if (compare_testvector(buf[0], 8, tests[x].ct, 8, "Khazad Encrypt", x) ||
+             compare_testvector(buf[1], 8, tests[x].pt, 8, "Khazad Decrypt", x)) {
           return CRYPT_FAIL_TESTVECTOR;
        }
 
        for (y = 0; y < 1000; y++) khazad_ecb_encrypt(buf[0], buf[0], &skey);
        for (y = 0; y < 1000; y++) khazad_ecb_decrypt(buf[0], buf[0], &skey);
-       if (XMEMCMP(buf[0], tests[x].ct, 8)) {
+       if (compare_testvector(buf[0], 8, tests[x].ct, 8, "Khazad 1000", 1000)) {
           return CRYPT_FAIL_TESTVECTOR;
        }
 

--- a/src/ciphers/kseed.c
+++ b/src/ciphers/kseed.c
@@ -344,22 +344,8 @@ int kseed_test(void)
        kseed_setup(tests[x].key, 16, 0, &skey);
        kseed_ecb_encrypt(tests[x].pt, buf[0], &skey);
        kseed_ecb_decrypt(buf[0], buf[1], &skey);
-       if (XMEMCMP(buf[0], tests[x].ct, 16) || XMEMCMP(buf[1], tests[x].pt, 16)) {
-#if 0
-          int i, j;
-          printf ("\n\nLTC_KSEED failed for x=%d, I got:\n", x);
-          for (i = 0; i < 2; i++) {
-             const unsigned char *expected, *actual;
-             expected = (i ? tests[x].pt : tests[x].ct);
-             actual = buf[i];
-             printf ("expected    actual   (%s)\n", (i ? "plaintext" : "ciphertext"));
-             for (j = 0; j < 16; j++) {
-                const char *eq = (expected[j] == actual[j] ? "==" : "!=");
-                printf ("     %02x  %s  %02x\n", expected[j], eq, actual[j]);
-             }
-             printf ("\n");
-          }
-#endif
+       if (compare_testvector(buf[0], 16, tests[x].ct, 16, "KSEED Encrypt", x) ||
+             compare_testvector(buf[1], 16, tests[x].pt, 16, "KSEED Decrypt", x)) {
           return CRYPT_FAIL_TESTVECTOR;
        }
    }

--- a/src/ciphers/multi2.c
+++ b/src/ciphers/multi2.c
@@ -256,14 +256,14 @@ int multi2_test(void)
          return err;
       }
 
-      if (XMEMCMP(buf, tests[x].ct, 8)) {
+      if (compare_testvector(buf, 8, tests[x].ct, 8, "Multi2 Encrypt", x)) {
          return CRYPT_FAIL_TESTVECTOR;
       }
 
       if ((err = multi2_ecb_decrypt(buf, buf, &skey)) != CRYPT_OK) {
          return err;
       }
-      if (XMEMCMP(buf, tests[x].pt, 8)) {
+      if (compare_testvector(buf, 8, tests[x].pt, 8, "Multi2 Decrypt", x)) {
          return CRYPT_FAIL_TESTVECTOR;
       }
    }
@@ -280,7 +280,7 @@ int multi2_test(void)
         if ((err = multi2_ecb_decrypt(ct, buf, &skey)) != CRYPT_OK) {
                 return err;
         }
-        if (XMEMCMP(buf, tests[0].pt, 8)) {
+        if (compare_testvector(buf, 8, tests[0].pt, 8, "Multi2 Rounds", x)) {
                 return CRYPT_FAIL_TESTVECTOR;
         }
    }

--- a/src/ciphers/noekeon.c
+++ b/src/ciphers/noekeon.c
@@ -281,23 +281,8 @@ int noekeon_test(void)
 
     noekeon_ecb_encrypt(tests[i].pt, tmp[0], &key);
     noekeon_ecb_decrypt(tmp[0], tmp[1], &key);
-    if (XMEMCMP(tmp[0], tests[i].ct, 16) || XMEMCMP(tmp[1], tests[i].pt, 16)) {
-#if 0
-       printf("\n\nTest %d failed\n", i);
-       if (XMEMCMP(tmp[0], tests[i].ct, 16)) {
-          printf("CT: ");
-          for (i = 0; i < 16; i++) {
-             printf("%02x ", tmp[0][i]);
-          }
-          printf("\n");
-       } else {
-          printf("PT: ");
-          for (i = 0; i < 16; i++) {
-             printf("%02x ", tmp[1][i]);
-          }
-          printf("\n");
-       }
-#endif
+    if (compare_testvector(tmp[0], 16, tests[i].ct, 16, "Noekeon Encrypt", i) ||
+          compare_testvector(tmp[1], 16, tests[i].pt, 16, "Noekeon Decrypt", i)) {
         return CRYPT_FAIL_TESTVECTOR;
     }
 

--- a/src/ciphers/rc5.c
+++ b/src/ciphers/rc5.c
@@ -273,7 +273,8 @@ int rc5_test(void)
       rc5_ecb_decrypt(tmp[0], tmp[1], &key);
 
       /* compare */
-      if (XMEMCMP(tmp[0], tests[x].ct, 8) != 0 || XMEMCMP(tmp[1], tests[x].pt, 8) != 0) {
+      if (compare_testvector(tmp[0], 8, tests[x].ct, 8, "RC5 Encrypt", x) != 0 ||
+            compare_testvector(tmp[1], 8, tests[x].pt, 8, "RC5 Decrypt", x) != 0) {
          return CRYPT_FAIL_TESTVECTOR;
       }
 

--- a/src/ciphers/rc6.c
+++ b/src/ciphers/rc6.c
@@ -283,24 +283,8 @@ int rc6_test(void)
       rc6_ecb_decrypt(tmp[0], tmp[1], &key);
 
       /* compare */
-      if (XMEMCMP(tmp[0], tests[x].ct, 16) || XMEMCMP(tmp[1], tests[x].pt, 16)) {
-#if 0
-         printf("\n\nFailed test %d\n", x);
-         if (XMEMCMP(tmp[0], tests[x].ct, 16)) {
-            printf("Ciphertext:  ");
-            for (y = 0; y < 16; y++) printf("%02x ", tmp[0][y]);
-            printf("\nExpected  :  ");
-            for (y = 0; y < 16; y++) printf("%02x ", tests[x].ct[y]);
-            printf("\n");
-         }
-         if (XMEMCMP(tmp[1], tests[x].pt, 16)) {
-            printf("Plaintext:  ");
-            for (y = 0; y < 16; y++) printf("%02x ", tmp[0][y]);
-            printf("\nExpected :  ");
-            for (y = 0; y < 16; y++) printf("%02x ", tests[x].pt[y]);
-            printf("\n");
-         }
-#endif
+      if (compare_testvector(tmp[0], 16, tests[x].ct, 16, "RC6 Encrypt", x) ||
+            compare_testvector(tmp[1], 16, tests[x].pt, 16, "RC6 Decrypt", x)) {
          return CRYPT_FAIL_TESTVECTOR;
       }
 

--- a/src/ciphers/safer/safer.c
+++ b/src/ciphers/safer/safer.c
@@ -395,7 +395,8 @@ int safer_k64_test(void)
    safer_ecb_encrypt(k64_pt, buf[0], &skey);
    safer_ecb_decrypt(buf[0], buf[1], &skey);
 
-   if (XMEMCMP(buf[0], k64_ct, 8) != 0 || XMEMCMP(buf[1], k64_pt, 8) != 0) {
+   if (compare_testvector(buf[0], 8, k64_ct, 8, "Safer K64 Encrypt", 0) != 0 ||
+         compare_testvector(buf[1], 8, k64_pt, 8, "Safer K64 Decrypt", 0) != 0) {
       return CRYPT_FAIL_TESTVECTOR;
    }
 
@@ -425,7 +426,8 @@ int safer_sk64_test(void)
    safer_ecb_encrypt(sk64_pt, buf[0], &skey);
    safer_ecb_decrypt(buf[0], buf[1], &skey);
 
-   if (XMEMCMP(buf[0], sk64_ct, 8) != 0 || XMEMCMP(buf[1], sk64_pt, 8) != 0) {
+   if (compare_testvector(buf[0], 8, sk64_ct, 8, "Safer SK64 Encrypt", 0) != 0 ||
+         compare_testvector(buf[1], 8, sk64_pt, 8, "Safer SK64 Decrypt", 0) != 0) {
       return CRYPT_FAIL_TESTVECTOR;
    }
 
@@ -468,7 +470,8 @@ int safer_sk128_test(void)
    safer_ecb_encrypt(sk128_pt, buf[0], &skey);
    safer_ecb_decrypt(buf[0], buf[1], &skey);
 
-   if (XMEMCMP(buf[0], sk128_ct, 8) != 0 || XMEMCMP(buf[1], sk128_pt, 8) != 0) {
+   if (compare_testvector(buf[0], 8, sk128_ct, 8, "Safer SK128 Encrypt", 0) != 0 ||
+         compare_testvector(buf[1], 8, sk128_pt, 8, "Safer SK128 Decrypt", 0) != 0) {
       return CRYPT_FAIL_TESTVECTOR;
    }
 

--- a/src/ciphers/safer/saferp.c
+++ b/src/ciphers/safer/saferp.c
@@ -514,7 +514,8 @@ int saferp_test(void)
       saferp_ecb_decrypt(tmp[0], tmp[1], &skey);
 
       /* compare */
-      if (XMEMCMP(tmp[0], tests[i].ct, 16) || XMEMCMP(tmp[1], tests[i].pt, 16)) {
+      if (compare_testvector(tmp[0], 16, tests[i].ct, 16, "Safer+ Encrypt", i) ||
+            compare_testvector(tmp[1], 16, tests[i].pt, 16, "Safer+ Decrypt", i)) {
          return CRYPT_FAIL_TESTVECTOR;
       }
 

--- a/src/ciphers/skipjack.c
+++ b/src/ciphers/skipjack.c
@@ -296,7 +296,8 @@ int skipjack_test(void)
       skipjack_ecb_decrypt(buf[0], buf[1], &key);
 
       /* compare */
-      if (XMEMCMP(buf[0], tests[x].ct, 8) != 0 || XMEMCMP(buf[1], tests[x].pt, 8) != 0) {
+      if (compare_testvector(buf[0], 8, tests[x].ct, 8, "Skipjack Encrypt", x) != 0 ||
+            compare_testvector(buf[1], 8, tests[x].pt, 8, "Skipjack Decrypt", x) != 0) {
          return CRYPT_FAIL_TESTVECTOR;
       }
 

--- a/src/ciphers/twofish/twofish.c
+++ b/src/ciphers/twofish/twofish.c
@@ -657,10 +657,8 @@ int twofish_test(void)
     }
     twofish_ecb_encrypt(tests[i].pt, tmp[0], &key);
     twofish_ecb_decrypt(tmp[0], tmp[1], &key);
-    if (XMEMCMP(tmp[0], tests[i].ct, 16) != 0 || XMEMCMP(tmp[1], tests[i].pt, 16) != 0) {
-#if 0
-       printf("Twofish failed test %d, %d, %d\n", i, XMEMCMP(tmp[0], tests[i].ct, 16), XMEMCMP(tmp[1], tests[i].pt, 16));
-#endif
+    if (compare_testvector(tmp[0], 16, tests[i].ct, 16, "Twofish Encrypt", i) != 0 ||
+          compare_testvector(tmp[1], 16, tests[i].pt, 16, "Twofish Decrypt", i) != 0) {
        return CRYPT_FAIL_TESTVECTOR;
     }
     /* now see if we can encrypt all zero bytes 1000 times, decrypt and come back where we started */

--- a/src/ciphers/xtea.c
+++ b/src/ciphers/xtea.c
@@ -211,23 +211,8 @@ int xtea_test(void)
        xtea_ecb_encrypt(tests[i].pt, tmp[0], &skey);
        xtea_ecb_decrypt(tmp[0], tmp[1], &skey);
 
-       if (XMEMCMP(tmp[0], tests[i].ct, 8) != 0 || XMEMCMP(tmp[1], tests[i].pt, 8) != 0) {
-#if 0
-          printf("\n\nTest %d failed\n", i);
-          if (XMEMCMP(tmp[0], tests[i].ct, 8)) {
-            printf("CT: ");
-            for (i = 0; i < 8; i++) {
-              printf("%02x ", tmp[0][i]);
-            }
-            printf("\n");
-          } else {
-            printf("PT: ");
-            for (i = 0; i < 8; i++) {
-              printf("%02x ", tmp[1][i]);
-            }
-            printf("\n");
-          }
-#endif
+       if (compare_testvector(tmp[0], 8, tests[i].ct, 8, "XTEA Encrypt", i) != 0 ||
+             compare_testvector(tmp[1], 8, tests[i].pt, 8, "XTEA Decrypt", i) != 0) {
           return CRYPT_FAIL_TESTVECTOR;
        }
 

--- a/src/encauth/eax/eax_decrypt_verify_memory.c
+++ b/src/encauth/eax/eax_decrypt_verify_memory.c
@@ -82,7 +82,7 @@ int eax_decrypt_verify_memory(int cipher,
    }
 
    /* compare tags */
-   if (buflen >= taglen && XMEMCMP(buf, tag, taglen) == 0) {
+   if (buflen >= taglen && XMEM_NEQ(buf, tag, taglen) == 0) {
       *stat = 1;
    }
 

--- a/src/encauth/eax/eax_test.c
+++ b/src/encauth/eax/eax_test.c
@@ -229,22 +229,8 @@ int eax_test(void)
             tests[x].plaintext, tests[x].msglen, outct, outtag, &len)) != CRYPT_OK) {
            return err;
         }
-        if (XMEMCMP(outct, tests[x].ciphertext, tests[x].msglen) || XMEMCMP(outtag, tests[x].tag, len)) {
-#if 0
-           unsigned long y;
-           printf("\n\nFailure: \nCT:\n");
-           for (y = 0; y < (unsigned long)tests[x].msglen; ) {
-               printf("0x%02x", outct[y]);
-               if (y < (unsigned long)(tests[x].msglen-1)) printf(", ");
-               if (!(++y % 8)) printf("\n");
-           }
-           printf("\nTAG:\n");
-           for (y = 0; y < len; ) {
-               printf("0x%02x", outtag[y]);
-               if (y < len-1) printf(", ");
-               if (!(++y % 8)) printf("\n");
-           }
-#endif
+        if (compare_testvector(outtag, len, tests[x].tag, len, "EAX Tag", x) ||
+              compare_testvector(outct, tests[x].msglen, tests[x].ciphertext, tests[x].msglen, "EAX CT", x)) {
            return CRYPT_FAIL_TESTVECTOR;
         }
 
@@ -254,16 +240,10 @@ int eax_test(void)
              outct, tests[x].msglen, outct, outtag, len, &res)) != CRYPT_OK) {
             return err;
         }
-        if ((res != 1) || XMEMCMP(outct, tests[x].plaintext, tests[x].msglen)) {
-#if 0
-           unsigned long y;
-           printf("\n\nFailure (res == %d): \nPT:\n", res);
-           for (y = 0; y < (unsigned long)tests[x].msglen; ) {
-               printf("0x%02x", outct[y]);
-               if (y < (unsigned long)(tests[x].msglen-1)) printf(", ");
-               if (!(++y % 8)) printf("\n");
-           }
-           printf("\n\n");
+        if ((res != 1) || compare_testvector(outct, tests[x].msglen, tests[x].plaintext, tests[x].msglen, "EAX", x)) {
+#ifdef LTC_TEST_DBG
+           printf("\n\nEAX: Failure-decrypt\n");
+           printf("\nres = %d\n\n", res);
 #endif
            return CRYPT_FAIL_TESTVECTOR;
         }

--- a/src/encauth/gcm/gcm_gf_mult.c
+++ b/src/encauth/gcm/gcm_gf_mult.c
@@ -58,7 +58,7 @@ const unsigned char gcm_shift_table[256*2] = {
 
 #ifndef LTC_FAST
 /* right shift */
-static void gcm_rightshift(unsigned char *a)
+static void _gcm_rightshift(unsigned char *a)
 {
    int x;
    for (x = 15; x > 0; x--) {
@@ -92,7 +92,7 @@ void gcm_gf_mult(const unsigned char *a, const unsigned char *b, unsigned char *
           }
        }
        z     = V[15] & 0x01;
-       gcm_rightshift(V);
+       _gcm_rightshift(V);
        V[0] ^= poly[z];
    }
    XMEMCPY(c, Z, 16);

--- a/src/encauth/gcm/gcm_test.c
+++ b/src/encauth/gcm/gcm_test.c
@@ -345,25 +345,11 @@ int gcm_test(void)
           return err;
        }
 
-       if (XMEMCMP(out[0], tests[x].C, tests[x].ptlen)) {
-#if 0
-          printf("\nCiphertext wrong %lu\n", x);
-          for (y = 0; y < tests[x].ptlen; y++) {
-              printf("%02x", out[0][y] & 255);
-          }
-          printf("\n");
-#endif
+       if (compare_testvector(out[0], tests[x].ptlen, tests[x].C, tests[x].ptlen, "GCM CT", x)) {
           return CRYPT_FAIL_TESTVECTOR;
        }
 
-       if (XMEMCMP(T[0], tests[x].T, 16)) {
-#if 0
-          printf("\nTag on plaintext wrong %lu\n", x);
-          for (y = 0; y < 16; y++) {
-              printf("%02x", T[0][y] & 255);
-          }
-          printf("\n");
-#endif
+       if (compare_testvector(T[0], y, tests[x].T, 16, "GCM Encrypt Tag", x)) {
           return CRYPT_FAIL_TESTVECTOR;
        }
 
@@ -376,25 +362,11 @@ int gcm_test(void)
           return err;
        }
 
-       if (XMEMCMP(out[1], tests[x].P, tests[x].ptlen)) {
-#if 0
-          printf("\nplaintext wrong %lu\n", x);
-          for (y = 0; y < tests[x].ptlen; y++) {
-              printf("%02x", out[0][y] & 255);
-          }
-          printf("\n");
-#endif
+       if (compare_testvector(out[1], tests[x].ptlen, tests[x].P, tests[x].ptlen, "GCM PT", x)) {
           return CRYPT_FAIL_TESTVECTOR;
        }
 
-       if (XMEMCMP(T[1], tests[x].T, 16)) {
-#if 0
-          printf("\nTag on ciphertext wrong %lu\n", x);
-          for (y = 0; y < 16; y++) {
-              printf("%02x", T[1][y] & 255);
-          }
-          printf("\n");
-#endif
+       if (compare_testvector(T[1], y, tests[x].T, 16, "GCM Decrypt Tag", x)) {
           return CRYPT_FAIL_TESTVECTOR;
        }
 

--- a/src/encauth/ocb/ocb_done_decrypt.c
+++ b/src/encauth/ocb/ocb_done_decrypt.c
@@ -55,7 +55,7 @@ int ocb_done_decrypt(ocb_state *ocb,
       goto LBL_ERR;
    }
 
-   if (taglen <= tagbuflen && XMEMCMP(tagbuf, tag, taglen) == 0) {
+   if (taglen <= tagbuflen && XMEM_NEQ(tagbuf, tag, taglen) == 0) {
       *stat = 1;
    }
 

--- a/src/encauth/ocb/ocb_test.c
+++ b/src/encauth/ocb/ocb_test.c
@@ -180,22 +180,8 @@ int ocb_test(void)
            return err;
         }
 
-        if (XMEMCMP(outtag, tests[x].tag, len) || XMEMCMP(outct, tests[x].ct, tests[x].ptlen)) {
-#if 0
-           unsigned long y;
-           printf("\n\nFailure: \nCT:\n");
-           for (y = 0; y < (unsigned long)tests[x].ptlen; ) {
-               printf("0x%02x", outct[y]);
-               if (y < (unsigned long)(tests[x].ptlen-1)) printf(", ");
-               if (!(++y % 8)) printf("\n");
-           }
-           printf("\nTAG:\n");
-           for (y = 0; y < len; ) {
-               printf("0x%02x", outtag[y]);
-               if (y < len-1) printf(", ");
-               if (!(++y % 8)) printf("\n");
-           }
-#endif
+        if (compare_testvector(outtag, len, tests[x].tag, sizeof(tests[x].tag), "OCB Tag", x) ||
+              compare_testvector(outct, tests[x].ptlen, tests[x].ct, tests[x].ptlen, "OCB CT", x)) {
            return CRYPT_FAIL_TESTVECTOR;
         }
 
@@ -203,17 +189,12 @@ int ocb_test(void)
              outct, tests[x].tag, len, &res)) != CRYPT_OK) {
            return err;
         }
-        if ((res != 1) || XMEMCMP(tests[x].pt, outct, tests[x].ptlen)) {
-#if 0
-           unsigned long y;
-           printf("\n\nFailure-decrypt: \nPT:\n");
-           for (y = 0; y < (unsigned long)tests[x].ptlen; ) {
-               printf("0x%02x", outct[y]);
-               if (y < (unsigned long)(tests[x].ptlen-1)) printf(", ");
-               if (!(++y % 8)) printf("\n");
-           }
+        if ((res != 1) || compare_testvector(outct, tests[x].ptlen, tests[x].pt, tests[x].ptlen, "OCB", x)) {
+#ifdef LTC_TEST_DBG
+           printf("\n\nOCB: Failure-decrypt\n");
            printf("\nres = %d\n\n", res);
 #endif
+           return CRYPT_FAIL_TESTVECTOR;
         }
     }
     return CRYPT_OK;

--- a/src/encauth/ocb3/ocb3_decrypt_verify_memory.c
+++ b/src/encauth/ocb3/ocb3_decrypt_verify_memory.c
@@ -87,7 +87,7 @@ int ocb3_decrypt_verify_memory(int cipher,
    }
 
    /* compare tags */
-   if (buflen >= taglen && XMEMCMP(buf, tag, taglen) == 0) {
+   if (buflen >= taglen && XMEM_NEQ(buf, tag, taglen) == 0) {
       *stat = 1;
    }
 

--- a/src/encauth/ocb3/ocb3_test.c
+++ b/src/encauth/ocb3/ocb3_test.c
@@ -186,22 +186,8 @@ int ocb3_test(void)
            return err;
         }
 
-        if (XMEMCMP(outtag, tests[x].tag, len) || XMEMCMP(outct, tests[x].ct, tests[x].ptlen)) {
-#if 0
-           unsigned long y;
-           printf("\n\nFailure: \nCT:\n");
-           for (y = 0; y < (unsigned long)tests[x].ptlen; ) {
-               printf("0x%02x", outct[y]);
-               if (y < (unsigned long)(tests[x].ptlen-1)) printf(", ");
-               if (!(++y % 8)) printf("\n");
-           }
-           printf("\nTAG:\n");
-           for (y = 0; y < len; ) {
-               printf("0x%02x", outtag[y]);
-               if (y < len-1) printf(", ");
-               if (!(++y % 8)) printf("\n");
-           }
-#endif
+        if (compare_testvector(outtag, len, tests[x].tag, sizeof(tests[x].tag), "OCB3 Tag", x) ||
+              compare_testvector(outct, tests[x].ptlen, tests[x].ct, tests[x].ptlen, "OCB3 CT", x)) {
            return CRYPT_FAIL_TESTVECTOR;
         }
 
@@ -213,17 +199,12 @@ int ocb3_test(void)
              outct, tests[x].tag, len, &res)) != CRYPT_OK) {
            return err;
         }
-        if ((res != 1) || XMEMCMP(tests[x].pt, outct, tests[x].ptlen)) {
-#if 0
-           unsigned long y;
-           printf("\n\nFailure-decrypt: \nPT:\n");
-           for (y = 0; y < (unsigned long)tests[x].ptlen; ) {
-               printf("0x%02x", outct[y]);
-               if (y < (unsigned long)(tests[x].ptlen-1)) printf(", ");
-               if (!(++y % 8)) printf("\n");
-           }
+        if ((res != 1) || compare_testvector(outct, tests[x].ptlen, tests[x].pt, tests[x].ptlen, "OCB3", x)) {
+#ifdef LTC_TEST_DBG
+           printf("\n\nOCB3: Failure-decrypt\n");
            printf("\nres = %d\n\n", res);
 #endif
+           return CRYPT_FAIL_TESTVECTOR;
         }
     }
     return CRYPT_OK;

--- a/src/headers/tomcrypt_custom.h
+++ b/src/headers/tomcrypt_custom.h
@@ -33,6 +33,9 @@
 #ifndef XMEMCMP
 #define XMEMCMP  memcmp
 #endif
+/* A memory compare function that has to run in constant time,
+ * c.f. mem_neq() API summary.
+ */
 #ifndef XMEM_NEQ
 #define XMEM_NEQ  mem_neq
 #endif

--- a/src/headers/tomcrypt_custom.h
+++ b/src/headers/tomcrypt_custom.h
@@ -30,6 +30,9 @@
 #ifndef XMEMCPY
 #define XMEMCPY  memcpy
 #endif
+#ifndef XMEMMOVE
+#define XMEMMOVE memmove
+#endif
 #ifndef XMEMCMP
 #define XMEMCMP  memcmp
 #endif

--- a/src/mac/f9/f9_test.c
+++ b/src/mac/f9/f9_test.c
@@ -59,7 +59,7 @@ int f9_test(void)
      if ((err = f9_memory(idx, tests[x].K, 16, tests[x].M, tests[x].msglen, T, &taglen)) != CRYPT_OK) {
         return err;
      }
-     if (taglen != 4 || XMEMCMP(T, tests[x].T, 4)) {
+     if (compare_testvector(T, taglen, tests[x].T, 4, "F9", x)) {
         return CRYPT_FAIL_TESTVECTOR;
      }
   }

--- a/src/mac/omac/omac_test.c
+++ b/src/mac/omac/omac_test.c
@@ -88,12 +88,7 @@ int omac_test(void)
           return err;
        }
 
-       if (XMEMCMP(out, tests[x].tag, 16) != 0) {
-#if 0
-          int y;
-          printf("\n\nTag: ");
-          for (y = 0; y < 16; y++) printf("%02x", out[y]); printf("\n\n");
-#endif
+       if (compare_testvector(out, len, tests[x].tag, sizeof(tests[x].tag), "OMAC", x) != 0) {
           return CRYPT_FAIL_TESTVECTOR;
        }
     }

--- a/src/mac/pelican/pelican.c
+++ b/src/mac/pelican/pelican.c
@@ -51,7 +51,7 @@ int pelican_init(pelican_state *pelmac, const unsigned char *key, unsigned long 
     return CRYPT_OK;
 }
 
-static void four_rounds(pelican_state *pelmac)
+static void _four_rounds(pelican_state *pelmac)
 {
     ulong32 s0, s1, s2, s3, t0, t1, t2, t3;
     int r;
@@ -114,7 +114,7 @@ int pelican_process(pelican_state *pelmac, const unsigned char *in, unsigned lon
          for (x = 0; x < 16; x += sizeof(LTC_FAST_TYPE)) {
             *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)pelmac->state + x)) ^= *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)in + x));
          }
-         four_rounds(pelmac);
+         _four_rounds(pelmac);
          in    += 16;
          inlen -= 16;
       }
@@ -124,7 +124,7 @@ int pelican_process(pelican_state *pelmac, const unsigned char *in, unsigned lon
    while (inlen--) {
        pelmac->state[pelmac->buflen++] ^= *in++;
        if (pelmac->buflen == 16) {
-          four_rounds(pelmac);
+          _four_rounds(pelmac);
           pelmac->buflen = 0;
        }
    }
@@ -148,7 +148,7 @@ int pelican_done(pelican_state *pelmac, unsigned char *out)
    }
 
    if  (pelmac->buflen == 16) {
-       four_rounds(pelmac);
+       _four_rounds(pelmac);
        pelmac->buflen = 0;
    }
    pelmac->state[pelmac->buflen++] ^= 0x80;

--- a/src/mac/pelican/pelican_test.c
+++ b/src/mac/pelican/pelican_test.c
@@ -97,12 +97,7 @@ int pelican_test(void)
           return err;
        }
 
-       if (XMEMCMP(out, tests[x].T, 16)) {
-#if 0
-           int y;
-           printf("\nFailed test %d\n", x);
-           printf("{ "); for (y = 0; y < 16; ) { printf("0x%02x, ", out[y]); if (!(++y & 7)) printf("\n"); } printf(" }\n");
-#endif
+       if (compare_testvector(out, 16, tests[x].T, 16, "PELICAN", x)) {
            return CRYPT_FAIL_TESTVECTOR;
        }
    }

--- a/src/mac/pmac/pmac_test.c
+++ b/src/mac/pmac/pmac_test.c
@@ -136,16 +136,7 @@ int pmac_test(void)
            return err;
         }
 
-        if (XMEMCMP(outtag, tests[x].tag, len)) {
-#if 0
-           unsigned long y;
-           printf("\nTAG:\n");
-           for (y = 0; y < len; ) {
-               printf("0x%02x", outtag[y]);
-               if (y < len-1) printf(", ");
-               if (!(++y % 8)) printf("\n");
-           }
-#endif
+        if (compare_testvector(outtag, len, tests[x].tag, sizeof(tests[x].tag), "PMAC", x)) {
            return CRYPT_FAIL_TESTVECTOR;
         }
     }

--- a/src/mac/xcbc/xcbc_test.c
+++ b/src/mac/xcbc/xcbc_test.c
@@ -109,7 +109,7 @@ int xcbc_test(void)
      if ((err = xcbc_memory(idx, tests[x].K, 16, tests[x].M, tests[x].msglen, T, &taglen)) != CRYPT_OK) {
         return err;
      }
-     if (taglen != 16 || XMEMCMP(T, tests[x].T, 16)) {
+     if (compare_testvector(T, taglen, tests[x].T, 16, "XCBC", x)) {
         return CRYPT_FAIL_TESTVECTOR;
      }
   }

--- a/src/math/fp/ltc_ecc_fp_mulmod.c
+++ b/src/math/fp/ltc_ecc_fp_mulmod.c
@@ -572,7 +572,7 @@ static const struct {
 };
 
 /* find a hole and free as required, return -1 if no hole found */
-static int find_hole(void)
+static int _find_hole(void)
 {
    unsigned x;
    int      y, z;
@@ -608,7 +608,7 @@ static int find_hole(void)
 }
 
 /* determine if a base is already in the cache and if so, where */
-static int find_base(ecc_point *g)
+static int _find_base(ecc_point *g)
 {
    int x;
    for (x = 0; x < FP_ENTRIES; x++) {
@@ -626,7 +626,7 @@ static int find_base(ecc_point *g)
 }
 
 /* add a new base to the cache */
-static int add_entry(int idx, ecc_point *g)
+static int _add_entry(int idx, ecc_point *g)
 {
    unsigned x, y;
 
@@ -668,7 +668,7 @@ static int add_entry(int idx, ecc_point *g)
  * The algorithm builds patterns in increasing bit order by first making all
  * single bit input patterns, then all two bit input patterns and so on
  */
-static int build_lut(int idx, void *modulus, void *mp, void *mu)
+static int _build_lut(int idx, void *modulus, void *mp, void *mu)
 {
    unsigned x, y, err, bitlen, lut_gap;
    void    *tmp;
@@ -775,7 +775,7 @@ DONE:
 }
 
 /* perform a fixed point ECC mulmod */
-static int accel_fp_mul(int idx, void *k, ecc_point *R, void *modulus, void *mp, int map)
+static int _accel_fp_mul(int idx, void *k, ecc_point *R, void *modulus, void *mp, int map)
 {
    unsigned char kb[128];
    int      x;
@@ -898,7 +898,7 @@ static int accel_fp_mul(int idx, void *k, ecc_point *R, void *modulus, void *mp,
 
 #ifdef LTC_ECC_SHAMIR
 /* perform a fixed point ECC mulmod */
-static int accel_fp_mul2add(int idx1, int idx2,
+static int _accel_fp_mul2add(int idx1, int idx2,
                             void *kA, void *kB,
                             ecc_point *R, void *modulus, void *mp)
 {
@@ -1119,13 +1119,13 @@ int ltc_ecc_fp_mul2add(ecc_point *A, void *kA,
    mu = NULL;
    LTC_MUTEX_LOCK(&ltc_ecc_fp_lock);
       /* find point */
-      idx1 = find_base(A);
+      idx1 = _find_base(A);
 
       /* no entry? */
       if (idx1 == -1) {
          /* find hole and add it */
-         if ((idx1 = find_hole()) >= 0) {
-            if ((err = add_entry(idx1, A)) != CRYPT_OK) {
+         if ((idx1 = _find_hole()) >= 0) {
+            if ((err = _add_entry(idx1, A)) != CRYPT_OK) {
                goto LBL_ERR;
             }
          }
@@ -1136,13 +1136,13 @@ int ltc_ecc_fp_mul2add(ecc_point *A, void *kA,
       }
 
       /* find point */
-      idx2 = find_base(B);
+      idx2 = _find_base(B);
 
       /* no entry? */
       if (idx2 == -1) {
          /* find hole and add it */
-         if ((idx2 = find_hole()) >= 0) {
-            if ((err = add_entry(idx2, B)) != CRYPT_OK) {
+         if ((idx2 = _find_hole()) >= 0) {
+            if ((err = _add_entry(idx2, B)) != CRYPT_OK) {
                goto LBL_ERR;
             }
          }
@@ -1166,7 +1166,7 @@ int ltc_ecc_fp_mul2add(ecc_point *A, void *kA,
          }
 
          /* build the LUT */
-         if ((err = build_lut(idx1, modulus, mp, mu)) != CRYPT_OK) {
+         if ((err = _build_lut(idx1, modulus, mp, mu)) != CRYPT_OK) {
              goto LBL_ERR;;
          }
       }
@@ -1187,7 +1187,7 @@ int ltc_ecc_fp_mul2add(ecc_point *A, void *kA,
          }
 
          /* build the LUT */
-         if ((err = build_lut(idx2, modulus, mp, mu)) != CRYPT_OK) {
+         if ((err = _build_lut(idx2, modulus, mp, mu)) != CRYPT_OK) {
              goto LBL_ERR;;
          }
       }
@@ -1198,7 +1198,7 @@ int ltc_ecc_fp_mul2add(ecc_point *A, void *kA,
             /* compute mp */
             if ((err = mp_montgomery_setup(modulus, &mp)) != CRYPT_OK) { goto LBL_ERR; }
          }
-         err = accel_fp_mul2add(idx1, idx2, kA, kB, C, modulus, mp);
+         err = _accel_fp_mul2add(idx1, idx2, kA, kB, C, modulus, mp);
       } else {
          err = ltc_ecc_mul2add(A, kA, B, kB, C, modulus);
       }
@@ -1231,15 +1231,15 @@ int ltc_ecc_fp_mulmod(void *k, ecc_point *G, ecc_point *R, void *modulus, int ma
    mu = NULL;
    LTC_MUTEX_LOCK(&ltc_ecc_fp_lock);
       /* find point */
-      idx = find_base(G);
+      idx = _find_base(G);
 
       /* no entry? */
       if (idx == -1) {
          /* find hole and add it */
-         idx = find_hole();
+         idx = _find_hole();
 
          if (idx >= 0) {
-            if ((err = add_entry(idx, G)) != CRYPT_OK) {
+            if ((err = _add_entry(idx, G)) != CRYPT_OK) {
                goto LBL_ERR;
             }
          }
@@ -1264,7 +1264,7 @@ int ltc_ecc_fp_mulmod(void *k, ecc_point *G, ecc_point *R, void *modulus, int ma
          }
 
          /* build the LUT */
-         if ((err = build_lut(idx, modulus, mp, mu)) != CRYPT_OK) {
+         if ((err = _build_lut(idx, modulus, mp, mu)) != CRYPT_OK) {
              goto LBL_ERR;;
          }
       }
@@ -1274,7 +1274,7 @@ int ltc_ecc_fp_mulmod(void *k, ecc_point *G, ecc_point *R, void *modulus, int ma
             /* compute mp */
             if ((err = mp_montgomery_setup(modulus, &mp)) != CRYPT_OK) { goto LBL_ERR; }
          }
-         err = accel_fp_mul(idx, k, R, modulus, mp, map);
+         err = _accel_fp_mul(idx, k, R, modulus, mp, map);
       } else {
          err = ltc_ecc_mulmod(k, G, R, modulus, map);
       }
@@ -1290,7 +1290,7 @@ LBL_ERR:
 }
 
 /* helper function for freeing the cache ... must be called with the cache mutex locked */
-static void ltc_ecc_fp_free_cache(void)
+static void _ltc_ecc_fp_free_cache(void)
 {
    unsigned x, y;
    for (x = 0; x < FP_ENTRIES; x++) {
@@ -1315,7 +1315,7 @@ static void ltc_ecc_fp_free_cache(void)
 void ltc_ecc_fp_free(void)
 {
    LTC_MUTEX_LOCK(&ltc_ecc_fp_lock);
-   ltc_ecc_fp_free_cache();
+   _ltc_ecc_fp_free_cache();
    LTC_MUTEX_UNLOCK(&ltc_ecc_fp_lock);
 }
 
@@ -1334,7 +1334,7 @@ ltc_ecc_fp_add_point(ecc_point *g, void *modulus, int lock)
    void *mu = NULL;
 
    LTC_MUTEX_LOCK(&ltc_ecc_fp_lock);
-   if ((idx = find_base(g)) >= 0) {
+   if ((idx = _find_base(g)) >= 0) {
       /* it is already in the cache ... just check that the LUT is initialized */
       if(fp_cache[idx].lru_count >= 2) {
          LTC_MUTEX_UNLOCK(&ltc_ecc_fp_lock);
@@ -1342,11 +1342,11 @@ ltc_ecc_fp_add_point(ecc_point *g, void *modulus, int lock)
       }
    }
 
-   if(idx == -1 && (idx = find_hole()) == -1) {
+   if(idx == -1 && (idx = _find_hole()) == -1) {
       err = CRYPT_BUFFER_OVERFLOW;
       goto LBL_ERR;
    }
-   if ((err = add_entry(idx, g)) != CRYPT_OK) {
+   if ((err = _add_entry(idx, g)) != CRYPT_OK) {
       goto LBL_ERR;
    }
    /* compute mp */
@@ -1363,7 +1363,7 @@ ltc_ecc_fp_add_point(ecc_point *g, void *modulus, int lock)
    }
 
    /* build the LUT */
-   if ((err = build_lut(idx, modulus, mp, mu)) != CRYPT_OK) {
+   if ((err = _build_lut(idx, modulus, mp, mu)) != CRYPT_OK) {
        goto LBL_ERR;
    }
    fp_cache[idx].lru_count = 2;
@@ -1501,7 +1501,7 @@ int ltc_ecc_fp_restore_state(unsigned char *in, unsigned long inlen)
    /*
     * start with an empty cache
     */
-   ltc_ecc_fp_free_cache();
+   _ltc_ecc_fp_free_cache();
 
    /*
     * decode the input packet: It consists of a sequence with a few
@@ -1571,7 +1571,7 @@ int ltc_ecc_fp_restore_state(unsigned char *in, unsigned long inlen)
 ERR_OUT:
    if(asn1_list)
       XFREE(asn1_list);
-   ltc_ecc_fp_free_cache();
+   _ltc_ecc_fp_free_cache();
    LTC_MUTEX_UNLOCK(&ltc_ecc_fp_lock);
    return err;
 }

--- a/src/misc/adler32.c
+++ b/src/misc/adler32.c
@@ -118,13 +118,7 @@ int adler32_test(void)
    adler32_init(&ctx);
    adler32_update(&ctx, in, strlen(in));
    adler32_finish(&ctx, out, 4);
-   if (XMEMCMP(adler32, out, 4)) {
-#ifdef LTC_TEST_DBG
-      ulong32 _out, _adler32;
-      LOAD32H(_out, out);
-      LOAD32H(_adler32, adler32);
-      printf("adler32 fail! Is: 0x%x Should: 0x%x\n", _out, _adler32);
-#endif
+   if (compare_testvector(adler32, 4, out, 4, "adler32", 0)) {
       return CRYPT_FAIL_TESTVECTOR;
    }
    return CRYPT_OK;

--- a/src/misc/crc32.c
+++ b/src/misc/crc32.c
@@ -189,13 +189,7 @@ int crc32_test(void)
    crc32_init(&ctx);
    crc32_update(&ctx, in, strlen(in));
    crc32_finish(&ctx, out, 4);
-   if (XMEMCMP(crc32, out, 4)) {
-#ifdef LTC_TEST_DBG
-      ulong32 _out, _crc32;
-      LOAD32H(_out, out);
-      LOAD32H(_crc32, crc32);
-      printf("crc32 fail! Is: 0x%x Should: 0x%x\n", _out, _crc32);
-#endif
+   if (compare_testvector(crc32, 4, out, 4, "CRC32", 0)) {
       return CRYPT_FAIL_TESTVECTOR;
    }
    return CRYPT_OK;

--- a/src/misc/hkdf/hkdf_test.c
+++ b/src/misc/hkdf/hkdf_test.c
@@ -265,33 +265,17 @@ int hkdf_test(void)
                         cases[i].info, cases[i].info_l,
                         cases[i].IKM,   cases[i].IKM_l,
                         OKM, cases[i].OKM_l)) != CRYPT_OK) {
-#ifdef LTC_TEST_DBG
+#if LTC_TEST_DBG > 1
             printf("LTC_HKDF-%s test #%d, %s\n", cases[i].Hash, i, error_to_string(err));
 #endif
             return err;
         }
 
-        if(XMEMCMP(OKM, cases[i].OKM, (size_t)cases[i].OKM_l) != 0)  {
+        if(compare_testvector(OKM, cases[i].OKM_l, cases[i].OKM, (size_t)cases[i].OKM_l, "HKDF", cases[i].num)) {
             failed++;
-#ifdef LTC_TEST_DBG
-          {
-            unsigned int j;
-            printf("\nLTC_HKDF-%s test #%d:\n", cases[i].Hash, cases[i].num);
-            printf(  "Result:  0x");
-            for(j=0; j < cases[i].OKM_l; j++) {
-                printf("%02x ", OKM[j]);
-            }
-            printf("\nCorrect: 0x");
-            for(j=0; j < cases[i].OKM_l; j++) {
-               printf("%02x ", cases[i].OKM[j]);
-            }
-            printf("\n");
-            return CRYPT_ERROR;
-          }
 #if LTC_TEST_DBG > 1
         } else {
             printf("LTC_HKDF-%s test #%d: Passed\n", cases[i].Hash, cases[i].num);
-#endif
 #endif
         }
     }

--- a/src/misc/mem_neq.c
+++ b/src/misc/mem_neq.c
@@ -10,22 +10,27 @@
 
 /**
    @file mem_neq.c
-   Compare two blocks of memory for inequality.
+   Compare two blocks of memory for inequality in constant time.
    Steffen Jaeckel
 */
 
 /**
-   Compare two blocks of memory for inequality.
+   Compare two blocks of memory for inequality in constant time.
 
    The usage is similar to that of standard memcmp, but you can only test
    if the memory is equal or not - you can not determine by how much the
    first different byte differs.
 
+   This function shall be used to compare results of cryptographic
+   operations where inequality means most likely usage of a wrong key.
+   The execution time has therefore to be constant as otherwise
+   timing attacks could be possible.
+
    @param a     The first memory region
    @param b     The second memory region
    @param len   The length of the area to compare (octets)
 
-   @return 0 when a and b are equal for len bytes, else they are not equal.
+   @return 0 when a and b are equal for len bytes, 1 they are not equal.
 */
 int mem_neq(const void *a, const void *b, size_t len)
 {

--- a/src/modes/ctr/ctr_test.c
+++ b/src/modes/ctr/ctr_test.c
@@ -65,7 +65,7 @@ int ctr_test(void)
         return err;
      }
      ctr_done(&ctr);
-     if (XMEMCMP(buf, tests[x].ct, tests[x].msglen)) {
+     if (compare_testvector(buf, tests[x].msglen, tests[x].ct, tests[x].msglen, "CTR", x)) {
         return CRYPT_FAIL_TESTVECTOR;
      }
   }

--- a/src/modes/f8/f8_test_mode.c
+++ b/src/modes/f8/f8_test_mode.c
@@ -59,7 +59,7 @@ int f8_test_mode(void)
    f8_done(&f8);
 
    /* compare */
-   if (XMEMCMP(buf, ct, sizeof(ct))) {
+   if (compare_testvector(buf, sizeof(ct), ct, sizeof(ct), "f8", 0)) {
       return CRYPT_FAIL_TESTVECTOR;
    }
 

--- a/src/modes/lrw/lrw_test.c
+++ b/src/modes/lrw/lrw_test.c
@@ -86,7 +86,7 @@ int lrw_test(void)
      }
 
      /* check pad against expected tweak */
-     if (XMEMCMP(tests[x].expected_tweak, lrw.pad, 16)) {
+     if (compare_testvector(tests[x].expected_tweak, 16, lrw.pad, 16, "LRW Tweak", x)) {
         lrw_done(&lrw);
         return CRYPT_FAIL_TESTVECTOR;
      }
@@ -97,7 +97,7 @@ int lrw_test(void)
         return err;
      }
 
-     if (XMEMCMP(buf[0], tests[x].C, 16)) {
+     if (compare_testvector(buf[0], 16, tests[x].C, 16, "LRW Encrypt", x)) {
         lrw_done(&lrw);
         return CRYPT_FAIL_TESTVECTOR;
      }
@@ -113,7 +113,7 @@ int lrw_test(void)
         return err;
      }
 
-     if (XMEMCMP(buf[1], tests[x].P, 16)) {
+     if (compare_testvector(buf[1], 16, tests[x].P, 16, "LRW Decrypt", x)) {
         lrw_done(&lrw);
         return CRYPT_FAIL_TESTVECTOR;
      }

--- a/src/modes/xts/xts_decrypt.c
+++ b/src/modes/xts/xts_decrypt.c
@@ -14,7 +14,7 @@
 
 #ifdef LTC_XTS_MODE
 
-static int tweak_uncrypt(const unsigned char *C, unsigned char *P, unsigned char *T, symmetric_xts *xts)
+static int _tweak_uncrypt(const unsigned char *C, unsigned char *P, unsigned char *T, symmetric_xts *xts)
 {
    unsigned long x;
    int err;
@@ -108,7 +108,7 @@ int xts_decrypt(const unsigned char *ct, unsigned long ptlen, unsigned char *pt,
       }
 
       for (i = 0; i < lim; i++) {
-         if ((err = tweak_uncrypt(ct, pt, T, xts)) != CRYPT_OK) {
+         if ((err = _tweak_uncrypt(ct, pt, T, xts)) != CRYPT_OK) {
             return err;
          }
          ct += 16;
@@ -122,7 +122,7 @@ int xts_decrypt(const unsigned char *ct, unsigned long ptlen, unsigned char *pt,
       xts_mult_x(CC);
 
       /* PP = tweak decrypt block m-1 */
-      if ((err = tweak_uncrypt(ct, PP, CC, xts)) != CRYPT_OK) {
+      if ((err = _tweak_uncrypt(ct, PP, CC, xts)) != CRYPT_OK) {
          return err;
       }
 
@@ -136,7 +136,7 @@ int xts_decrypt(const unsigned char *ct, unsigned long ptlen, unsigned char *pt,
       }
 
       /* Pm-1 = Tweak uncrypt CC */
-      if ((err = tweak_uncrypt(CC, pt, T, xts)) != CRYPT_OK) {
+      if ((err = _tweak_uncrypt(CC, pt, T, xts)) != CRYPT_OK) {
          return err;
       }
    }

--- a/src/modes/xts/xts_encrypt.c
+++ b/src/modes/xts/xts_encrypt.c
@@ -14,7 +14,7 @@
 
 #ifdef LTC_XTS_MODE
 
-static int tweak_crypt(const unsigned char *P, unsigned char *C, unsigned char *T, symmetric_xts *xts)
+static int _tweak_crypt(const unsigned char *P, unsigned char *C, unsigned char *T, symmetric_xts *xts)
 {
    unsigned long x;
    int err;
@@ -111,7 +111,7 @@ int xts_encrypt(const unsigned char *pt, unsigned long ptlen, unsigned char *ct,
       }
 
       for (i = 0; i < lim; i++) {
-         if ((err = tweak_crypt(pt, ct, T, xts)) != CRYPT_OK) {
+         if ((err = _tweak_crypt(pt, ct, T, xts)) != CRYPT_OK) {
             return err;
          }
          ct += 16;
@@ -122,7 +122,7 @@ int xts_encrypt(const unsigned char *pt, unsigned long ptlen, unsigned char *ct,
    /* if ptlen not divide 16 then */
    if (mo > 0) {
       /* CC = tweak encrypt block m-1 */
-      if ((err = tweak_crypt(pt, CC, T, xts)) != CRYPT_OK) {
+      if ((err = _tweak_crypt(pt, CC, T, xts)) != CRYPT_OK) {
          return err;
       }
 
@@ -137,7 +137,7 @@ int xts_encrypt(const unsigned char *pt, unsigned long ptlen, unsigned char *ct,
       }
 
       /* Cm-1 = Tweak encrypt PP */
-      if ((err = tweak_crypt(PP, ct, T, xts)) != CRYPT_OK) {
+      if ((err = _tweak_crypt(PP, ct, T, xts)) != CRYPT_OK) {
          return err;
       }
    }

--- a/src/modes/xts/xts_test.c
+++ b/src/modes/xts/xts_test.c
@@ -10,6 +10,7 @@
 
 #ifdef LTC_XTS_MODE
 
+#ifndef LTC_NO_TEST
 static int _xts_test_accel_xts_encrypt(const unsigned char *pt, unsigned char *ct, unsigned long blocks,
                                        unsigned char *tweak, symmetric_key *skey1, symmetric_key *skey2)
 {
@@ -63,6 +64,7 @@ static int _xts_test_accel_xts_decrypt(const unsigned char *ct, unsigned char *p
 
    return ret;
 }
+#endif
 
 /**
   Source donated by Elliptic Semiconductor Inc (www.ellipticsemi.com) to the LibTom Projects

--- a/src/pk/asn1/der/generalizedtime/der_decode_generalizedtime.c
+++ b/src/pk/asn1/der/generalizedtime/der_decode_generalizedtime.c
@@ -16,7 +16,7 @@
 
 #ifdef LTC_DER
 
-static int char_to_int(unsigned char x)
+static int _char_to_int(unsigned char x)
 {
    switch (x)  {
       case '0': return 0;
@@ -34,13 +34,13 @@ static int char_to_int(unsigned char x)
 }
 
 #define DECODE_V(y, max) do {\
-   y  = char_to_int(buf[x])*10 + char_to_int(buf[x+1]); \
+   y  = _char_to_int(buf[x])*10 + _char_to_int(buf[x+1]); \
    if (y >= max) return CRYPT_INVALID_PACKET;           \
    x += 2; \
 } while(0)
 
 #define DECODE_V4(y, max) do {\
-   y  = char_to_int(buf[x])*1000 + char_to_int(buf[x+1])*100 + char_to_int(buf[x+2])*10 + char_to_int(buf[x+3]); \
+   y  = _char_to_int(buf[x])*1000 + _char_to_int(buf[x+1])*100 + _char_to_int(buf[x+2])*10 + _char_to_int(buf[x+3]); \
    if (y >= max) return CRYPT_INVALID_PACKET; \
    x += 4; \
 } while(0)
@@ -118,7 +118,7 @@ YYYYMMDDhhmmss.fs-hh'mm'
           unsigned fs = out->fs;
           if (x >= sizeof(buf)) return CRYPT_INVALID_PACKET;
           out->fs *= 10;
-          out->fs += char_to_int(buf[x]);
+          out->fs += _char_to_int(buf[x]);
           if (fs > out->fs) return CRYPT_OVERFLOW;
           x++;
        }

--- a/src/pk/asn1/der/sequence/der_decode_sequence_flexi.c
+++ b/src/pk/asn1/der/sequence/der_decode_sequence_flexi.c
@@ -15,7 +15,7 @@
 
 #ifdef LTC_DER
 
-static unsigned long fetch_length(const unsigned char *in, unsigned long inlen, unsigned long *data_offset)
+static unsigned long _fetch_length(const unsigned char *in, unsigned long inlen, unsigned long *data_offset)
 {
    unsigned long x, z;
 
@@ -51,7 +51,7 @@ static unsigned long fetch_length(const unsigned char *in, unsigned long inlen, 
    return z+*data_offset;
 }
 
-static int new_element(ltc_asn1_list **l)
+static int _new_element(ltc_asn1_list **l)
 {
    /* alloc new link */
    if (*l == NULL) {
@@ -92,7 +92,7 @@ int der_decode_sequence_flexi(const unsigned char *in, unsigned long *inlen, ltc
 
    if (*inlen == 0) {
       /* alloc new link */
-      if ((err = new_element(&l)) != CRYPT_OK) {
+      if ((err = _new_element(&l)) != CRYPT_OK) {
          goto error;
       }
    }
@@ -103,14 +103,14 @@ int der_decode_sequence_flexi(const unsigned char *in, unsigned long *inlen, ltc
       type = *in;
 
       /* fetch length */
-      len = fetch_length(in, *inlen, &data_offset);
+      len = _fetch_length(in, *inlen, &data_offset);
       if (len > *inlen) {
          err = CRYPT_INVALID_PACKET;
          goto error;
       }
 
       /* alloc new link */
-      if ((err = new_element(&l)) != CRYPT_OK) {
+      if ((err = _new_element(&l)) != CRYPT_OK) {
          goto error;
       }
 

--- a/src/pk/asn1/der/set/der_encode_set.c
+++ b/src/pk/asn1/der/set/der_encode_set.c
@@ -16,7 +16,7 @@
 #ifdef LTC_DER
 
 /* LTC define to ASN.1 TAG */
-static int ltc_to_asn1(ltc_asn1_type v)
+static int _ltc_to_asn1(ltc_asn1_type v)
 {
    switch (v) {
       case LTC_ASN1_BOOLEAN:                 return 0x01;
@@ -45,12 +45,12 @@ static int ltc_to_asn1(ltc_asn1_type v)
 }
 
 
-static int qsort_helper(const void *a, const void *b)
+static int _qsort_helper(const void *a, const void *b)
 {
    ltc_asn1_list *A = (ltc_asn1_list *)a, *B = (ltc_asn1_list *)b;
    int            r;
 
-   r = ltc_to_asn1(A->type) - ltc_to_asn1(B->type);
+   r = _ltc_to_asn1(A->type) - _ltc_to_asn1(B->type);
 
    /* for QSORT the order is UNDEFINED if they are "equal" which means it is NOT DETERMINISTIC.  So we force it to be :-) */
    if (r == 0) {
@@ -89,7 +89,7 @@ int der_encode_set(ltc_asn1_list *list, unsigned long inlen,
    }
 
    /* sort it by the "type" field */
-   XQSORT(copy, inlen, sizeof(*copy), &qsort_helper);
+   XQSORT(copy, inlen, sizeof(*copy), &_qsort_helper);
 
    /* call der_encode_sequence_ex() */
    err = der_encode_sequence_ex(copy, inlen, out, outlen, LTC_ASN1_SET);

--- a/src/pk/asn1/der/set/der_encode_setof.c
+++ b/src/pk/asn1/der/set/der_encode_setof.c
@@ -20,7 +20,7 @@ struct edge {
    unsigned long  size;
 };
 
-static int qsort_helper(const void *a, const void *b)
+static int _qsort_helper(const void *a, const void *b)
 {
    struct edge   *A = (struct edge *)a, *B = (struct edge *)b;
    int            r;
@@ -132,7 +132,7 @@ int der_encode_setof(ltc_asn1_list *list, unsigned long inlen,
    }
 
    /* sort based on contents (using edges) */
-   XQSORT(edges, inlen, sizeof(*edges), &qsort_helper);
+   XQSORT(edges, inlen, sizeof(*edges), &_qsort_helper);
 
    /* copy static header */
    XMEMCPY(out, buf, hdrlen);

--- a/src/pk/asn1/der/utctime/der_decode_utctime.c
+++ b/src/pk/asn1/der/utctime/der_decode_utctime.c
@@ -15,7 +15,7 @@
 
 #ifdef LTC_DER
 
-static int char_to_int(unsigned char x)
+static int _char_to_int(unsigned char x)
 {
    switch (x)  {
       case '0': return 0;
@@ -33,7 +33,7 @@ static int char_to_int(unsigned char x)
 }
 
 #define DECODE_V(y, max) \
-   y  = char_to_int(buf[x])*10 + char_to_int(buf[x+1]); \
+   y  = _char_to_int(buf[x])*10 + _char_to_int(buf[x+1]); \
    if (y >= max) return CRYPT_INVALID_PACKET;           \
    x += 2;
 

--- a/src/pk/dsa/dsa_make_key.c
+++ b/src/pk/dsa/dsa_make_key.c
@@ -26,7 +26,7 @@
   @param g             [out] bignum where generated 'g' is stored (must be initialized by caller)
   @return CRYPT_OK if successful, upon error this function will free all allocated memory
 */
-static int dsa_make_params(prng_state *prng, int wprng, int group_size, int modulus_size, void *p, void *q, void *g)
+static int _dsa_make_params(prng_state *prng, int wprng, int group_size, int modulus_size, void *p, void *q, void *g)
 {
   unsigned long L, N, n, outbytes, seedbytes, counter, j, i;
   int err, res, mr_tests_q, mr_tests_p, found_p, found_q, hash;
@@ -227,7 +227,7 @@ int dsa_make_key_ex(prng_state *prng, int wprng, int group_size, int modulus_siz
 
   if (p_hex == NULL || q_hex == NULL || g_hex == NULL) {
     /* generate params */
-    err = dsa_make_params(prng, wprng, group_size, modulus_size, key->p, key->q, key->g);
+    err = _dsa_make_params(prng, wprng, group_size, modulus_size, key->p, key->q, key->g);
     if (err != CRYPT_OK)                                                         { goto cleanup; }
   }
   else {

--- a/src/pk/ecc/ecc_import.c
+++ b/src/pk/ecc/ecc_import.c
@@ -21,7 +21,7 @@
 
 #ifdef LTC_MECC
 
-static int is_point(ecc_key *key)
+static int _is_point(ecc_key *key)
 {
    void *prime, *b, *t1, *t2;
    int err;
@@ -153,7 +153,7 @@ int ecc_import_ex(const unsigned char *in, unsigned long inlen, ecc_key *key, co
    if ((err = mp_set(key->pubkey.z, 1)) != CRYPT_OK) { goto done; }
 
    /* is it a point on the curve?  */
-   if ((err = is_point(key)) != CRYPT_OK) {
+   if ((err = _is_point(key)) != CRYPT_OK) {
       goto done;
    }
 

--- a/src/pk/rsa/rsa_verify_hash.c
+++ b/src/pk/rsa/rsa_verify_hash.c
@@ -163,7 +163,7 @@ int rsa_verify_hash_ex(const unsigned char *sig,      unsigned long siglen,
     } else {
       /* only check if the hash is equal */
       if ((hashlen == outlen) &&
-          (XMEMCMP(out, hash, hashlen) == 0)) {
+          (XMEM_NEQ(out, hash, hashlen) == 0)) {
         *stat = 1;
       }
     }

--- a/src/pk/rsa/rsa_verify_hash.c
+++ b/src/pk/rsa/rsa_verify_hash.c
@@ -155,15 +155,15 @@ int rsa_verify_hash_ex(const unsigned char *sig,      unsigned long siglen,
       /* test OID */
       if ((reallen == outlen) &&
           (digestinfo[0].size == hash_descriptor[hash_idx].OIDlen) &&
-        (XMEM_NEQ(digestinfo[0].data, hash_descriptor[hash_idx].OID, sizeof(unsigned long) * hash_descriptor[hash_idx].OIDlen) == 0) &&
+        (XMEMCMP(digestinfo[0].data, hash_descriptor[hash_idx].OID, sizeof(unsigned long) * hash_descriptor[hash_idx].OIDlen) == 0) &&
           (siginfo[1].size == hashlen) &&
-        (XMEM_NEQ(siginfo[1].data, hash, hashlen) == 0)) {
+        (XMEMCMP(siginfo[1].data, hash, hashlen) == 0)) {
          *stat = 1;
       }
     } else {
       /* only check if the hash is equal */
       if ((hashlen == outlen) &&
-          (XMEM_NEQ(out, hash, hashlen) == 0)) {
+          (XMEMCMP(out, hash, hashlen) == 0)) {
         *stat = 1;
       }
     }

--- a/src/stream/rc4/rc4_test.c
+++ b/src/stream/rc4/rc4_test.c
@@ -25,7 +25,7 @@ int rc4_stream_test(void)
 
    if ((err = rc4_stream_setup(&st, key, sizeof(key))) != CRYPT_OK)    return err;
    if ((err = rc4_stream_crypt(&st, pt, sizeof(pt), buf)) != CRYPT_OK) return err;
-   if (XMEMCMP(buf, ct, sizeof(ct)))                                   return CRYPT_FAIL_TESTVECTOR;
+   if (compare_testvector(buf, sizeof(ct), ct, sizeof(ct), "RC4", 0))  return CRYPT_FAIL_TESTVECTOR;
    if ((err = rc4_stream_done(&st)) != CRYPT_OK)                       return err;
 
    return CRYPT_OK;

--- a/src/stream/sober128/sober128_test.c
+++ b/src/stream/sober128/sober128_test.c
@@ -31,15 +31,7 @@ int sober128_stream_test(void)
    if ((err = sober128_stream_setiv(&st, iv, sizeof(iv))) != CRYPT_OK)   return err;
    if ((err = sober128_stream_crypt(&st, src, len, dst)) != CRYPT_OK)    return err;
    if ((err = sober128_stream_done(&st)) != CRYPT_OK)                    return err;
-   if (XMEMCMP(dst, out, len)) {
-#if 0
-      int y;
-      printf("\nLTC_SOBER128 failed, I got:\n");
-      for (y = 0; y < len; y++) printf("%02x ", dst[y]);
-      printf("\nLTC_SOBER128 failed, expected:\n");
-      for (y = 0; y < len; y++) printf("%02x ", out[y]);
-      printf("\n");
-#endif
+   if (compare_testvector(dst, len, out, len, "SOBER-128", 0)) {
       return CRYPT_FAIL_TESTVECTOR;
    }
    return CRYPT_OK;

--- a/tests/test.c
+++ b/tests/test.c
@@ -351,7 +351,7 @@ int main(int argc, char **argv)
 
    dur = epoch_usec();
    for (i = 0; i < sizeof(test_functions)/sizeof(test_functions[0]); ++i) {
-      if (single_test && strcmp(test_functions[i].name, single_test)) {
+      if (single_test && strstr(test_functions[i].name, single_test) == NULL) {
         continue;
       }
       dots = fn_len - strlen(test_functions[i].name);


### PR DESCRIPTION
* fix potential timing attacks in rsa, eax, ocb and ocb3
* use `compare_testvector()` in all the algorithm tests
* use `_function()` pattern for (most of the) static functions
* improve `./test`