### PR TITLE
ASN.1 changes extracted from ECC stuff

### DIFF
--- a/src/headers/tomcrypt_pk.h
+++ b/src/headers/tomcrypt_pk.h
@@ -559,6 +559,8 @@ int der_decode_sequence_ex(const unsigned char *in, unsigned long  inlen,
 
 int der_length_sequence(ltc_asn1_list *list, unsigned long inlen,
                         unsigned long *outlen);
+int der_length_sequence_ex(ltc_asn1_list *list, unsigned long inlen,
+                           unsigned long *outlen, unsigned long *payloadlen);
 
 
 #ifdef LTC_SOURCE

--- a/src/headers/tomcrypt_pk.h
+++ b/src/headers/tomcrypt_pk.h
@@ -559,12 +559,12 @@ int der_decode_sequence_ex(const unsigned char *in, unsigned long  inlen,
 
 int der_length_sequence(ltc_asn1_list *list, unsigned long inlen,
                         unsigned long *outlen);
-int der_length_sequence_ex(ltc_asn1_list *list, unsigned long inlen,
-                           unsigned long *outlen, unsigned long *payloadlen);
 
 
 #ifdef LTC_SOURCE
 /* internal helper functions */
+int der_length_sequence_ex(ltc_asn1_list *list, unsigned long inlen,
+                           unsigned long *outlen, unsigned long *payloadlen);
 /* SUBJECT PUBLIC KEY INFO */
 int der_encode_subject_public_key_info(unsigned char *out, unsigned long *outlen,
         unsigned int algorithm, void* public_key, unsigned long public_key_len,

--- a/src/pk/asn1/der/sequence/der_decode_sequence_ex.c
+++ b/src/pk/asn1/der/sequence/der_decode_sequence_ex.c
@@ -98,6 +98,7 @@ int der_decode_sequence_ex(const unsigned char *in, unsigned long  inlen,
            case LTC_ASN1_BOOLEAN:
                z = inlen;
                if ((err = der_decode_boolean(in + x, z, ((int *)data))) != CRYPT_OK) {
+                   if (!ordered) { continue; }
                    goto LBL_ERR;
                }
                if ((err = der_length_boolean(&z)) != CRYPT_OK) {

--- a/src/pk/asn1/der/sequence/der_encode_sequence_ex.c
+++ b/src/pk/asn1/der/sequence/der_encode_sequence_ex.c
@@ -38,135 +38,8 @@ int der_encode_sequence_ex(ltc_asn1_list *list, unsigned long inlen,
    LTC_ARGCHK(outlen  != NULL);
 
    /* get size of output that will be required */
-   y = 0;
-   for (i = 0; i < inlen; i++) {
-       type = list[i].type;
-       size = list[i].size;
-       data = list[i].data;
-
-       if (type == LTC_ASN1_EOL) {
-          break;
-       }
-
-       switch (type) {
-            case LTC_ASN1_BOOLEAN:
-               if ((err = der_length_boolean(&x)) != CRYPT_OK) {
-                  goto LBL_ERR;
-               }
-               y += x;
-               break;
-
-           case LTC_ASN1_INTEGER:
-               if ((err = der_length_integer(data, &x)) != CRYPT_OK) {
-                  goto LBL_ERR;
-               }
-               y += x;
-               break;
-
-           case LTC_ASN1_SHORT_INTEGER:
-               if ((err = der_length_short_integer(*((unsigned long*)data), &x)) != CRYPT_OK) {
-                  goto LBL_ERR;
-               }
-               y += x;
-               break;
-
-           case LTC_ASN1_BIT_STRING:
-           case LTC_ASN1_RAW_BIT_STRING:
-               if ((err = der_length_bit_string(size, &x)) != CRYPT_OK) {
-                  goto LBL_ERR;
-               }
-               y += x;
-               break;
-
-           case LTC_ASN1_OCTET_STRING:
-               if ((err = der_length_octet_string(size, &x)) != CRYPT_OK) {
-                  goto LBL_ERR;
-               }
-               y += x;
-               break;
-
-           case LTC_ASN1_NULL:
-               y += 2;
-               break;
-
-           case LTC_ASN1_OBJECT_IDENTIFIER:
-               if ((err = der_length_object_identifier(data, size, &x)) != CRYPT_OK) {
-                  goto LBL_ERR;
-               }
-               y += x;
-               break;
-
-           case LTC_ASN1_IA5_STRING:
-               if ((err = der_length_ia5_string(data, size, &x)) != CRYPT_OK) {
-                  goto LBL_ERR;
-               }
-               y += x;
-               break;
-
-           case LTC_ASN1_PRINTABLE_STRING:
-               if ((err = der_length_printable_string(data, size, &x)) != CRYPT_OK) {
-                  goto LBL_ERR;
-               }
-               y += x;
-               break;
-
-           case LTC_ASN1_UTF8_STRING:
-               if ((err = der_length_utf8_string(data, size, &x)) != CRYPT_OK) {
-                  goto LBL_ERR;
-               }
-               y += x;
-               break;
-
-           case LTC_ASN1_UTCTIME:
-               if ((err = der_length_utctime(data, &x)) != CRYPT_OK) {
-                  goto LBL_ERR;
-               }
-               y += x;
-               break;
-
-           case LTC_ASN1_GENERALIZEDTIME:
-               if ((err = der_length_generalizedtime(data, &x)) != CRYPT_OK) {
-                  goto LBL_ERR;
-               }
-               y += x;
-               break;
-
-           case LTC_ASN1_SET:
-           case LTC_ASN1_SETOF:
-           case LTC_ASN1_SEQUENCE:
-               if ((err = der_length_sequence(data, size, &x)) != CRYPT_OK) {
-                  goto LBL_ERR;
-               }
-               y += x;
-               break;
-
-           case LTC_ASN1_CHOICE:
-           case LTC_ASN1_CONSTRUCTED:
-           case LTC_ASN1_CONTEXT_SPECIFIC:
-           case LTC_ASN1_EOL:
-           case LTC_ASN1_TELETEX_STRING:
-               err = CRYPT_INVALID_ARG;
-               goto LBL_ERR;
-       }
-   }
-
-   /* calc header size */
-   z = y;
-   if (y < 128) {
-      y += 2;
-   } else if (y < 256) {
-      /* 0x30 0x81 LL */
-      y += 3;
-   } else if (y < 65536UL) {
-      /* 0x30 0x82 LL LL */
-      y += 4;
-   } else if (y < 16777216UL) {
-      /* 0x30 0x83 LL LL LL */
-      y += 5;
-   } else {
-      err = CRYPT_INVALID_ARG;
-      goto LBL_ERR;
-   }
+   y = 0; z = 0;
+   if ((err = der_length_sequence_ex(list, inlen, &y, &z)) != CRYPT_OK) return CRYPT_INVALID_ARG;
 
    /* too big ? */
    if (*outlen < y) {
@@ -212,8 +85,6 @@ int der_encode_sequence_ex(ltc_asn1_list *list, unsigned long inlen,
                if ((err = der_encode_boolean(*((int *)data), out + x, &z)) != CRYPT_OK) {
                   goto LBL_ERR;
                }
-               x       += z;
-               *outlen -= z;
                break;
 
            case LTC_ASN1_INTEGER:
@@ -221,8 +92,6 @@ int der_encode_sequence_ex(ltc_asn1_list *list, unsigned long inlen,
                if ((err = der_encode_integer(data, out + x, &z)) != CRYPT_OK) {
                   goto LBL_ERR;
                }
-               x       += z;
-               *outlen -= z;
                break;
 
            case LTC_ASN1_SHORT_INTEGER:
@@ -230,8 +99,6 @@ int der_encode_sequence_ex(ltc_asn1_list *list, unsigned long inlen,
                if ((err = der_encode_short_integer(*((unsigned long*)data), out + x, &z)) != CRYPT_OK) {
                   goto LBL_ERR;
                }
-               x       += z;
-               *outlen -= z;
                break;
 
            case LTC_ASN1_BIT_STRING:
@@ -239,8 +106,6 @@ int der_encode_sequence_ex(ltc_asn1_list *list, unsigned long inlen,
                if ((err = der_encode_bit_string(data, size, out + x, &z)) != CRYPT_OK) {
                   goto LBL_ERR;
                }
-               x       += z;
-               *outlen -= z;
                break;
 
            case LTC_ASN1_RAW_BIT_STRING:
@@ -248,8 +113,6 @@ int der_encode_sequence_ex(ltc_asn1_list *list, unsigned long inlen,
                if ((err = der_encode_raw_bit_string(data, size, out + x, &z)) != CRYPT_OK) {
                   goto LBL_ERR;
                }
-               x       += z;
-               *outlen -= z;
                break;
 
            case LTC_ASN1_OCTET_STRING:
@@ -257,14 +120,12 @@ int der_encode_sequence_ex(ltc_asn1_list *list, unsigned long inlen,
                if ((err = der_encode_octet_string(data, size, out + x, &z)) != CRYPT_OK) {
                   goto LBL_ERR;
                }
-               x       += z;
-               *outlen -= z;
                break;
 
            case LTC_ASN1_NULL:
-               out[x++] = 0x05;
-               out[x++] = 0x00;
-               *outlen -= 2;
+               out[x] = 0x05;
+               out[x+1] = 0x00;
+               z = 2;
                break;
 
            case LTC_ASN1_OBJECT_IDENTIFIER:
@@ -272,8 +133,6 @@ int der_encode_sequence_ex(ltc_asn1_list *list, unsigned long inlen,
                if ((err = der_encode_object_identifier(data, size, out + x, &z)) != CRYPT_OK) {
                   goto LBL_ERR;
                }
-               x       += z;
-               *outlen -= z;
                break;
 
            case LTC_ASN1_IA5_STRING:
@@ -281,8 +140,6 @@ int der_encode_sequence_ex(ltc_asn1_list *list, unsigned long inlen,
                if ((err = der_encode_ia5_string(data, size, out + x, &z)) != CRYPT_OK) {
                   goto LBL_ERR;
                }
-               x       += z;
-               *outlen -= z;
                break;
 
            case LTC_ASN1_PRINTABLE_STRING:
@@ -290,8 +147,6 @@ int der_encode_sequence_ex(ltc_asn1_list *list, unsigned long inlen,
                if ((err = der_encode_printable_string(data, size, out + x, &z)) != CRYPT_OK) {
                   goto LBL_ERR;
                }
-               x       += z;
-               *outlen -= z;
                break;
 
            case LTC_ASN1_UTF8_STRING:
@@ -299,8 +154,6 @@ int der_encode_sequence_ex(ltc_asn1_list *list, unsigned long inlen,
                if ((err = der_encode_utf8_string(data, size, out + x, &z)) != CRYPT_OK) {
                   goto LBL_ERR;
                }
-               x       += z;
-               *outlen -= z;
                break;
 
            case LTC_ASN1_UTCTIME:
@@ -308,8 +161,6 @@ int der_encode_sequence_ex(ltc_asn1_list *list, unsigned long inlen,
                if ((err = der_encode_utctime(data, out + x, &z)) != CRYPT_OK) {
                   goto LBL_ERR;
                }
-               x       += z;
-               *outlen -= z;
                break;
 
            case LTC_ASN1_GENERALIZEDTIME:
@@ -317,8 +168,6 @@ int der_encode_sequence_ex(ltc_asn1_list *list, unsigned long inlen,
                if ((err = der_encode_generalizedtime(data, out + x, &z)) != CRYPT_OK) {
                   goto LBL_ERR;
                }
-               x       += z;
-               *outlen -= z;
                break;
 
            case LTC_ASN1_SET:
@@ -326,8 +175,6 @@ int der_encode_sequence_ex(ltc_asn1_list *list, unsigned long inlen,
                if ((err = der_encode_set(data, size, out + x, &z)) != CRYPT_OK) {
                   goto LBL_ERR;
                }
-               x       += z;
-               *outlen -= z;
                break;
 
            case LTC_ASN1_SETOF:
@@ -335,8 +182,6 @@ int der_encode_sequence_ex(ltc_asn1_list *list, unsigned long inlen,
                if ((err = der_encode_setof(data, size, out + x, &z)) != CRYPT_OK) {
                   goto LBL_ERR;
                }
-               x       += z;
-               *outlen -= z;
                break;
 
            case LTC_ASN1_SEQUENCE:
@@ -344,8 +189,6 @@ int der_encode_sequence_ex(ltc_asn1_list *list, unsigned long inlen,
                if ((err = der_encode_sequence_ex(data, size, out + x, &z, type)) != CRYPT_OK) {
                   goto LBL_ERR;
                }
-               x       += z;
-               *outlen -= z;
                break;
 
            case LTC_ASN1_CHOICE:
@@ -356,6 +199,9 @@ int der_encode_sequence_ex(ltc_asn1_list *list, unsigned long inlen,
                err = CRYPT_INVALID_ARG;
                goto LBL_ERR;
        }
+
+       x       += z;
+       *outlen -= z;
    }
    *outlen = x;
    err = CRYPT_OK;

--- a/src/pk/asn1/der/sequence/der_length_sequence.c
+++ b/src/pk/asn1/der/sequence/der_length_sequence.c
@@ -25,9 +25,15 @@
 int der_length_sequence(ltc_asn1_list *list, unsigned long inlen,
                         unsigned long *outlen)
 {
+   return der_length_sequence_ex(list, inlen, outlen, NULL);
+}
+
+int der_length_sequence_ex(ltc_asn1_list *list, unsigned long inlen,
+                           unsigned long *outlen, unsigned long *payloadlen)
+{
    int           err;
    ltc_asn1_type type;
-   unsigned long size, x, y, i;
+   unsigned long size, x, y, i, z;
    void          *data;
 
    LTC_ARGCHK(list    != NULL);
@@ -154,6 +160,7 @@ int der_length_sequence(ltc_asn1_list *list, unsigned long inlen,
    }
 
    /* calc header size */
+   z = y;
    if (y < 128) {
       y += 2;
    } else if (y < 256) {
@@ -171,6 +178,7 @@ int der_length_sequence(ltc_asn1_list *list, unsigned long inlen,
    }
 
    /* store size */
+   if (payloadlen) *payloadlen = z;
    *outlen = y;
    err     = CRYPT_OK;
 


### PR DESCRIPTION
As mentioned in https://github.com/libtom/libtomcrypt/pull/187#discussion_r123453123

The motivation is to make rebasing of ECC branches a bit smoother.