### PR TITLE
fix warning: missing braces around initializer (gcc3)

### DIFF
--- a/demos/timing.c
+++ b/demos/timing.c
@@ -697,7 +697,7 @@ static void time_rsa(void)
 {
    rsa_key       key;
    ulong64       t1, t2;
-   unsigned char buf[2][2048] = { 0 };
+   unsigned char buf[2][2048] = { { 0 } };
    unsigned long x, y, z, zzz;
    int           err, zz, stat;
 
@@ -923,7 +923,7 @@ static void time_ecc(void)
 {
    ecc_key key;
    ulong64 t1, t2;
-   unsigned char buf[2][256] = { 0 };
+   unsigned char buf[2][256] = { { 0 } };
    unsigned long i, w, x, y, z;
    int           err, stat;
    static unsigned long sizes[] = {


### PR DESCRIPTION
just cosmetics

the warning was:
```
cc -O2 -DUSE_LTM -DLTM_DESC -I../libtommath -Werror -Wall -Isrc/headers -Itests -DLTC_SOURCE -c demos/timing.c -o demos/timing.o
demos/timing.c: In function `time_rsa':
demos/timing.c:700: warning: missing braces around initializer
demos/timing.c:700: warning: (near initialization for `buf[0]')
demos/timing.c: In function `time_ecc':
demos/timing.c:926: warning: missing braces around initializer
demos/timing.c:926: warning: (near initialization for `buf[0]')
*** Error code 1
```