### PR TITLE
GCM allow skipping gcm_add_aad and gcm_process

### DIFF
--- a/src/encauth/gcm/gcm_done.c
+++ b/src/encauth/gcm/gcm_done.c
@@ -40,6 +40,15 @@ int gcm_done(gcm_state *gcm,
       return err;
    }
 
+   if (gcm->mode == LTC_GCM_MODE_IV) {
+      /* let's process the IV */
+      if ((err = gcm_add_aad(gcm, NULL, 0)) != CRYPT_OK) return err;
+   }
+
+   if (gcm->mode == LTC_GCM_MODE_AAD) {
+      /* let's process the AAD */
+      if ((err = gcm_process(gcm, NULL, 0, NULL, 0)) != CRYPT_OK) return err;
+   }
 
    if (gcm->mode != LTC_GCM_MODE_TEXT) {
       return CRYPT_INVALID_ARG;

--- a/src/encauth/gcm/gcm_process.c
+++ b/src/encauth/gcm/gcm_process.c
@@ -52,6 +52,11 @@ int gcm_process(gcm_state *gcm,
       return CRYPT_INVALID_ARG;
    }
 
+   if (gcm->mode == LTC_GCM_MODE_IV) {
+      /* let's process the IV */
+      if ((err = gcm_add_aad(gcm, NULL, 0)) != CRYPT_OK) return err;
+   }
+
    /* in AAD mode? */
    if (gcm->mode == LTC_GCM_MODE_AAD) {
       /* let's process the AAD */

--- a/src/encauth/gcm/gcm_test.c
+++ b/src/encauth/gcm/gcm_test.c
@@ -325,6 +325,7 @@ int gcm_test(void)
    int           idx, err;
    unsigned long x, y;
    unsigned char out[2][128], T[2][16];
+   gcm_state gcm;
 
    /* find aes */
    idx = find_cipher("aes");
@@ -334,6 +335,15 @@ int gcm_test(void)
          return CRYPT_NOP;
       }
    }
+
+   /* Special test case for empty AAD + empty PT */
+   y = sizeof(T[0]);
+   if ((err = gcm_init(&gcm, idx, tests[0].K, tests[0].keylen)) != CRYPT_OK) return err;
+   if ((err = gcm_add_iv(&gcm, tests[0].IV, tests[0].IVlen)) != CRYPT_OK)    return err;
+   /* intentionally skip gcm_add_aad + gcm_process */
+   if ((err = gcm_done(&gcm, T[0], &y)) != CRYPT_OK)                         return err;
+   if (compare_testvector(out[0], 0, tests[0].C, tests[0].ptlen, "GCM CT-special", 0)) return CRYPT_FAIL_TESTVECTOR;
+   if (compare_testvector(T[0], y, tests[0].T, 16, "GCM Encrypt Tag-special", 0))      return CRYPT_FAIL_TESTVECTOR;
 
    for (x = 0; x < (int)(sizeof(tests)/sizeof(tests[0])); x++) {
        y = sizeof(T[0]);


### PR DESCRIPTION
This patch is a by-product of fixing issues related to my perl bindings:
* https://github.com/DCIT/perl-CryptX/issues/36
* https://github.com/DCIT/perl-CryptX/issues/37

Current implementation strictly requires to call `gcm_add_aad` and `gcm_process` even if there is no AAD and no plain/cipher text to process.

With this patch you can skip calling `gcm_add_aad` if you do not want to add any additional authenticated data (and similarly  `gcm_process`).

No need to add this to 1.18