### PR TITLE
make it possible to 'make all' w/o an MPI provider

### DIFF
--- a/demos/timing.c
+++ b/demos/timing.c
@@ -520,8 +520,11 @@ static void time_hash(void)
 }
 
 /*#warning you need an mp_rand!!!*/
-#ifndef USE_LTM
+#if !defined(USE_LTM) && !defined(USE_TFM) && !defined(USE_GMP) && !defined(EXT_MATH_LIB)
   #undef LTC_MPI
+  #undef LTC_TEST_MPI
+#else
+  #define LTC_TEST_MPI
 #endif
 
 #ifdef LTC_MPI
@@ -642,7 +645,7 @@ static void time_prng(void)
    }
 }
 
-#ifdef LTC_MDSA
+#if defined(LTC_MDSA) && defined(LTC_TEST_MPI)
 /* time various DSA operations */
 static void time_dsa(void)
 {
@@ -695,7 +698,7 @@ static void time_dsa(void) { fprintf(stderr, "NO DSA\n"); }
 #endif
 
 
-#ifdef LTC_MRSA
+#if defined(LTC_MRSA) && defined(LTC_TEST_MPI)
 /* time various RSA operations */
 static void time_rsa(void)
 {
@@ -819,7 +822,7 @@ static void time_rsa(void)
 static void time_rsa(void) { fprintf(stderr, "NO RSA\n"); }
 #endif
 
-#ifdef LTC_MKAT
+#if defined(LTC_MKAT) && defined(LTC_TEST_MPI)
 /* time various KAT operations */
 static void time_katja(void)
 {
@@ -889,7 +892,7 @@ static void time_katja(void)
 static void time_katja(void) { fprintf(stderr, "NO Katja\n"); }
 #endif
 
-#ifdef LTC_MDH
+#if defined(LTC_MDH) && defined(LTC_TEST_MPI)
 /* time various DH operations */
 static void time_dh(void)
 {
@@ -926,7 +929,7 @@ static void time_dh(void)
 static void time_dh(void) { fprintf(stderr, "NO DH\n"); }
 #endif
 
-#ifdef LTC_MECC
+#if defined(LTC_MECC) && defined(LTC_TEST_MPI)
 /* time various ECC operations */
 static void time_ecc(void)
 {
@@ -1427,9 +1430,11 @@ register_all_prngs();
    ltc_mp = tfm_desc;
 #elif defined(USE_GMP)
    ltc_mp = gmp_desc;
-#else
-   extern ltc_math_descriptor EXT_MATH_LIB;
-   ltc_mp = EXT_MATH_LIB;
+#elif defined(EXT_MATH_LIB)
+   {
+      extern ltc_math_descriptor EXT_MATH_LIB;
+      ltc_mp = EXT_MATH_LIB;
+   }
 #endif
 
 if ((err = rng_make_prng(128, find_prng("yarrow"), &yarrow_prng, NULL)) != CRYPT_OK) {

--- a/tests/der_test.c
+++ b/tests/der_test.c
@@ -11,7 +11,7 @@
 #include <gmp.h>
 #endif
 
-#ifndef LTC_DER
+#if !defined(LTC_DER) || !defined(LTC_TEST_MPI)
 
 int der_test(void)
 {

--- a/tests/dh_test.c
+++ b/tests/dh_test.c
@@ -8,7 +8,7 @@
  */
 #include <tomcrypt_test.h>
 
-#ifdef LTC_MDH
+#if defined(LTC_MDH) && defined(LTC_TEST_MPI)
 
 #ifdef LTC_DH4096
 #define KEYSIZE 4096

--- a/tests/dsa_test.c
+++ b/tests/dsa_test.c
@@ -8,7 +8,7 @@
  */
 #include <tomcrypt_test.h>
 
-#ifdef LTC_MDSA
+#if defined(LTC_MDSA) && defined(LTC_TEST_MPI)
 
 /* This is the private key from test_dsa.key */
 static const unsigned char openssl_priv_dsa[] = {

--- a/tests/ecc_test.c
+++ b/tests/ecc_test.c
@@ -8,7 +8,7 @@
  */
 #include <tomcrypt_test.h>
 
-#ifdef LTC_MECC
+#if defined(LTC_MECC) && defined(LTC_TEST_MPI)
 
 static unsigned int sizes[] = {
 #ifdef LTC_ECC112

--- a/tests/katja_test.c
+++ b/tests/katja_test.c
@@ -8,7 +8,7 @@
  */
 #include <tomcrypt_test.h>
 
-#ifdef LTC_MKAT
+#if defined(LTC_MKAT) && defined(LTC_TEST_MPI)
 
 int katja_test(void)
 {

--- a/tests/mpi_test.c
+++ b/tests/mpi_test.c
@@ -8,7 +8,7 @@
  */
 #include  <tomcrypt_test.h>
 
-#ifdef LTC_MPI
+#if defined(LTC_MPI) && defined(LTC_TEST_MPI)
 static int _radix_to_bin_test(void)
 {
    /* RADIX 16 */

--- a/tests/pkcs_1_eme_test.c
+++ b/tests/pkcs_1_eme_test.c
@@ -8,7 +8,7 @@
  */
 #include <tomcrypt_test.h>
 
-#ifdef LTC_PKCS_1
+#if defined(LTC_PKCS_1) && defined(LTC_TEST_MPI)
 
 #include "../notes/rsa-testvectors/pkcs1v15crypt-vectors.c"
 

--- a/tests/pkcs_1_emsa_test.c
+++ b/tests/pkcs_1_emsa_test.c
@@ -8,7 +8,7 @@
  */
 #include <tomcrypt_test.h>
 
-#ifdef LTC_PKCS_1
+#if defined(LTC_PKCS_1) && defined(LTC_TEST_MPI)
 
 #include "../notes/rsa-testvectors/pkcs1v15sign-vectors.c"
 

--- a/tests/pkcs_1_oaep_test.c
+++ b/tests/pkcs_1_oaep_test.c
@@ -8,7 +8,7 @@
  */
 #include <tomcrypt_test.h>
 
-#ifdef LTC_PKCS_1
+#if defined(LTC_PKCS_1) && defined(LTC_TEST_MPI)
 
 #include "../notes/rsa-testvectors/oaep-vect.c"
 

--- a/tests/pkcs_1_pss_test.c
+++ b/tests/pkcs_1_pss_test.c
@@ -8,7 +8,7 @@
  */
 #include <tomcrypt_test.h>
 
-#ifdef LTC_PKCS_1
+#if defined(LTC_PKCS_1) && defined(LTC_TEST_MPI)
 
 #include "../notes/rsa-testvectors/pss-vect.c"
 

--- a/tests/rsa_test.c
+++ b/tests/rsa_test.c
@@ -8,7 +8,7 @@
  */
 #include <tomcrypt_test.h>
 
-#ifdef LTC_MRSA
+#if defined(LTC_MRSA) && defined(LTC_TEST_MPI)
 
 #define RSA_MSGSIZE 78
 

--- a/tests/test.c
+++ b/tests/test.c
@@ -313,12 +313,24 @@ int main(int argc, char **argv)
 #elif defined(USE_GMP)
    ltc_mp = gmp_desc;
    printf("math provider = gnump\n");
-#else
-   extern ltc_math_descriptor EXT_MATH_LIB;
-   ltc_mp = EXT_MATH_LIB;
-   printf("math provider = EXT_MATH_LIB\n");
+#elif defined(EXT_MATH_LIB)
+   {
+      extern ltc_math_descriptor EXT_MATH_LIB;
+      ltc_mp = EXT_MATH_LIB;
+   }
+
+#define NAME_VALUE(s) #s"="NAME(s)
+#define NAME(s) #s
+   printf("math provider = %s\n", NAME_VALUE(EXT_MATH_LIB));
+#undef NAME_VALUE
+#undef NAME
+
 #endif
+#ifdef LTC_TEST_MPI
    printf("MP_DIGIT_BIT = %d\n", MP_DIGIT_BIT);
+#else
+   printf("NO math provider selected, all tests requiring MPI were disabled and will 'nop'\n");
+#endif
 
 
 #ifdef LTC_PTHREAD

--- a/tests/tomcrypt_test.h
+++ b/tests/tomcrypt_test.h
@@ -16,21 +16,16 @@
 
 #ifdef USE_LTM
 /* Use libtommath as MPI provider */
+#define LTC_TEST_MPI
 #elif defined(USE_TFM)
 /* Use tomsfastmath as MPI provider */
+#define LTC_TEST_MPI
 #elif defined(USE_GMP)
 /* Use GNU Multiple Precision Arithmetic Library as MPI provider */
-#else
+#define LTC_TEST_MPI
+#elif defined(EXT_MATH_LIB)
 /* The user must define his own MPI provider! */
-#ifndef EXT_MATH_LIB
-/*
- * Yes, you're right, you could also name your instance of the MPI provider
- * "EXT_MATH_LIB" and you wouldn't need to define it, but most users won't do
- * this and so it's treated as an error and you have to comment out the
- * following statement :)
- */
-#error One of USE_LTM, USE_TFM, USE_GMP and EXT_MATH_LIB is required to be defined
-#endif
+#define LTC_TEST_MPI
 #endif
 
 typedef struct {


### PR DESCRIPTION
As there were issues where people mentioned that `make all` can't build w/o MPI provider I decided to fix it like that.
Feel free to add your comments. ideas and/or opinions to this PR.