### PR TITLE
special makefiles: add targets for sizes and constants demos

### DIFF
--- a/makefile.mingw
+++ b/makefile.mingw
@@ -248,6 +248,10 @@ small.exe: demos/small.o $(LIBMAIN_S)
 	$(CC) demos/small.o $(LIBMAIN_S) $(LTC_LDFLAGS) -o $@
 tv_gen.exe: demos/tv_gen.o $(LIBMAIN_S)
 	$(CC) demos/tv_gen.o $(LIBMAIN_S) $(LTC_LDFLAGS) -o $@
+sizes.exe: demos/sizes.o $(LIBMAIN_S)
+	$(CC) demos/sizes.o $(LIBMAIN_S) $(LTC_LDFLAGS) -o $@
+constants.exe: demos/constants.o $(LIBMAIN_S)
+	$(CC) demos/constants.o $(LIBMAIN_S) $(LTC_LDFLAGS) -o $@
 timing.exe: demos/timing.o $(LIBMAIN_S)
 	$(CC) demos/timing.o $(LIBMAIN_S) $(LTC_LDFLAGS) -o $@
 
@@ -256,7 +260,7 @@ test.exe: $(TOBJECTS) $(LIBMAIN_S)
 	$(CC) $(TOBJECTS) $(LIBMAIN_S) $(LTC_LDFLAGS) -o $@
 	@echo NOTICE: start the tests by launching test.exe
 
-all: $(LIBMAIN_S) $(LIBMAIN_I) $(LIBMAIN_D) hashsum.exe ltcrypt.exe small.exe tv_gen.exe timing.exe test.exe
+all: $(LIBMAIN_S) $(LIBMAIN_I) $(LIBMAIN_D) hashsum.exe ltcrypt.exe small.exe tv_gen.exe sizes.exe constants.exe timing.exe test.exe
 
 test: test.exe
 

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -235,6 +235,10 @@ small.exe: demos/small.c $(LIBMAIN_S)
 	cl $(LTC_CFLAGS) demos/small.c tests/common.c $(LIBMAIN_S) $(LTC_LDFLAGS) /Fe$@
 tv_gen.exe: demos/tv_gen.c $(LIBMAIN_S)
 	cl $(LTC_CFLAGS) demos/tv_gen.c tests/common.c $(LIBMAIN_S) $(LTC_LDFLAGS) /Fe$@
+sizes.exe: demos/sizes.c $(LIBMAIN_S)
+	cl $(LTC_CFLAGS) demos/sizes.c tests/common.c $(LIBMAIN_S) $(LTC_LDFLAGS) /Fe$@
+constants.exe: demos/constants.c $(LIBMAIN_S)
+	cl $(LTC_CFLAGS) demos/constants.c tests/common.c $(LIBMAIN_S) $(LTC_LDFLAGS) /Fe$@
 timing.exe: demos/timing.c $(LIBMAIN_S)
 	cl $(LTC_CFLAGS) demos/timing.c tests/common.c $(LIBMAIN_S) $(LTC_LDFLAGS) /Fe$@
 
@@ -243,7 +247,7 @@ test.exe: $(LIBMAIN_S) $(TOBJECTS)
 	cl $(LTC_CFLAGS) $(TOBJECTS) $(LIBMAIN_S) $(LTC_LDFLAGS) /Fe$@
 	@echo NOTICE: start the tests by launching test.exe
 
-all: $(LIBMAIN_S) hashsum.exe ltcrypt.exe small.exe tv_gen.exe timing.exe test.exe
+all: $(LIBMAIN_S) hashsum.exe ltcrypt.exe small.exe tv_gen.exe sizes.exe constants.exe timing.exe test.exe
 
 test: test.exe
 

--- a/makefile.unix
+++ b/makefile.unix
@@ -255,6 +255,10 @@ small: demos/small.o $(LIBMAIN_S)
 	$(CC) demos/small.o $(LIBMAIN_S) $(LTC_LDFLAGS) -o $@
 tv_gen: demos/tv_gen.o $(LIBMAIN_S)
 	$(CC) demos/tv_gen.o $(LIBMAIN_S) $(LTC_LDFLAGS) -o $@
+sizes: demos/sizes.o $(LIBMAIN_S)
+	$(CC) demos/sizes.o $(LIBMAIN_S) $(LTC_LDFLAGS) -o $@
+constants: demos/constants.o $(LIBMAIN_S)
+	$(CC) demos/constants.o $(LIBMAIN_S) $(LTC_LDFLAGS) -o $@
 timing: demos/timing.o $(LIBMAIN_S)
 	$(CC) demos/timing.o $(LIBMAIN_S) $(LTC_LDFLAGS) -o $@
 
@@ -263,15 +267,15 @@ test: $(TOBJECTS) $(LIBMAIN_S)
 	$(CC) $(TOBJECTS) $(LIBMAIN_S) $(LTC_LDFLAGS) -o $@
 	@echo "NOTICE: start the tests by: ./test"
 
-all: $(LIBMAIN_S) hashsum ltcrypt small tv_gen timing test
+all: $(LIBMAIN_S) hashsum ltcrypt small tv_gen sizes constants timing test
 
 #NOTE: this makefile works also on cygwin, thus we need to delete *.exe
 clean:
 	-@rm -f $(OBJECTS) $(TOBJECTS)
 	-@rm -f $(LIBMAIN_S)
 	-@rm -f demos/*.o *_tv.txt
-	-@rm -f test tv_gen hashsum ltcrypt small timing
-	-@rm -f test.exe tv_gen.exe hashsum.exe ltcrypt.exe small.exe timing.exe
+	-@rm -f test constants sizes tv_gen hashsum ltcrypt small timing
+	-@rm -f test.exe constants.exe sizes.exe tv_gen.exe hashsum.exe ltcrypt.exe small.exe timing.exe
 
 #Install the library + headers
 install: $(LIBMAIN_S) $(HEADERS)


### PR DESCRIPTION
How about adding the `sizes` and `constants` demos to the generic `makefile.unix`, to keep it on par with the main `makefile`?

I tested this on macOS 10.12.6, and it seems to work.

```
[~/local/repos/libtomcrypt on ⇄ develop ±]
$ make -f makefile.unix EXTRALIBS=/usr/local/lib/libtommath.a sizes
cc -O2 -DUSE_LTM -DLTM_DESC -I../libtommath -Isrc/headers -Itests -DLTC_SOURCE -c demos/sizes.c -o demos/sizes.o
cc demos/sizes.o libtomcrypt.a  /usr/local/lib/libtommath.a -o sizes
[~/local/repos/libtomcrypt on ⇄ develop ±]
$ ./sizes

  size of 'ecc_key' is 48

  need to allocate 1151 bytes

  supported sizes:

ltc_hash_descriptor,208
hash_state,416
[...]
$ make -f makefile.unix EXTRALIBS=/usr/local/lib/libtommath.a constants
cc -O2 -DUSE_LTM -DLTM_DESC -I../libtommath -Isrc/headers -Itests -DLTC_SOURCE -c demos/constants.c -o demos/constants.o
cc demos/constants.o libtomcrypt.a  /usr/local/lib/libtommath.a -o constants
[~/local/repos/libtomcrypt on ⇄ add-sizes-and-constants-demo-targets ±]
$ ./constants

  CTR_COUNTER_BIG_ENDIAN is 4096

  need to allocate 627 bytes

  supported constants:

PK_PUBLIC,0
PK_PRIVATE,1
PKA_RSA,0
[...]
```