### PR TITLE
initialize ltc_mp to fix build on clang/macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ There are several `makefile`s provided. Please choose the one that fits best for
 
 | makefile | use-case |
 | -------- | -------- |
-| `makefile` | builds a static library (GNU Make required, broken on Mac OSX - use `makefile.unix` instead) |
+| `makefile` | builds a static library (GNU Make required) |
 | `makefile.shared` | builds a shared (and static) library (GNU Make required) |
 | `makefile.unix` | for unusual UNIX platforms, or if you do not have GNU Make |
 | `makefile.mingw` | for usage with the mingw compiler on MS Windows |

--- a/makefile
+++ b/makefile
@@ -15,12 +15,6 @@ endif
 
 PLATFORM := $(shell uname | sed -e 's/_.*//')
 
-ifneq ($(MAKECMDGOALS),clean)
-ifeq ($(PLATFORM), Darwin)
-$(error Known to not work on Mac, please use makefile.unix for static libraries or makefile.shared for shared libraries)
-endif
-endif
-
 # ranlib tools
 ifndef RANLIB
 RANLIB:=$(CROSS_COMPILE)ranlib

--- a/src/misc/crypt/crypt_ltc_mp_descriptor.c
+++ b/src/misc/crypt/crypt_ltc_mp_descriptor.c
@@ -8,7 +8,8 @@
  */
 #include "tomcrypt.h"
 
-ltc_math_descriptor ltc_mp;
+/* Initialize ltc_mp to nulls, to force allocation on all platforms, including macOS. */
+ltc_math_descriptor ltc_mp = { 0 };
 
 /* ref:         $Format:%D$ */
 /* git commit:  $Format:%H$ */


### PR DESCRIPTION
Fixes #281.

This adds an initializer to the `ltc_tmp` definition to force it to be allocated by all compilers. Seems like `clang` on macOS is leaving it unallocated, leading to link failures when building a program that actually tries to use it.