### PR TITLE
Fix typos in makefile.shared help

### DIFF
--- a/makefile.shared
+++ b/makefile.shared
@@ -59,14 +59,14 @@ endef
 
 $(foreach demo, $(strip $(DEMOS)), $(eval $(call DEMO_template,$(demo))))
 
-install: $(call print-help,install,Installs the library, headers and pkd-config file) .common_install
+install: $(call print-help,install,Installs the library + headers + pkg-config file) .common_install
 	sed -e 's,^prefix=.*,prefix=$(PREFIX),' -e 's,^Version:.*,Version: $(VERSION_PC),' libtomcrypt.pc.in > libtomcrypt.pc
 	install -d $(DESTDIR)$(LIBPATH)/pkgconfig
 	install -m 644 libtomcrypt.pc $(DESTDIR)$(LIBPATH)/pkgconfig/
 
 install_bins: $(call print-help,install_bins,Installs the useful demos ($(USEFUL_DEMOS))) .common_install_bins
 
-uninstall: $(call print-help,uninstall,Uninstalls the library, headers and pkd-config file) .common_uninstall
+uninstall: $(call print-help,uninstall,Uninstalls the library + headers + pkg-config file) .common_uninstall
 	rm $(DESTDIR)$(LIBPATH)/pkgconfig/libtomcrypt.pc
 
 # ref:         $Format:%D$


### PR DESCRIPTION
This fixes a couple typos in the "help" info in `makefile.shared`.

It protects commas using variable substitution; otherwise, they are interpreted as separating function parameters. It also fixes a typo for "pkg-config".

Before comma protection:

```
$ make -f makefile.shared help
...
install -- Installs the library
...
uninstall -- Uninstalls the library
```

After comma protection:

```
$ make -f makefile.shared help
...
install -- Installs the library, headers and pkd-config file
...
uninstall -- Uninstalls the library, headers and pkd-config file
```

This approach is recommended by the GNU Make manual: https://www.gnu.org/software/make/manual/html_node/Syntax-of-Functions.html.


And then a fix to a typo for "pkg-config":

```
install -- Installs the library, headers and pkg-config file
...
uninstall -- Uninstalls the library, headers and pkg-config file
```