### PR TITLE
Add -Wwrite-strings (char* vs. const char*)

### DIFF
--- a/makefile_include.mk
+++ b/makefile_include.mk
@@ -70,6 +70,7 @@ LTC_CFLAGS += -Wextra
 LTC_CFLAGS += -Wsystem-headers -Wbad-function-cast -Wcast-align
 LTC_CFLAGS += -Wstrict-prototypes -Wpointer-arith
 LTC_CFLAGS += -Wdeclaration-after-statement
+LTC_CFLAGS += -Wwrite-strings
 endif
 
 LTC_CFLAGS += -Wno-type-limits

--- a/src/headers/tomcrypt_argchk.h
+++ b/src/headers/tomcrypt_argchk.h
@@ -20,7 +20,7 @@
 #define NORETURN
 #endif
 
-void crypt_argchk(char *v, char *s, int d) NORETURN;
+void crypt_argchk(const char *v, const char *s, int d) NORETURN;
 #define LTC_ARGCHK(x) do { if (!(x)) { crypt_argchk(#x, __FILE__, __LINE__); } }while(0)
 #define LTC_ARGCHKVD(x) do { if (!(x)) { crypt_argchk(#x, __FILE__, __LINE__); } }while(0)
 

--- a/src/headers/tomcrypt_cipher.h
+++ b/src/headers/tomcrypt_cipher.h
@@ -349,7 +349,7 @@ typedef struct {
 /** cipher descriptor table, last entry has "name == NULL" to mark the end of table */
 extern struct ltc_cipher_descriptor {
    /** name of cipher */
-   char *name;
+   const char *name;
    /** internal ID */
    unsigned char ID;
    /** min keysize (octets) */

--- a/src/headers/tomcrypt_hash.h
+++ b/src/headers/tomcrypt_hash.h
@@ -204,7 +204,7 @@ typedef union Hash_state {
 /** hash descriptor */
 extern  struct ltc_hash_descriptor {
     /** name of hash */
-    char *name;
+    const char *name;
     /** internal ID */
     unsigned char ID;
     /** Size of digest in octets */

--- a/src/headers/tomcrypt_math.h
+++ b/src/headers/tomcrypt_math.h
@@ -35,7 +35,7 @@ int radix_to_bin(const void *in, int radix, void *out, unsigned long *len);
 /** math descriptor */
 typedef struct {
    /** Name of the math provider */
-   char *name;
+   const char *name;
 
    /** Bits per digit, amount of bits must fit in an unsigned long */
    int  bits_per_digit;

--- a/src/headers/tomcrypt_pk.h
+++ b/src/headers/tomcrypt_pk.h
@@ -230,7 +230,7 @@ int dh_export_key(void *out, unsigned long *outlen, int type, dh_key *key);
 #ifdef LTC_SOURCE
 typedef struct {
   int size;
-  char *name, *base, *prime;
+  const char *name, *base, *prime;
 } ltc_dh_set_type;
 
 extern const ltc_dh_set_type ltc_dh_sets[];
@@ -257,22 +257,22 @@ typedef struct {
    int size;
 
    /** name of curve */
-   char *name;
+   const char *name;
 
    /** The prime that defines the field the curve is in (encoded in hex) */
-   char *prime;
+   const char *prime;
 
    /** The fields B param (hex) */
-   char *B;
+   const char *B;
 
    /** The order of the curve (hex) */
-   char *order;
+   const char *order;
 
    /** The x co-ordinate of the base point on the curve (hex) */
-   char *Gx;
+   const char *Gx;
 
    /** The y co-ordinate of the base point on the curve (hex) */
-   char *Gy;
+   const char *Gy;
 } ltc_ecc_set_type;
 
 /** A point on a ECC curve, stored in Jacbobian format such that (x,y,z) => (x/z^2, y/z^3, 1) when interpretted as affine */

--- a/src/headers/tomcrypt_prng.h
+++ b/src/headers/tomcrypt_prng.h
@@ -81,7 +81,7 @@ typedef struct {
 /** PRNG descriptor */
 extern struct ltc_prng_descriptor {
     /** Name of the PRNG */
-    char *name;
+    const char *name;
     /** size in bytes of exported state */
     int  export_size;
     /** Start a PRNG state

--- a/src/misc/crypt/crypt_argchk.c
+++ b/src/misc/crypt/crypt_argchk.c
@@ -14,7 +14,7 @@
 */
 
 #if (ARGTYPE == 0)
-void crypt_argchk(char *v, char *s, int d)
+void crypt_argchk(const char *v, const char *s, int d)
 {
  fprintf(stderr, "LTC_ARGCHK '%s' failure on line %d of file %s\n",
          v, d, s);


### PR DESCRIPTION
This PR fixes warnings which appeared after turning on `-Wwrite-strings`.

But frankly, I am not sure whether we want or need to apply this.