### PR TITLE
Improve MPI provider selection

### DIFF
--- a/demos/timing.c
+++ b/demos/timing.c
@@ -1399,45 +1399,6 @@ static void time_encmacs(void)
    time_encmacs_(32);
 }
 
-static void init_mpi(const char* mpi)
-{
-   switch (mpi[0]) {
-#ifdef LTM_DESC
-      case 'l':
-         init_LTM();
-         break;
-#endif
-#ifdef TFM_DESC
-      case 't':
-         init_TFM();
-         break;
-#endif
-#ifdef GMP_DESC
-      case 'g':
-         init_GMP();
-         break;
-#endif
-#ifdef EXT_MATH_LIB
-      case 'e':
-         {
-            extern ltc_math_descriptor EXT_MATH_LIB;
-            ltc_mp = EXT_MATH_LIB;
-         }
-
-#define NAME_VALUE(s) #s"="NAME(s)
-#define NAME(s) #s
-         printf("EXT_MATH_LIB = %s\n", NAME_VALUE(EXT_MATH_LIB));
-#undef NAME_VALUE
-#undef NAME
-
-         break;
-#endif
-      default:
-         printf("Unknown/Invalid MPI provider: %s\n", mpi);
-         break;
-   }
-}
-
 #define LTC_TEST_FN(f)  { f, #f }
 int main(int argc, char **argv)
 {
@@ -1488,7 +1449,7 @@ register_all_prngs();
       mpi_provider = argv[2];
    }
 
-   init_mpi(mpi_provider);
+   crypt_mp_init(mpi_provider);
 
 if ((err = rng_make_prng(128, find_prng("yarrow"), &yarrow_prng, NULL)) != CRYPT_OK) {
    fprintf(stderr, "rng_make_prng failed: %s\n", error_to_string(err));

--- a/doc/crypt.tex
+++ b/doc/crypt.tex
@@ -6539,29 +6539,36 @@ int crypt_list_all_constants(        char *names_list,
                              unsigned int *names_list_size);
 \end{verbatim}
 You may want to call these functions twice, first to get the amount
-of memory to be allocated for the $names_list$, and a final time to
-actually populate $names_list$.  If $names_list$ is NULL,
-$names_list_size$ will be the minimum size needed to receive the
-complete $names_list$.  If $names_list$ is NOT NULL, $names_list$ must
-be a pointer to sufficient memory into which the $names_list$ will be
-written.  Also, the value in $names_list_size$ sets the upper bound of
+of memory to be allocated for the $names\_list$, and a final time to
+actually populate $names\_list$.  If $names\_list$ is NULL,
+$names\_list\_size$ will be the minimum size needed to receive the
+complete $names\_list$.  If $names\_list$ is NOT NULL, $names\_list$ must
+be a pointer to sufficient memory into which the $names\_list$ will be
+written.  Also, the value in $names\_list\_size$ sets the upper bound of
 the number of characters to be written.  A -1 return value signifies
 insufficient space.
 
-The format of the $names_list$ string is a series of $name,value$ pairs
+The format of the $names\_list$ string is a series of $name,value$ pairs
 where each name and value is separated by a comma, the pairs are separated
 by newlines, and the list is null terminated.
 
-Calling either of these functions will initialize the respective
-math library.
+\index{crypt\_mp\_init()}
 \begin{verbatim}
-void init_LTM(void);
-void init_TFM(void);
-void init_GMP(void);
+int crypt_mp_init(const char* mpi);
 \end{verbatim}
+
+To ease the setup of a specific math descriptor, in cases where the library was compiled with support for multiple MPI libraries,
+the function \textit{crypt\_mp\_init()} is provided.
+It takes a string to the desired MPI library to use as an argument.
+The three default MPI libraries are identified as follows, \textit{LibTomMath} as \texttt{"ltm"}, \textit{TomsFastmath} as \texttt{"tfm"}
+and the \textit{GNU Multi Precision Arithmetic Library} as \texttt{"gmp"}.
+The identification happens case-insensitive and only on the first character.
 
 Here is a Python program demonstrating how to call various LTC dynamic
 language support functions.
+
+A more detailed example is given in the library source in \texttt{demos/demo\_dynamic.py}.
+
 \begin{verbatim}
 from ctypes import *
 
@@ -8254,6 +8261,20 @@ to the \textit{out} buffer.  The output must be zero padded (leading bytes) so t
 for RSA--1024 the output is always 128 bytes regardless of how small the numerical value of the exponentiation is.
 
 Since the function is given the entire RSA key (for private keys only) CRT is possible as prescribed in the PKCS \#1 v2.1 specification.
+
+
+\mysection{Deprecated API functions}
+
+\subsection{After v1.18.0}
+
+\index{init\_LTM()} \index{init\_TFM()} \index{init\_GMP()}
+\begin{verbatim}
+void init_LTM(void);
+void init_TFM(void);
+void init_GMP(void);
+\end{verbatim}
+
+These three MPI init functions have been introduced in version 1.18.0 and have been deprecated in the same version in favor of \textit{crypt\_mp\_init()}.
 
 \newpage
 \markboth{Index}{Index}

--- a/src/headers/tomcrypt_cfg.h
+++ b/src/headers/tomcrypt_cfg.h
@@ -277,6 +277,15 @@ typedef unsigned long ltc_mp_digit;
    #define LTC_HAVE_BSWAP_BUILTIN
 #endif
 
+#ifdef __GNUC__
+   #define LTC_DEPRECATED __attribute__((deprecated))
+#elif defined(_MSC_VER)
+   #define LTC_DEPRECATED __declspec(deprecated)
+#endif
+
+#ifndef LTC_DEPRECATED
+   #error "You need to define LTC_DEPRECATED for this compiler"
+#endif
 
 /* ref:         $Format:%D$ */
 /* git commit:  $Format:%H$ */

--- a/src/headers/tomcrypt_cfg.h
+++ b/src/headers/tomcrypt_cfg.h
@@ -277,14 +277,12 @@ typedef unsigned long ltc_mp_digit;
    #define LTC_HAVE_BSWAP_BUILTIN
 #endif
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 301)
    #define LTC_DEPRECATED __attribute__((deprecated))
 #elif defined(_MSC_VER)
    #define LTC_DEPRECATED __declspec(deprecated)
-#endif
-
-#ifndef LTC_DEPRECATED
-   #error "You need to define LTC_DEPRECATED for this compiler"
+#else
+   #define LTC_DEPRECATED
 #endif
 
 /* ref:         $Format:%D$ */

--- a/src/headers/tomcrypt_misc.h
+++ b/src/headers/tomcrypt_misc.h
@@ -81,6 +81,7 @@ void init_TFM(void);
 #ifdef GMP_DESC
 void init_GMP(void);
 #endif
+int crypt_mp_init(const char* mpi);
 
 #ifdef LTC_ADLER32
 typedef struct adler32_state_s

--- a/src/headers/tomcrypt_misc.h
+++ b/src/headers/tomcrypt_misc.h
@@ -73,13 +73,13 @@ int crypt_get_size(const char* namein, unsigned int *sizeout);
 int crypt_list_all_sizes(char *names_list, unsigned int *names_list_size);
 
 #ifdef LTM_DESC
-void init_LTM(void);
+LTC_DEPRECATED void init_LTM(void);
 #endif
 #ifdef TFM_DESC
-void init_TFM(void);
+LTC_DEPRECATED void init_TFM(void);
 #endif
 #ifdef GMP_DESC
-void init_GMP(void);
+LTC_DEPRECATED void init_GMP(void);
 #endif
 int crypt_mp_init(const char* mpi);
 

--- a/src/misc/crypt/crypt_inits.c
+++ b/src/misc/crypt/crypt_inits.c
@@ -37,6 +37,54 @@ void init_GMP(void)
 }
 #endif
 
+int crypt_mp_init(const char* mpi)
+{
+   if (mpi == NULL) return CRYPT_ERROR;
+   switch (mpi[0]) {
+#ifdef LTM_DESC
+      case 'l':
+      case 'L':
+         init_LTM();
+         return CRYPT_OK;
+#endif
+#ifdef TFM_DESC
+      case 't':
+      case 'T':
+         init_TFM();
+         return CRYPT_OK;
+#endif
+#ifdef GMP_DESC
+      case 'g':
+      case 'G':
+         init_GMP();
+         return CRYPT_OK;
+#endif
+#ifdef EXT_MATH_LIB
+      case 'e':
+      case 'E':
+         {
+            extern ltc_math_descriptor EXT_MATH_LIB;
+            ltc_mp = EXT_MATH_LIB;
+         }
+
+#if defined(LTC_TEST_DBG)
+#define NAME_VALUE(s) #s"="NAME(s)
+#define NAME(s) #s
+         printf("EXT_MATH_LIB = %s\n", NAME_VALUE(EXT_MATH_LIB));
+#undef NAME_VALUE
+#undef NAME
+#endif
+
+         return CRYPT_OK;
+#endif
+      default:
+#if defined(LTC_TEST_DBG)
+         printf("Unknown/Invalid MPI provider: %s\n", mpi);
+#endif
+         return CRYPT_ERROR;
+   }
+}
+
 
 /* ref:         $Format:%D$ */
 /* git commit:  $Format:%H$ */

--- a/src/misc/crypt/crypt_inits.c
+++ b/src/misc/crypt/crypt_inits.c
@@ -44,19 +44,19 @@ int crypt_mp_init(const char* mpi)
 #ifdef LTM_DESC
       case 'l':
       case 'L':
-         init_LTM();
+         ltc_mp = ltm_desc;
          return CRYPT_OK;
 #endif
 #ifdef TFM_DESC
       case 't':
       case 'T':
-         init_TFM();
+         ltc_mp = tfm_desc;
          return CRYPT_OK;
 #endif
 #ifdef GMP_DESC
       case 'g':
       case 'G':
-         init_GMP();
+         ltc_mp = gmp_desc;
          return CRYPT_OK;
 #endif
 #ifdef EXT_MATH_LIB

--- a/tests/der_test.c
+++ b/tests/der_test.c
@@ -7,11 +7,8 @@
  * guarantee it works.
  */
 #include <tomcrypt_test.h>
-#if defined(GMP_LTC_DESC) || defined(USE_GMP)
-#include <gmp.h>
-#endif
 
-#if !defined(LTC_DER) || !defined(LTC_TEST_MPI)
+#if !defined(LTC_DER)
 
 int der_test(void)
 {
@@ -1125,6 +1122,8 @@ int der_test(void)
 
    unsigned char utf8_buf[32];
    wchar_t utf8_out[32];
+
+   if (ltc_mp.name == NULL) return CRYPT_NOP;
 
    der_cacert_test();
 

--- a/tests/dh_test.c
+++ b/tests/dh_test.c
@@ -8,7 +8,7 @@
  */
 #include <tomcrypt_test.h>
 
-#if defined(LTC_MDH) && defined(LTC_TEST_MPI)
+#if defined(LTC_MDH)
 
 #ifdef LTC_DH4096
 #define KEYSIZE 4096
@@ -433,6 +433,9 @@ static int _basic_test(void)
 int dh_test(void)
 {
    int fails = 0;
+
+   if (ltc_mp.name == NULL) return CRYPT_NOP;
+
    if (_prime_test() != CRYPT_OK) fails++;
    if (_basic_test() != CRYPT_OK) fails++;
    if (_dhparam_test() != CRYPT_OK) fails++;

--- a/tests/dsa_test.c
+++ b/tests/dsa_test.c
@@ -8,7 +8,7 @@
  */
 #include <tomcrypt_test.h>
 
-#if defined(LTC_MDSA) && defined(LTC_TEST_MPI)
+#if defined(LTC_MDSA)
 
 /* This is the private key from test_dsa.key */
 static const unsigned char openssl_priv_dsa[] = {
@@ -323,6 +323,8 @@ int dsa_test(void)
    unsigned long x, y;
    int stat1, stat2;
    dsa_key key, key2;
+
+   if (ltc_mp.name == NULL) return CRYPT_NOP;
 
    DO(_dsa_compat_test());
    DO(_dsa_wycheproof_test());

--- a/tests/ecc_test.c
+++ b/tests/ecc_test.c
@@ -8,7 +8,7 @@
  */
 #include <tomcrypt_test.h>
 
-#if defined(LTC_MECC) && defined(LTC_TEST_MPI)
+#if defined(LTC_MECC)
 
 static unsigned int sizes[] = {
 #ifdef LTC_ECC112
@@ -119,6 +119,8 @@ int ecc_tests (void)
   unsigned long x, y, z, s;
   int           stat, stat2;
   ecc_key usera, userb, pubKey, privKey;
+
+  if (ltc_mp.name == NULL) return CRYPT_NOP;
 
   DO(ecc_test ());
 

--- a/tests/katja_test.c
+++ b/tests/katja_test.c
@@ -8,7 +8,7 @@
  */
 #include <tomcrypt_test.h>
 
-#if defined(LTC_MKAT) && defined(LTC_TEST_MPI)
+#if defined(LTC_MKAT)
 
 int katja_test(void)
 {
@@ -17,6 +17,8 @@ int katja_test(void)
    int           hash_idx, prng_idx, stat, stat2, size;
    unsigned long kat_msgsize, len, len2, cnt;
    static unsigned char lparam[] = { 0x01, 0x02, 0x03, 0x04 };
+
+   if (ltc_mp.name == NULL) return CRYPT_NOP;
 
    hash_idx = find_hash("sha1");
    prng_idx = find_prng("yarrow");

--- a/tests/mpi_test.c
+++ b/tests/mpi_test.c
@@ -8,7 +8,7 @@
  */
 #include  <tomcrypt_test.h>
 
-#if defined(LTC_MPI) && defined(LTC_TEST_MPI)
+#if defined(LTC_MPI)
 static int _radix_to_bin_test(void)
 {
    /* RADIX 16 */
@@ -133,6 +133,7 @@ static int _radix_to_bin_test(void)
 
 int mpi_test(void)
 {
+   if (ltc_mp.name == NULL) return CRYPT_NOP;
    return _radix_to_bin_test();
 }
 #else

--- a/tests/pkcs_1_eme_test.c
+++ b/tests/pkcs_1_eme_test.c
@@ -8,7 +8,7 @@
  */
 #include <tomcrypt_test.h>
 
-#if defined(LTC_PKCS_1) && defined(LTC_TEST_MPI)
+#if defined(LTC_PKCS_1)
 
 #include "../notes/rsa-testvectors/pkcs1v15crypt-vectors.c"
 
@@ -21,6 +21,8 @@ int pkcs_1_eme_test(void)
   int hash_idx = find_hash("sha1");
   unsigned int i;
   unsigned int j;
+
+  if (ltc_mp.name == NULL) return CRYPT_NOP;
 
   DO(prng_is_valid(prng_idx));
   DO(hash_is_valid(hash_idx));

--- a/tests/pkcs_1_emsa_test.c
+++ b/tests/pkcs_1_emsa_test.c
@@ -8,7 +8,7 @@
  */
 #include <tomcrypt_test.h>
 
-#if defined(LTC_PKCS_1) && defined(LTC_TEST_MPI)
+#if defined(LTC_PKCS_1)
 
 #include "../notes/rsa-testvectors/pkcs1v15sign-vectors.c"
 
@@ -19,6 +19,8 @@ int pkcs_1_emsa_test(void)
   int hash_idx = find_hash("sha1");
   unsigned int i;
   unsigned int j;
+
+  if (ltc_mp.name == NULL) return CRYPT_NOP;
 
   DO(hash_is_valid(hash_idx));
 

--- a/tests/pkcs_1_oaep_test.c
+++ b/tests/pkcs_1_oaep_test.c
@@ -8,7 +8,7 @@
  */
 #include <tomcrypt_test.h>
 
-#if defined(LTC_PKCS_1) && defined(LTC_TEST_MPI)
+#if defined(LTC_PKCS_1)
 
 #include "../notes/rsa-testvectors/oaep-vect.c"
 
@@ -21,6 +21,8 @@ int pkcs_1_oaep_test(void)
   int hash_idx = find_hash("sha1");
   unsigned int i;
   unsigned int j;
+
+  if (ltc_mp.name == NULL) return CRYPT_NOP;
 
   DO(prng_is_valid(prng_idx));
   DO(hash_is_valid(hash_idx));

--- a/tests/pkcs_1_pss_test.c
+++ b/tests/pkcs_1_pss_test.c
@@ -8,7 +8,7 @@
  */
 #include <tomcrypt_test.h>
 
-#if defined(LTC_PKCS_1) && defined(LTC_TEST_MPI)
+#if defined(LTC_PKCS_1)
 
 #include "../notes/rsa-testvectors/pss-vect.c"
 
@@ -21,6 +21,8 @@ int pkcs_1_pss_test(void)
   int hash_idx = find_hash("sha1");
   unsigned int i;
   unsigned int j;
+
+  if (ltc_mp.name == NULL) return CRYPT_NOP;
 
   DO(prng_is_valid(prng_idx));
   DO(hash_is_valid(hash_idx));

--- a/tests/rsa_test.c
+++ b/tests/rsa_test.c
@@ -8,7 +8,7 @@
  */
 #include <tomcrypt_test.h>
 
-#if defined(LTC_MRSA) && defined(LTC_TEST_MPI)
+#if defined(LTC_MRSA)
 
 #define RSA_MSGSIZE 78
 
@@ -354,6 +354,8 @@ int rsa_test(void)
    unsigned char* p;
    unsigned char* p2;
    unsigned char* p3;
+
+   if (ltc_mp.name == NULL) return CRYPT_NOP;
 
    if (rsa_compat_test() != 0) {
       return 1;

--- a/tests/test.c
+++ b/tests/test.c
@@ -292,45 +292,6 @@ static void register_algs(void)
    }
 }
 
-static void init_mpi(const char* mpi)
-{
-   switch (mpi[0]) {
-#ifdef LTM_DESC
-      case 'l':
-         init_LTM();
-         break;
-#endif
-#ifdef TFM_DESC
-      case 't':
-         init_TFM();
-         break;
-#endif
-#ifdef GMP_DESC
-      case 'g':
-         init_GMP();
-         break;
-#endif
-#ifdef EXT_MATH_LIB
-      case 'e':
-         {
-            extern ltc_math_descriptor EXT_MATH_LIB;
-            ltc_mp = EXT_MATH_LIB;
-         }
-
-#define NAME_VALUE(s) #s"="NAME(s)
-#define NAME(s) #s
-         printf("EXT_MATH_LIB = %s\n", NAME_VALUE(EXT_MATH_LIB));
-#undef NAME_VALUE
-#undef NAME
-
-         break;
-#endif
-      default:
-         printf("Unknown/Invalid MPI provider: %s\n", mpi);
-         break;
-   }
-}
-
 int main(int argc, char **argv)
 {
 #ifdef LTC_PTHREAD
@@ -360,7 +321,7 @@ int main(int argc, char **argv)
       mpi_provider = argv[2];
    }
 
-   init_mpi(mpi_provider);
+   crypt_mp_init(mpi_provider);
 
    if (ltc_mp.name != NULL) {
       printf("MP_PROVIDER  = %s\n", ltc_mp.name);

--- a/tests/tomcrypt_test.h
+++ b/tests/tomcrypt_test.h
@@ -14,20 +14,6 @@
 
 #include "common.h"
 
-#ifdef USE_LTM
-/* Use libtommath as MPI provider */
-#define LTC_TEST_MPI
-#elif defined(USE_TFM)
-/* Use tomsfastmath as MPI provider */
-#define LTC_TEST_MPI
-#elif defined(USE_GMP)
-/* Use GNU Multiple Precision Arithmetic Library as MPI provider */
-#define LTC_TEST_MPI
-#elif defined(EXT_MATH_LIB)
-/* The user must define his own MPI provider! */
-#define LTC_TEST_MPI
-#endif
-
 typedef struct {
     char *name, *prov, *req;
     int  (*entry)(void);


### PR DESCRIPTION
With this patch you can build the library with `-DLTM_DESC -DTFM_DESC -DGMP_DESC` and then select the MPI provider at runtime of the _tools_ `test` and `timing`

I was lazy regarding the parameter parsing and therefore you have to pass the MPI provider as 2nd argument... Running all tests or timings requires you to execute `./test _ gmp` or something like that where arg1 matches for all cases... :)

Regarding the static `init_mpi()` function: I already thought about replacing the three functions by this single one /cc @buggywhip 