### PR TITLE
re-work PK crypto im- & export

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ The following list is a small part of the available, but the most often required
 | ---- | -------- |
 | `LTC_NO_TEST` | Remove all algorithm self-tests from the library |
 | `LTC_NO_FILE` | Remove all API functions requiring a pre-defined `FILE` data-type (mostly useful for embedded targets) |
-| `MAX_RSA_SIZE` | Per default set to `4096`, if you need support for generating bigger RSA keys, change this at compile-time. |
 | `GMP_DESC` | enable [gmp](https://gmplib.org/) as MPI provider *\*1* |
 | `LTM_DESC` | enable [libtommath](http://www.libtom.net/) as MPI provider *\*1* |
 | `TFM_DESC` | enable [tomsfastmath](http://www.libtom.net/) as MPI provider *\*1* *\*2* |

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The following list is a small part of the available, but the most often required
 | ---- | -------- |
 | `LTC_NO_TEST` | Remove all algorithm self-tests from the library |
 | `LTC_NO_FILE` | Remove all API functions requiring a pre-defined `FILE` data-type (mostly useful for embedded targets) |
-| `MAX_RSA_SIZE` | Per default set to `4096`, if you need support for importing or generating bigger RSA keys, change this at compile-time. |
+| `MAX_RSA_SIZE` | Per default set to `4096`, if you need support for generating bigger RSA keys, change this at compile-time. |
 | `GMP_DESC` | enable [gmp](https://gmplib.org/) as MPI provider *\*1* |
 | `LTM_DESC` | enable [libtommath](http://www.libtom.net/) as MPI provider *\*1* |
 | `TFM_DESC` | enable [tomsfastmath](http://www.libtom.net/) as MPI provider *\*1* *\*2* |

--- a/demos/demo_dynamic.py
+++ b/demos/demo_dynamic.py
@@ -150,7 +150,7 @@ if SHOW_SELECTED_CONSTANTS:
         b'ENDIAN_LITTLE',
         b'ENDIAN_64BITWORD',
         b'PK_PUBLIC',
-        b'MAX_RSA_SIZE',
+        b'LTC_MILLER_RABIN_REPS',
         b'CTR_COUNTER_BIG_ENDIAN',
     ]
     for name in names:

--- a/makefile_include.mk
+++ b/makefile_include.mk
@@ -76,6 +76,7 @@ endif
 LTC_CFLAGS += -Wno-type-limits
 
 ifdef LTC_DEBUG
+$(info Debug build)
 # compile for DEBUGGING (required for ccmalloc checking!!!)
 LTC_CFLAGS += -g3 -DLTC_NO_ASM
 ifneq (,$(strip $(LTC_DEBUG)))

--- a/src/headers/tomcrypt_custom.h
+++ b/src/headers/tomcrypt_custom.h
@@ -438,17 +438,6 @@
 #endif
 #endif
 
-/* in cases where you want ASN.1/DER functionality, but no
- * RSA, you can define this externally if 1024 is not enough
- */
-#if defined(LTC_MRSA)
-#define LTC_DER_MAX_PUBKEY_SIZE MAX_RSA_SIZE
-#elif !defined(LTC_DER_MAX_PUBKEY_SIZE)
-/* this includes DSA */
-#define LTC_DER_MAX_PUBKEY_SIZE 1024
-#endif
-
-
 /* PKCS #1 (RSA) and #5 (Password Handling) stuff */
 #ifndef LTC_NO_PKCS
 

--- a/src/headers/tomcrypt_custom.h
+++ b/src/headers/tomcrypt_custom.h
@@ -425,19 +425,6 @@
 #define LTC_ECC_TIMING_RESISTANT
 #endif
 
-/* define these PK sizes out of LTC_NO_PK
- * to have them always defined
- */
-#if defined(LTC_MRSA)
-/* Min and Max RSA key sizes (in bits) */
-#ifndef MIN_RSA_SIZE
-#define MIN_RSA_SIZE 1024
-#endif
-#ifndef MAX_RSA_SIZE
-#define MAX_RSA_SIZE 4096
-#endif
-#endif
-
 /* PKCS #1 (RSA) and #5 (Password Handling) stuff */
 #ifndef LTC_NO_PKCS
 

--- a/src/misc/crypt/crypt.c
+++ b/src/misc/crypt/crypt.c
@@ -399,9 +399,6 @@ const char *crypt_build_settings =
 #if defined(LTC_DER)
     " DER "
 #endif
-#if defined(LTC_DER_MAX_PUBKEY_SIZE)
-    " " NAME_VALUE(LTC_DER_MAX_PUBKEY_SIZE) " "
-#endif
 #if defined(LTC_PKCS_1)
     " PKCS#1 "
 #endif

--- a/src/misc/crypt/crypt_constants.c
+++ b/src/misc/crypt/crypt_constants.c
@@ -77,8 +77,6 @@ static const crypt_constant _crypt_constants[] = {
 
 #ifdef LTC_MRSA
     {"LTC_MRSA", 1},
-    _C_STRINGIFY(MIN_RSA_SIZE),
-    _C_STRINGIFY(MAX_RSA_SIZE),
 #else
     {"LTC_MRSA", 0},
 #endif

--- a/src/misc/crypt/crypt_constants.c
+++ b/src/misc/crypt/crypt_constants.c
@@ -107,9 +107,6 @@ static const crypt_constant _crypt_constants[] = {
     {"LTC_MDSA", 0},
 #endif
 
-#ifdef LTC_DER_MAX_PUBKEY_SIZE
-    _C_STRINGIFY(LTC_DER_MAX_PUBKEY_SIZE),
-#endif
 #ifdef LTC_MILLER_RABIN_REPS
     _C_STRINGIFY(LTC_MILLER_RABIN_REPS),
 #endif

--- a/src/pk/asn1/der/bit/der_decode_raw_bit_string.c
+++ b/src/pk/asn1/der/bit/der_decode_raw_bit_string.c
@@ -85,14 +85,14 @@ int der_decode_raw_bit_string(const unsigned char *in,  unsigned long inlen,
 
    /* decode/store the bits */
    for (y = 0; y < blen; y++) {
-       if (in[x] & (1 << (7 - (y & 7)))) {
-          SETBIT(out[y/8], 7-(y%8));
-       } else {
-          CLRBIT(out[y/8], 7-(y%8));
-       }
-       if ((y & 7) == 7) {
-          ++x;
-       }
+      if (in[x] & (1 << (7 - (y & 7)))) {
+         SETBIT(out[y/8], 7-(y%8));
+      } else {
+         CLRBIT(out[y/8], 7-(y%8));
+      }
+      if ((y & 7) == 7) {
+         ++x;
+      }
    }
 
    /* we done */

--- a/src/pk/asn1/der/bit/der_decode_raw_bit_string.c
+++ b/src/pk/asn1/der/bit/der_decode_raw_bit_string.c
@@ -77,7 +77,7 @@ int der_decode_raw_bit_string(const unsigned char *in,  unsigned long inlen,
    blen = ((dlen - 1) << 3) - (in[x++] & 7);
 
    /* too many bits? */
-   if (blen > *outlen) {
+   if (blen/8 > *outlen) {
       *outlen = blen;
       return CRYPT_BUFFER_OVERFLOW;
    }

--- a/src/pk/asn1/der/bit/der_decode_raw_bit_string.c
+++ b/src/pk/asn1/der/bit/der_decode_raw_bit_string.c
@@ -78,7 +78,7 @@ int der_decode_raw_bit_string(const unsigned char *in,  unsigned long inlen,
    blen = ((dlen - 1) << 3) - (in[x++] & 7);
 
    /* too many bits? */
-   if (blen/8 > *outlen) {
+   if ((blen + 7)/8 > *outlen) {
       *outlen = blen;
       return CRYPT_BUFFER_OVERFLOW;
    }

--- a/src/pk/asn1/der/bit/der_decode_raw_bit_string.c
+++ b/src/pk/asn1/der/bit/der_decode_raw_bit_string.c
@@ -78,7 +78,7 @@ int der_decode_raw_bit_string(const unsigned char *in,  unsigned long inlen,
    blen = ((dlen - 1) << 3) - (in[x++] & 7);
 
    /* too many bits? */
-   if (blen/8 > *outlen) {
+   if (blen > *outlen) {
       *outlen = blen;
       return CRYPT_BUFFER_OVERFLOW;
    }

--- a/src/pk/asn1/der/bit/der_decode_raw_bit_string.c
+++ b/src/pk/asn1/der/bit/der_decode_raw_bit_string.c
@@ -17,6 +17,7 @@
 #ifdef LTC_DER
 
 #define SETBIT(v, n)    (v=((unsigned char)(v) | (1U << (unsigned char)(n))))
+#define CLRBIT(v, n)    (v=((unsigned char)(v) & ~(1U << (unsigned char)(n))))
 
 /**
   Store a BIT STRING
@@ -86,6 +87,8 @@ int der_decode_raw_bit_string(const unsigned char *in,  unsigned long inlen,
    for (y = 0; y < blen; y++) {
        if (in[x] & (1 << (7 - (y & 7)))) {
           SETBIT(out[y/8], 7-(y%8));
+       } else {
+          CLRBIT(out[y/8], 7-(y%8));
        }
        if ((y & 7) == 7) {
           ++x;

--- a/src/pk/asn1/der/bit/der_decode_raw_bit_string.c
+++ b/src/pk/asn1/der/bit/der_decode_raw_bit_string.c
@@ -78,7 +78,7 @@ int der_decode_raw_bit_string(const unsigned char *in,  unsigned long inlen,
    blen = ((dlen - 1) << 3) - (in[x++] & 7);
 
    /* too many bits? */
-   if ((blen + 7)/8 > *outlen) {
+   if (blen/8 > *outlen) {
       *outlen = blen;
       return CRYPT_BUFFER_OVERFLOW;
    }

--- a/src/pk/asn1/der/bit/der_encode_raw_bit_string.c
+++ b/src/pk/asn1/der/bit/der_encode_raw_bit_string.c
@@ -21,7 +21,7 @@
 /**
   Store a BIT STRING
   @param in       The array of bits to store (8 per char)
-  @param inlen    The number of bits tostore
+  @param inlen    The number of bits to store
   @param out      [out] The destination for the DER encoded BIT STRING
   @param outlen   [in/out] The max size and resulting size of the DER BIT STRING
   @return CRYPT_OK if successful
@@ -68,11 +68,11 @@ int der_encode_raw_bit_string(const unsigned char *in, unsigned long inlen,
 
    /* store the bits in big endian format */
    for (y = buf = 0; y < inlen; y++) {
-        buf |= (getbit(in[y/8],7-y%8)?1:0) << (7 - (y & 7));
-       if ((y & 7) == 7) {
-          out[x++] = buf;
-          buf      = 0;
-       }
+      buf |= (getbit(in[y/8],7-y%8)?1:0) << (7 - (y & 7));
+      if ((y & 7) == 7) {
+         out[x++] = buf;
+         buf      = 0;
+      }
    }
    /* store last byte */
    if (inlen & 7) {

--- a/src/pk/asn1/der/sequence/der_decode_subject_public_key_info.c
+++ b/src/pk/asn1/der/sequence/der_decode_subject_public_key_info.c
@@ -58,7 +58,7 @@ int der_decode_subject_public_key_info(const unsigned char *in, unsigned long in
    }
 
    /* see if the OpenSSL DER format RSA public key will work */
-   tmpbuf = XCALLOC(1, LTC_DER_MAX_PUBKEY_SIZE*8);
+   tmpbuf = XCALLOC(1, inlen);
    if (tmpbuf == NULL) {
        err = CRYPT_MEM;
        goto LBL_ERR;
@@ -72,7 +72,7 @@ int der_decode_subject_public_key_info(const unsigned char *in, unsigned long in
     * in a **BIT** string ... so we have to extract it then proceed to convert bit to octet
     */
    LTC_SET_ASN1(subject_pubkey, 0, LTC_ASN1_SEQUENCE, alg_id, 2);
-   LTC_SET_ASN1(subject_pubkey, 1, LTC_ASN1_RAW_BIT_STRING, tmpbuf, LTC_DER_MAX_PUBKEY_SIZE*8);
+   LTC_SET_ASN1(subject_pubkey, 1, LTC_ASN1_RAW_BIT_STRING, tmpbuf, inlen);
 
    err=der_decode_sequence(in, inlen, subject_pubkey, 2UL);
    if (err != CRYPT_OK) {

--- a/src/pk/asn1/der/sequence/der_decode_subject_public_key_info.c
+++ b/src/pk/asn1/der/sequence/der_decode_subject_public_key_info.c
@@ -72,7 +72,7 @@ int der_decode_subject_public_key_info(const unsigned char *in, unsigned long in
     * in a **BIT** string ... so we have to extract it then proceed to convert bit to octet
     */
    LTC_SET_ASN1(subject_pubkey, 0, LTC_ASN1_SEQUENCE, alg_id, 2);
-   LTC_SET_ASN1(subject_pubkey, 1, LTC_ASN1_RAW_BIT_STRING, tmpbuf, inlen);
+   LTC_SET_ASN1(subject_pubkey, 1, LTC_ASN1_RAW_BIT_STRING, tmpbuf, inlen*8U);
 
    err=der_decode_sequence(in, inlen, subject_pubkey, 2UL);
    if (err != CRYPT_OK) {

--- a/src/pk/asn1/der/sequence/der_encode_subject_public_key_info.c
+++ b/src/pk/asn1/der/sequence/der_encode_subject_public_key_info.c
@@ -58,7 +58,7 @@ int der_encode_subject_public_key_info(unsigned char *out, unsigned long *outlen
 
    return der_encode_sequence_multi(out, outlen,
         LTC_ASN1_SEQUENCE, (unsigned long)sizeof(alg_id)/sizeof(alg_id[0]), alg_id,
-        LTC_ASN1_RAW_BIT_STRING, (unsigned long)(public_key_len*8), public_key,
+        LTC_ASN1_RAW_BIT_STRING, public_key_len*8U, public_key,
         LTC_ASN1_EOL,     0UL, NULL);
 
 }

--- a/src/pk/dsa/dsa_import.c
+++ b/src/pk/dsa/dsa_import.c
@@ -90,7 +90,7 @@ int dsa_import(const unsigned char *in, unsigned long inlen, dsa_key *key)
        key->type = PK_PRIVATE;
    } else { /* public */
       ltc_asn1_list params[3];
-      unsigned long tmpbuf_len = LTC_DER_MAX_PUBKEY_SIZE*8;
+      unsigned long tmpbuf_len = inlen;
 
       LTC_SET_ASN1(params, 0, LTC_ASN1_INTEGER, key->p, 1UL);
       LTC_SET_ASN1(params, 1, LTC_ASN1_INTEGER, key->q, 1UL);

--- a/src/pk/rsa/rsa_import.c
+++ b/src/pk/rsa/rsa_import.c
@@ -40,7 +40,7 @@ int rsa_import(const unsigned char *in, unsigned long inlen, rsa_key *key)
    }
 
    /* see if the OpenSSL DER format RSA public key will work */
-   tmpbuf_len = MAX_RSA_SIZE / 8;
+   tmpbuf_len = inlen;
    tmpbuf = XCALLOC(1, tmpbuf_len);
    if (tmpbuf == NULL) {
        err = CRYPT_MEM;

--- a/src/pk/rsa/rsa_import.c
+++ b/src/pk/rsa/rsa_import.c
@@ -40,7 +40,7 @@ int rsa_import(const unsigned char *in, unsigned long inlen, rsa_key *key)
    }
 
    /* see if the OpenSSL DER format RSA public key will work */
-   tmpbuf_len = MAX_RSA_SIZE * 8;
+   tmpbuf_len = MAX_RSA_SIZE / 8;
    tmpbuf = XCALLOC(1, tmpbuf_len);
    if (tmpbuf == NULL) {
        err = CRYPT_MEM;

--- a/src/pk/rsa/rsa_import_x509.c
+++ b/src/pk/rsa/rsa_import_x509.c
@@ -39,7 +39,7 @@ int rsa_import_x509(const unsigned char *in, unsigned long inlen, rsa_key *key)
       return err;
    }
 
-   tmpbuf_len = MAX_RSA_SIZE * 8;
+   tmpbuf_len = inlen;
    tmpbuf = XCALLOC(1, tmpbuf_len);
    if (tmpbuf == NULL) {
        err = CRYPT_MEM;

--- a/src/pk/rsa/rsa_make_key.c
+++ b/src/pk/rsa/rsa_make_key.c
@@ -32,10 +32,6 @@ int rsa_make_key(prng_state *prng, int wprng, int size, long e, rsa_key *key)
    LTC_ARGCHK(ltc_mp.name != NULL);
    LTC_ARGCHK(key         != NULL);
 
-   if ((size < (MIN_RSA_SIZE/8)) || (size > (MAX_RSA_SIZE/8))) {
-      return CRYPT_INVALID_KEYSIZE;
-   }
-
    if ((e < 3) || ((e & 1) == 0)) {
       return CRYPT_INVALID_ARG;
    }

--- a/src/pk/rsa/rsa_make_key.c
+++ b/src/pk/rsa/rsa_make_key.c
@@ -31,6 +31,7 @@ int rsa_make_key(prng_state *prng, int wprng, int size, long e, rsa_key *key)
 
    LTC_ARGCHK(ltc_mp.name != NULL);
    LTC_ARGCHK(key         != NULL);
+   LTC_ARGCHK(size        > 0);
 
    if ((e < 3) || ((e & 1) == 0)) {
       return CRYPT_INVALID_ARG;

--- a/tests/der_test.c
+++ b/tests/der_test.c
@@ -239,8 +239,8 @@ SEQUENCE(3 elem)
 static void _der_tests_print_flexi(ltc_asn1_list* l, unsigned int level)
 {
   char buf[1024];
-  char* name = NULL;
-  char* text = NULL;
+  const char* name = NULL;
+  const char* text = NULL;
   ltc_asn1_list* ostring = NULL;
   unsigned int n;
 

--- a/tests/rsa_test.c
+++ b/tests/rsa_test.c
@@ -339,6 +339,7 @@ static int _rsa_issue_301(int prng_idx)
    DO(_rsa_key_cmp(PK_PUBLIC, &key, &key_in));
    rsa_free(&key_in);
 
+   rsa_free(&key);
    return 0;
 }
 

--- a/tests/rsa_test.c
+++ b/tests/rsa_test.c
@@ -313,10 +313,10 @@ static int _rsa_key_cmp(const int should_type, const rsa_key *should, const rsa_
 static int _rsa_issue_301(int prng_idx)
 {
    rsa_key       key, key_in;
-   unsigned char buf[MAX_RSA_SIZE];
+   unsigned char buf[4096];
    unsigned long len;
 
-   DO(rsa_make_key(&yarrow_prng, prng_idx, MAX_RSA_SIZE/8, 65537, &key));
+   DO(rsa_make_key(&yarrow_prng, prng_idx, sizeof(buf)/8, 65537, &key));
 
    len = sizeof(buf);
    DO(rsa_export(buf, &len, PK_PRIVATE, &key));

--- a/tests/rsa_test.c
+++ b/tests/rsa_test.c
@@ -340,7 +340,7 @@ static int _rsa_issue_301(int prng_idx)
    rsa_free(&key_in);
 
    rsa_free(&key);
-   return 0;
+   return CRYPT_OK;
 }
 
 int rsa_test(void)
@@ -366,9 +366,7 @@ int rsa_test(void)
       return 1;
    }
 
-   if (_rsa_issue_301(prng_idx) != 0) {
-      return 1;
-   }
+   DO(_rsa_issue_301(prng_idx));
 
    /* make 10 random key */
    for (cnt = 0; cnt < 10; cnt++) {


### PR DESCRIPTION
well this turned out to become a bigger one with some real bugfixes as well...

This mostly removes `MAX_RSA_SIZE` from the code, only `rsa_make_key()` still checks for it.

After some thinking I'd even propose to remove `MIN_RSA_SIZE`and `MAX_RSA_SIZE` entirely! Somebody against it?