### PR TITLE
Add SIV

### DIFF
--- a/doc/crypt.tex
+++ b/doc/crypt.tex
@@ -2576,6 +2576,166 @@ IMPORTANT NOTICE 2: As mentioned in \ref{chacha20poly1305} there exists a discre
 In order to enable OpenSSH compatibility, the flag \textit{CHACHA20POLY1305\_OPENSSH\_COMPAT} has to be \textbf{OR}'ed into
 the \textit{direction} parameter.
 
+
+\mysection{SIV}
+\label{SIV}
+
+The SIV (Synthetic Initialization Vector) authenticated encryption is a block cipher mode of encryption
+defined by \url{https://tools.ietf.org/html/rfc5297}.
+
+In contrast to all the other AEAD modes, SIV provides no iterative API. Instead it only provides one--shot APIs.
+
+AEAD algorithm design usually suggests using a separate Nonce (also called IV) and additional authenticated Data (AAD).
+SIV treats this slightly different and does not enforce any of the two, but leaves it up to the user.
+Also SIV allows passing multiple sets of data as AAD, up to a maximum of \texttt{126} elements.
+In case one wants to use a Nonce in a classical style it is suggested to pass it as the last of the AAD elements,
+thereby limiting the number of AAD to \texttt{125}.
+
+\subsection{Encryption / Decryption}
+To encrypt and create a tag resp. decrypt and check the tag, the following API functions can be used.
+
+\index{siv\_encrypt\_memory()}
+\begin{verbatim}
+int siv_encrypt_memory(                int  cipher,
+                       const unsigned char *key,    unsigned long  keylen,
+                       const unsigned char *ad[],   unsigned long  adlen[],
+                       const unsigned char *pt,     unsigned long  ptlen,
+                             unsigned char *ct,     unsigned long *ctlen);
+\end{verbatim}
+This encrypts the data where \textit{pt} is the plaintext and \textit{ct} is the ciphertext.
+The length of the plaintext is given in \textit{ptlen} and the length of the ciphertext is given in \textit{ctlen}.
+\textit{ctlen} shall contain the max buffer size allocated at \textit{ct} on input, and will be updated with the
+written length on successful encryption.
+
+The buffer of \textit{ct} shall be at least \texttt{ptlen + 16} bytes wide.
+
+The key to the encrypt operation is passed in \textit{key} of length  \textit{keylen}.
+
+The AAD is passed as array of pointers in \textit{ad}. The length of each AAD is passed as array of
+\textit{unsigned long} in \textit{adlen}.
+As soon as an array element of \textit{ad} is hit which equals \texttt{NULL} or an array element of \textit{adlen}
+is hit which equals \texttt{0}, processing of the AAD is stopped.
+
+\index{siv\_decrypt\_memory()}
+\begin{verbatim}
+int siv_decrypt_memory(                int  cipher,
+                       const unsigned char *key,    unsigned long  keylen,
+                       const unsigned char *ad[],   unsigned long  adlen[],
+                       const unsigned char *ct,     unsigned long  ctlen,
+                             unsigned char *pt,     unsigned long *ptlen);
+\end{verbatim}
+This decrypts the data where \textit{ct} is the ciphertext of length \textit{ctlen} and \textit{pt} is the plaintext of length \textit{ptlen}.
+\textit{ptlen} shall contain the max buffer size allocated at \textit{pt} on input, and will be updated with the
+written lenth on successful decryption.
+
+The buffer of \textit{pt} shall be at least \texttt{ctlen - 16} bytes wide.
+
+The AAD is processed in the same way as in the encrypt function.
+
+An example of encryption and decryption with SIV using multiple AAD and a Nonce is given below.
+
+\begin{small}
+\begin{verbatim}
+#include <tomcrypt.h>
+
+int main(void)
+{
+   int err;
+   unsigned char plain[16] = {0};
+   unsigned char ct[sizeof(plain) + 16] = {0};
+   unsigned long plainlen = sizeof(plain), ctlen = sizeof(ct);
+
+   register_cipher(&aes_desc);
+
+   /* We need to cast the AAD strings because the API asks for an `unsigned char*`
+    * but a string is on most platforms defined as a "signed" `char*`. */
+   if ((err = siv_encrypt_memory(find_cipher("aes"),
+                                 ((unsigned char[32]) {0x0}), 32,
+                                 ((const unsigned char*[]) {(void*)"aad0", (void*)"aad1",
+                                                            (void*)"NONCE", NULL}),
+                                 ((unsigned long[]) {4, 4, 5, 0}),
+                                 plain, plainlen,
+                                 ct, &ctlen)) != CRYPT_OK) {
+      whine_and_pout(err);
+   }
+
+   if ((err = siv_decrypt_memory(find_cipher("aes"),
+                                 ((unsigned char[32]) {0x0}), 32,
+                                 ((const unsigned char*[]) {(void*)"aad0", (void*)"aad1",
+                                                            (void*)"NONCE", NULL}),
+                                 ((unsigned long[]) {4, 4, 5, 0}),
+                                 ct, ctlen,
+                                 plain, &plainlen)) != CRYPT_OK) {
+      whine_and_pout(err);
+   }
+
+   return EXIT_SUCCESS;
+}
+\end{verbatim}
+\end{small}
+
+\subsection{One--Shot Packet}
+To process a single packet under any given key the following helper function can be used.
+
+\index{siv\_memory()}
+\begin{verbatim}
+int siv_memory(                int  cipher,           int  direction,
+               const unsigned char *key,    unsigned long  keylen,
+               const unsigned char *in,     unsigned long  inlen,
+                     unsigned char *out,    unsigned long *outlen,
+                                   ...);
+\end{verbatim}
+
+This will execute a SIV operation of the \textit{direction} (\texttt{LTC\_ENCRYPT} resp. \texttt{LTC\_DECRYPT})
+using the \textit{cipher} with the \textit{key} of len \textit{keylen}.
+The AAD is optionally passed as varargs of the form \textit{(const unsigned char*, unsigned long)}, which musst be
+NULL terminated.
+The input is passed via the \textit{in} argument of length \textit{inlen}.
+The output is stored in the buffer pointer to by the \textit{out} argument where the length is passed as \textit{outlen}.
+\textit{outlen} shall contain the initial size of the buffer behind \textit{out} when calling the function and on
+return it will contain the written size.
+
+In case the operation is \textit{encryption} the buffer of \textit{out} shall be at least \texttt{inlen + 16} bytes wide.
+In the case of \textit{decryption} the buffer of \textit{out} shall be at least \texttt{inlen - 16} bytes wide.
+
+An example of encryption and decryption with the one--shot API of SIV using multiple AAD is given below.
+
+\begin{small}
+\begin{verbatim}
+#include <tomcrypt.h>
+
+int main(void)
+{
+   int err;
+   unsigned char plain[16] = {0};
+   unsigned char ct[sizeof(plain) + 16] = {0};
+   unsigned long plainlen = sizeof(plain), ctlen = sizeof(ct);
+
+   register_cipher(&aes_desc);
+
+   /* Note that constant length values must be suffixed by `uL` in order
+    * to operate correctly cross-platform. */
+   if ((err = siv_memory(find_cipher("aes"), LTC_ENCRYPT,
+                         ((unsigned char[32]) {0x0}), 32,
+                         plain, plainlen,
+                         ct, &ctlen,
+                         "aad0", 4uL, "aad1", 4uL, "NONCE", 5uL, NULL)) != CRYPT_OK) {
+      whine_and_pout(err);
+   }
+
+   if ((err = siv_memory(find_cipher("aes"), LTC_DECRYPT,
+                         ((unsigned char[32]) {0x0}), 32,
+                         ct, ctlen,
+                         plain, &plainlen,
+                         "aad0", 4uL, "aad1", 4uL, "NONCE", 5uL, NULL)) != CRYPT_OK) {
+      whine_and_pout(err);
+   }
+
+   return EXIT_SUCCESS;
+}
+\end{verbatim}
+\end{small}
+
 \chapter{One-Way Cryptographic Hash Functions}
 \mysection{Core Functions}
 Like the ciphers, there are hash core functions and a universal data type to hold the hash state called \textit{hash\_state}.  To initialize hash

--- a/libtomcrypt_VS2008.vcproj
+++ b/libtomcrypt_VS2008.vcproj
@@ -835,6 +835,14 @@
 					>
 				</File>
 			</Filter>
+			<Filter
+				Name="siv"
+				>
+				<File
+					RelativePath="src\encauth\siv\siv.c"
+					>
+				</File>
+			</Filter>
 		</Filter>
 		<Filter
 			Name="hashes"

--- a/makefile.mingw
+++ b/makefile.mingw
@@ -64,8 +64,8 @@ src/encauth/ocb3/ocb3_add_aad.o src/encauth/ocb3/ocb3_decrypt.o src/encauth/ocb3
 src/encauth/ocb3/ocb3_decrypt_verify_memory.o src/encauth/ocb3/ocb3_done.o \
 src/encauth/ocb3/ocb3_encrypt.o src/encauth/ocb3/ocb3_encrypt_authenticate_memory.o \
 src/encauth/ocb3/ocb3_encrypt_last.o src/encauth/ocb3/ocb3_init.o src/encauth/ocb3/ocb3_int_ntz.o \
-src/encauth/ocb3/ocb3_int_xor_blocks.o src/encauth/ocb3/ocb3_test.o src/hashes/blake2b.o \
-src/hashes/blake2s.o src/hashes/chc/chc.o src/hashes/helper/hash_file.o \
+src/encauth/ocb3/ocb3_int_xor_blocks.o src/encauth/ocb3/ocb3_test.o src/encauth/siv/siv.o \
+src/hashes/blake2b.o src/hashes/blake2s.o src/hashes/chc/chc.o src/hashes/helper/hash_file.o \
 src/hashes/helper/hash_filehandle.o src/hashes/helper/hash_memory.o \
 src/hashes/helper/hash_memory_multi.o src/hashes/md2.o src/hashes/md4.o src/hashes/md5.o \
 src/hashes/rmd128.o src/hashes/rmd160.o src/hashes/rmd256.o src/hashes/rmd320.o src/hashes/sha1.o \

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -57,8 +57,8 @@ src/encauth/ocb3/ocb3_add_aad.obj src/encauth/ocb3/ocb3_decrypt.obj src/encauth/
 src/encauth/ocb3/ocb3_decrypt_verify_memory.obj src/encauth/ocb3/ocb3_done.obj \
 src/encauth/ocb3/ocb3_encrypt.obj src/encauth/ocb3/ocb3_encrypt_authenticate_memory.obj \
 src/encauth/ocb3/ocb3_encrypt_last.obj src/encauth/ocb3/ocb3_init.obj src/encauth/ocb3/ocb3_int_ntz.obj \
-src/encauth/ocb3/ocb3_int_xor_blocks.obj src/encauth/ocb3/ocb3_test.obj src/hashes/blake2b.obj \
-src/hashes/blake2s.obj src/hashes/chc/chc.obj src/hashes/helper/hash_file.obj \
+src/encauth/ocb3/ocb3_int_xor_blocks.obj src/encauth/ocb3/ocb3_test.obj src/encauth/siv/siv.obj \
+src/hashes/blake2b.obj src/hashes/blake2s.obj src/hashes/chc/chc.obj src/hashes/helper/hash_file.obj \
 src/hashes/helper/hash_filehandle.obj src/hashes/helper/hash_memory.obj \
 src/hashes/helper/hash_memory_multi.obj src/hashes/md2.obj src/hashes/md4.obj src/hashes/md5.obj \
 src/hashes/rmd128.obj src/hashes/rmd160.obj src/hashes/rmd256.obj src/hashes/rmd320.obj src/hashes/sha1.obj \

--- a/makefile.unix
+++ b/makefile.unix
@@ -78,8 +78,8 @@ src/encauth/ocb3/ocb3_add_aad.o src/encauth/ocb3/ocb3_decrypt.o src/encauth/ocb3
 src/encauth/ocb3/ocb3_decrypt_verify_memory.o src/encauth/ocb3/ocb3_done.o \
 src/encauth/ocb3/ocb3_encrypt.o src/encauth/ocb3/ocb3_encrypt_authenticate_memory.o \
 src/encauth/ocb3/ocb3_encrypt_last.o src/encauth/ocb3/ocb3_init.o src/encauth/ocb3/ocb3_int_ntz.o \
-src/encauth/ocb3/ocb3_int_xor_blocks.o src/encauth/ocb3/ocb3_test.o src/hashes/blake2b.o \
-src/hashes/blake2s.o src/hashes/chc/chc.o src/hashes/helper/hash_file.o \
+src/encauth/ocb3/ocb3_int_xor_blocks.o src/encauth/ocb3/ocb3_test.o src/encauth/siv/siv.o \
+src/hashes/blake2b.o src/hashes/blake2s.o src/hashes/chc/chc.o src/hashes/helper/hash_file.o \
 src/hashes/helper/hash_filehandle.o src/hashes/helper/hash_memory.o \
 src/hashes/helper/hash_memory_multi.o src/hashes/md2.o src/hashes/md4.o src/hashes/md5.o \
 src/hashes/rmd128.o src/hashes/rmd160.o src/hashes/rmd256.o src/hashes/rmd320.o src/hashes/sha1.o \

--- a/makefile_include.mk
+++ b/makefile_include.mk
@@ -239,8 +239,8 @@ src/encauth/ocb3/ocb3_add_aad.o src/encauth/ocb3/ocb3_decrypt.o src/encauth/ocb3
 src/encauth/ocb3/ocb3_decrypt_verify_memory.o src/encauth/ocb3/ocb3_done.o \
 src/encauth/ocb3/ocb3_encrypt.o src/encauth/ocb3/ocb3_encrypt_authenticate_memory.o \
 src/encauth/ocb3/ocb3_encrypt_last.o src/encauth/ocb3/ocb3_init.o src/encauth/ocb3/ocb3_int_ntz.o \
-src/encauth/ocb3/ocb3_int_xor_blocks.o src/encauth/ocb3/ocb3_test.o src/hashes/blake2b.o \
-src/hashes/blake2s.o src/hashes/chc/chc.o src/hashes/helper/hash_file.o \
+src/encauth/ocb3/ocb3_int_xor_blocks.o src/encauth/ocb3/ocb3_test.o src/encauth/siv/siv.o \
+src/hashes/blake2b.o src/hashes/blake2s.o src/hashes/chc/chc.o src/hashes/helper/hash_file.o \
 src/hashes/helper/hash_filehandle.o src/hashes/helper/hash_memory.o \
 src/hashes/helper/hash_memory_multi.o src/hashes/md2.o src/hashes/md4.o src/hashes/md5.o \
 src/hashes/rmd128.o src/hashes/rmd160.o src/hashes/rmd256.o src/hashes/rmd320.o src/hashes/sha1.o \

--- a/sources.cmake
+++ b/sources.cmake
@@ -85,6 +85,7 @@ src/encauth/ocb3/ocb3_init.c
 src/encauth/ocb3/ocb3_int_ntz.c
 src/encauth/ocb3/ocb3_int_xor_blocks.c
 src/encauth/ocb3/ocb3_test.c
+src/encauth/siv/siv.c
 src/hashes/blake2b.c
 src/hashes/blake2s.c
 src/hashes/chc/chc.c

--- a/src/encauth/siv/siv.c
+++ b/src/encauth/siv/siv.c
@@ -1,0 +1,397 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis */
+/* SPDX-License-Identifier: Unlicense */
+#include "tomcrypt_private.h"
+
+/**
+  @file siv.c
+  RFC 5297  SIV - Synthetic Initialization Vector, Steffen Jaeckel
+*/
+
+#ifdef LTC_SIV_MODE
+
+static void s_siv_dbl(unsigned char *inout)
+{
+   int y, mask, msb, len;
+
+   /* setup the system */
+   mask = 0x87;
+   len = 16;
+
+   /* if msb(L * u^(x+1)) = 0 then just shift, otherwise shift and xor constant mask */
+   msb = inout[0] >> 7;
+
+   /* shift left */
+   for (y = 0; y < (len - 1); y++) {
+      inout[y] = ((inout[y] << 1) | (inout[y + 1] >> 7)) & 255;
+   }
+   inout[len - 1] = ((inout[len - 1] << 1) ^ (msb ? mask : 0)) & 255;
+}
+
+static int s_siv_S2V(int cipher,
+    const unsigned char *key,    unsigned long keylen,
+    const unsigned char **ad,    unsigned long *adlen,
+    const unsigned char *in,     unsigned long inlen,
+          unsigned char *V,      unsigned long *Vlen)
+{
+   int err, n;
+   unsigned long Dlen, TMPlen, Tlen, i, j;
+   unsigned char D[16], TMP[16], *T;
+   unsigned char zero_or_one[16] = {0};
+
+   if(ad == NULL || adlen == NULL || ad[0] == NULL || adlen[0] == 0) {
+      /* if n = 0 then
+       *   return V = AES-CMAC(K, <one>)
+       */
+      zero_or_one[0] = 1;
+      err = omac_memory(cipher, key, keylen, zero_or_one, sizeof(zero_or_one), V, Vlen);
+   } else {
+      /* D = AES-CMAC(K, <zero>) */
+      Dlen = sizeof(D);
+      if ((err = omac_memory(cipher, key, keylen, zero_or_one, sizeof(zero_or_one), D, &Dlen)) != CRYPT_OK) {
+         return err;
+      }
+      /* for i = 1 to n-1 do
+       *   D = dbl(D) xor AES-CMAC(K, Si)
+       * done
+       */
+      n = 0;
+      while(ad[n] != NULL && adlen[n] != 0) {
+         s_siv_dbl(D);
+         TMPlen = sizeof(TMP);
+         if ((err = omac_memory(cipher, key, keylen, ad[n], adlen[n], TMP, &TMPlen)) != CRYPT_OK) {
+            return err;
+         }
+         for (i = 0; i < sizeof(D); ++i) {
+            D[i] ^= TMP[i];
+         }
+         n++;
+      }
+      /* if len(Sn) >= 128 then
+       *   T = Sn xorend D
+       * else
+       *   T = dbl(D) xor pad(Sn)
+       * fi
+       */
+      Tlen = inlen >= 16 ? inlen : 16;
+      T = XMALLOC(Tlen);
+      if (T == NULL) {
+         return CRYPT_MEM;
+      }
+      XMEMCPY(T, in, inlen);
+      if (inlen >= 16) {
+         for(i = inlen - 16, j = 0; i < inlen; ++i, ++j) {
+            T[i] = D[j] ^ T[i];
+         }
+      } else {
+         s_siv_dbl(D);
+         T[inlen] = 0x80;
+         for (i = inlen + 1; i < 16; ++i) {
+            T[i] = 0x0;
+         }
+         for(i = 0; i < Tlen; ++i) {
+            T[i] ^= D[i];
+         }
+      }
+      err = omac_memory(cipher, key, keylen, T, Tlen, V, Vlen);
+#ifdef LTC_CLEAN_STACK
+      zeromem(T, Tlen);
+#endif
+      XFREE(T);
+   }
+
+   return err;
+
+}
+
+static void s_siv_bitand(const unsigned char* V, unsigned char* Q)
+{
+   int n;
+   XMEMSET(Q, 0xff, 16);
+   Q[8] = Q[12] = 0x7f;
+   for (n = 0; n < 16; ++n) {
+      Q[n] &= V[n];
+   }
+}
+
+
+typedef struct {
+   unsigned char V[16];
+   symmetric_CTR ctr;
+} siv_state;
+
+/**
+   SIV encrypt
+
+   @param cipher     The index of the cipher desired
+   @param key        The secret key to use
+   @param keylen     The length of the secret key (octets)
+   @param ad         An array of Associated Data pointers (must be NULL terminated)
+   @param adlen      An array with the lengths of the Associated Data
+   @param pt         The plaintext
+   @param ptlen      The length of the plaintext
+   @param ct         The ciphertext
+   @param ctlen      [in/out] The length of the ciphertext
+   @return CRYPT_OK if successful
+*/
+int siv_encrypt(int cipher,
+    const unsigned char *key,    unsigned long keylen,
+    const unsigned char **ad,    unsigned long *adlen,
+    const unsigned char *pt,     unsigned long ptlen,
+          unsigned char *ct,     unsigned long *ctlen)
+{
+   int err;
+   unsigned char Q[16];
+   const unsigned char *K1, *K2;
+   unsigned long Vlen;
+   siv_state siv;
+
+   LTC_ARGCHK(key    != NULL);
+   LTC_ARGCHK(ad     != NULL);
+   LTC_ARGCHK(adlen  != NULL);
+   LTC_ARGCHK(pt     != NULL);
+   LTC_ARGCHK(ct     != NULL);
+   LTC_ARGCHK(ctlen  != NULL);
+
+   if ((err = cipher_is_valid(cipher)) != CRYPT_OK) {
+      return err;
+   }
+   if (*ctlen < ptlen + 16) {
+      return CRYPT_BUFFER_OVERFLOW;
+   }
+
+   K1 = key;
+   K2 = &key[keylen/2];
+
+   Vlen = sizeof(siv.V);
+   err = s_siv_S2V(cipher, K1, keylen/2, ad, adlen, pt, ptlen, siv.V, &Vlen);
+#ifdef LTC_CLEAN_STACK
+   burn_stack(3 * 16 + 7 * sizeof(unsigned long) + 1 * sizeof(void*));
+#endif
+   if (err != CRYPT_OK) {
+      return err;
+   }
+   s_siv_bitand(siv.V, Q);
+   err = ctr_start(cipher, Q, K2, keylen/2, 0, CTR_COUNTER_BIG_ENDIAN | 16, &siv.ctr);
+   if (err != CRYPT_OK) {
+      goto out;
+   }
+   XMEMCPY(ct, siv.V, 16);
+   ct += 16;
+   err = ctr_encrypt(pt, ct, ptlen, &siv.ctr);
+   if (err != CRYPT_OK) {
+      zeromem(ct, ptlen + 16);
+   } else {
+      *ctlen = ptlen + 16;
+   }
+   ctr_done(&siv.ctr);
+
+out:
+#ifdef LTC_CLEAN_STACK
+   zeromem(Q, sizeof(Q));
+   zeromem(&siv, sizeof(siv));
+#endif
+
+   return err;
+}
+
+/**
+   SIV decrypt
+
+   @param cipher     The index of the cipher desired
+   @param key        The secret key to use
+   @param keylen     The length of the secret key (octets)
+   @param ad         An array of Associated Data pointers (must be NULL terminated)
+   @param adlen      An array with the lengths of the Associated Data
+   @param ct         The ciphertext
+   @param ctlen      The length of the ciphertext
+   @param pt         The plaintext
+   @param ptlen      [in/out] The length of the plaintext
+   @return CRYPT_OK if successful
+*/
+int siv_decrypt(int cipher,
+    const unsigned char *key,    unsigned long keylen,
+    const unsigned char **ad,    unsigned long *adlen,
+    const unsigned char *ct,     unsigned long ctlen,
+          unsigned char *pt,     unsigned long *ptlen)
+{
+   int err;
+   unsigned char Q[16], *pt_work;
+   const unsigned char *K1, *K2, *V;
+   unsigned long Vlen;
+   siv_state siv;
+
+   LTC_ARGCHK(key    != NULL);
+   LTC_ARGCHK(ad     != NULL);
+   LTC_ARGCHK(adlen  != NULL);
+   LTC_ARGCHK(ct     != NULL);
+   LTC_ARGCHK(pt     != NULL);
+   LTC_ARGCHK(ptlen  != NULL);
+
+   if ((err = cipher_is_valid(cipher)) != CRYPT_OK) {
+      return err;
+   }
+   if (*ptlen < ctlen || ctlen < 16) {
+      return CRYPT_BUFFER_OVERFLOW;
+   }
+
+   *ptlen = ctlen - 16;
+   pt_work = XMALLOC(*ptlen);
+   if (pt_work == NULL) {
+      return CRYPT_MEM;
+   }
+
+   K1 = key;
+   K2 = &key[keylen/2];
+
+   V = ct;
+   s_siv_bitand(V, Q);
+   ct += 16;
+
+   err = ctr_start(cipher, Q, K2, keylen/2, 0, CTR_COUNTER_BIG_ENDIAN | 16, &siv.ctr);
+   if (err != CRYPT_OK) {
+      goto out;
+   }
+   err = ctr_decrypt(ct, pt_work, *ptlen, &siv.ctr);
+   if (err != CRYPT_OK) {
+      goto out;
+   }
+   Vlen = sizeof(siv.V);
+   err = s_siv_S2V(cipher, K1, keylen/2, ad, adlen, pt_work, *ptlen, siv.V, &Vlen);
+#ifdef LTC_CLEAN_STACK
+   burn_stack(3 * 16 + 7 * sizeof(unsigned long) + 1 * sizeof(void*));
+#endif
+   if (err != CRYPT_OK) {
+      goto out;
+   }
+
+   err = XMEM_NEQ(siv.V, V, Vlen);
+   copy_or_zeromem(pt_work, pt, *ptlen, err);
+out:
+#ifdef LTC_CLEAN_STACK
+   zeromem(Q, sizeof(Q));
+   zeromem(&siv, sizeof(siv));
+   zeromem(pt_work, *ptlen);
+#endif
+   XFREE(pt_work);
+
+   return err;
+}
+
+int siv_test(void)
+{
+   /*
+    * RFC5297 - A.1.  Deterministic Authenticated Encryption Example
+    */
+   const unsigned char Key_A1[] =
+      { 0xff, 0xfe, 0xfd, 0xfc, 0xfb, 0xfa, 0xf9, 0xf8,
+        0xf7, 0xf6, 0xf5, 0xf4, 0xf3, 0xf2, 0xf1, 0xf0,
+        0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7,
+        0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff };
+   const unsigned char AD_A1[] =
+      { 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+        0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+        0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27 };
+   const unsigned char Plaintext_A1[] =
+      { 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+        0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee };
+   const unsigned char output_A1[] =
+      { 0x85, 0x63, 0x2d, 0x07, 0xc6, 0xe8, 0xf3, 0x7f,
+        0x95, 0x0a, 0xcd, 0x32, 0x0a, 0x2e, 0xcc, 0x93,
+        0x40, 0xc0, 0x2b, 0x96, 0x90, 0xc4, 0xdc, 0x04,
+        0xda, 0xef, 0x7f, 0x6a, 0xfe, 0x5c };
+   const unsigned char *ad_A1[] =
+      { AD_A1, NULL };
+   unsigned long adlen_A1[] =
+      { sizeof(AD_A1), 0 };
+
+   const unsigned char Key_A2[] =
+      { 0x7f, 0x7e, 0x7d, 0x7c, 0x7b, 0x7a, 0x79, 0x78,
+        0x77, 0x76, 0x75, 0x74, 0x73, 0x72, 0x71, 0x70,
+        0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47,
+        0x48, 0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 0x4f };
+   const unsigned char AD1_A2[] =
+      { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+        0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
+        0xde, 0xad, 0xda, 0xda, 0xde, 0xad, 0xda, 0xda,
+        0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, 0x99, 0x88,
+        0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00 };
+   const unsigned char AD2_A2[] =
+      { 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80,
+        0x90, 0xa0 };
+   const unsigned char AD3_A2[] =
+      { 0x09, 0xf9, 0x11, 0x02, 0x9d, 0x74, 0xe3, 0x5b,
+        0xd8, 0x41, 0x56, 0xc5, 0x63, 0x56, 0x88, 0xc0 };
+   const unsigned char Plaintext_A2[] =
+      { 0x74, 0x68, 0x69, 0x73, 0x20, 0x69, 0x73, 0x20,
+        0x73, 0x6f, 0x6d, 0x65, 0x20, 0x70, 0x6c, 0x61,
+        0x69, 0x6e, 0x74, 0x65, 0x78, 0x74, 0x20, 0x74,
+        0x6f, 0x20, 0x65, 0x6e, 0x63, 0x72, 0x79, 0x70,
+        0x74, 0x20, 0x75, 0x73, 0x69, 0x6e, 0x67, 0x20,
+        0x53, 0x49, 0x56, 0x2d, 0x41, 0x45, 0x53 };
+   const unsigned char output_A2[] =
+      { 0x7b, 0xdb, 0x6e, 0x3b, 0x43, 0x26, 0x67, 0xeb,
+        0x06, 0xf4, 0xd1, 0x4b, 0xff, 0x2f, 0xbd, 0x0f,
+        0xcb, 0x90, 0x0f, 0x2f, 0xdd, 0xbe, 0x40, 0x43,
+        0x26, 0x60, 0x19, 0x65, 0xc8, 0x89, 0xbf, 0x17,
+        0xdb, 0xa7, 0x7c, 0xeb, 0x09, 0x4f, 0xa6, 0x63,
+        0xb7, 0xa3, 0xf7, 0x48, 0xba, 0x8a, 0xf8, 0x29,
+        0xea, 0x64, 0xad, 0x54, 0x4a, 0x27, 0x2e, 0x9c,
+        0x48, 0x5b, 0x62, 0xa3, 0xfd, 0x5c, 0x0d };
+   const unsigned char *ad_A2[] =
+      { AD1_A2, AD2_A2, AD3_A2, NULL };
+   unsigned long adlen_A2[] =
+      { sizeof(AD1_A2), sizeof(AD2_A2), sizeof(AD3_A2), 0 };
+
+#define PL_PAIR(n) n, sizeof(n)
+   struct {
+      const unsigned char* Key;
+            unsigned long  Keylen;
+      const unsigned char* Plaintext;
+            unsigned long  Plaintextlen;
+      const          void* ADs;
+                     void* ADlens;
+      const unsigned char* output;
+            unsigned long  outputlen;
+      const          char* name;
+   } siv_tests[] = {
+     { PL_PAIR(Key_A1), PL_PAIR(Plaintext_A1), &ad_A1, &adlen_A1, PL_PAIR(output_A1), "RFC5297 - A.1.  Deterministic Authenticated Encryption Example" },
+     { PL_PAIR(Key_A2), PL_PAIR(Plaintext_A2), &ad_A2, &adlen_A2, PL_PAIR(output_A2), "RFC5297 - A.2.  Nonce-Based Authenticated Encryption Example" }
+   };
+#undef PL_PAIR
+
+   int err;
+   unsigned n;
+   unsigned char buf[MAX(sizeof(output_A1), sizeof(output_A2))];
+
+   for (n = 0; n < sizeof(siv_tests)/sizeof(siv_tests[0]); ++n) {
+      unsigned long buflen = sizeof(buf);
+      if ((err = siv_encrypt(find_cipher("aes"),
+                             siv_tests[n].Key, siv_tests[n].Keylen,
+                             (const unsigned char **)siv_tests[n].ADs, siv_tests[n].ADlens,
+                             siv_tests[n].Plaintext, siv_tests[n].Plaintextlen,
+                             buf, &buflen)) != CRYPT_OK) {
+         return err;
+      }
+      if (compare_testvector(buf, buflen, siv_tests[n].output, siv_tests[n].outputlen, siv_tests[n].name, n) != 0) {
+         return CRYPT_FAIL_TESTVECTOR;
+      }
+      buflen = sizeof(buf);
+      if ((err = siv_decrypt(find_cipher("aes"),
+                             siv_tests[n].Key, siv_tests[n].Keylen,
+                             (const unsigned char **)siv_tests[n].ADs, siv_tests[n].ADlens,
+                             siv_tests[n].output, siv_tests[n].outputlen,
+                             buf, &buflen)) != CRYPT_OK) {
+         return err;
+      }
+      if (compare_testvector(buf, buflen, siv_tests[n].Plaintext, siv_tests[n].Plaintextlen, siv_tests[n].name, n + 1000) != 0) {
+         return CRYPT_FAIL_TESTVECTOR;
+      }
+   }
+
+   return CRYPT_OK;
+}
+#endif
+
+/* ref:         $Format:%D$ */
+/* git commit:  $Format:%H$ */
+/* commit time: $Format:%ai$ */

--- a/src/headers/tomcrypt_custom.h
+++ b/src/headers/tomcrypt_custom.h
@@ -301,6 +301,7 @@
 #define LTC_CCM_MODE
 #define LTC_GCM_MODE
 #define LTC_CHACHA20POLY1305_MODE
+#define LTC_SIV_MODE
 
 /* Use 64KiB tables */
 #ifndef LTC_NO_TABLES

--- a/src/headers/tomcrypt_mac.h
+++ b/src/headers/tomcrypt_mac.h
@@ -569,10 +569,19 @@ int chacha20poly1305_test(void);
 
 int siv_encrypt(int cipher,
     const unsigned char *key,    unsigned long keylen,
-    const unsigned char **ad,    unsigned long *adlen,
-    const unsigned char *in,     unsigned long inlen,
-          unsigned char *out,    unsigned long *outlen);
-
+    const unsigned char *ad[],   unsigned long adlen[],
+    const unsigned char *pt,     unsigned long ptlen,
+          unsigned char *ct,     unsigned long *ctlen);
+int siv_decrypt(int cipher,
+    const unsigned char *key,    unsigned long keylen,
+    const unsigned char *ad[],   unsigned long adlen[],
+    const unsigned char *ct,     unsigned long ctlen,
+          unsigned char *pt,     unsigned long *ptlen);
+int siv_memory(                int cipher,           int direction,
+               const unsigned char *key,   unsigned long keylen,
+               const unsigned char *in,    unsigned long inlen,
+                     unsigned char *out,   unsigned long *outlen,
+               ...) LTC_NULL_TERMINATED;
 int siv_test(void);
 
 #endif

--- a/src/headers/tomcrypt_mac.h
+++ b/src/headers/tomcrypt_mac.h
@@ -567,21 +567,21 @@ int chacha20poly1305_test(void);
 #endif /* LTC_CHACHA20POLY1305_MODE */
 #ifdef LTC_SIV_MODE
 
-int siv_encrypt(int cipher,
-    const unsigned char *key,    unsigned long keylen,
-    const unsigned char *ad[],   unsigned long adlen[],
-    const unsigned char *pt,     unsigned long ptlen,
-          unsigned char *ct,     unsigned long *ctlen);
-int siv_decrypt(int cipher,
-    const unsigned char *key,    unsigned long keylen,
-    const unsigned char *ad[],   unsigned long adlen[],
-    const unsigned char *ct,     unsigned long ctlen,
-          unsigned char *pt,     unsigned long *ptlen);
-int siv_memory(                int cipher,           int direction,
-               const unsigned char *key,   unsigned long keylen,
-               const unsigned char *in,    unsigned long inlen,
-                     unsigned char *out,   unsigned long *outlen,
-               ...) LTC_NULL_TERMINATED;
+int siv_encrypt_memory(                int  cipher,
+                       const unsigned char *key,    unsigned long  keylen,
+                       const unsigned char *ad[],   unsigned long  adlen[],
+                       const unsigned char *pt,     unsigned long  ptlen,
+                             unsigned char *ct,     unsigned long *ctlen);
+int siv_decrypt_memory(                int  cipher,
+                       const unsigned char *key,    unsigned long  keylen,
+                       const unsigned char *ad[],   unsigned long  adlen[],
+                       const unsigned char *ct,     unsigned long  ctlen,
+                             unsigned char *pt,     unsigned long *ptlen);
+int siv_memory(                int  cipher,           int  direction,
+               const unsigned char *key,    unsigned long  keylen,
+               const unsigned char *in,     unsigned long  inlen,
+                     unsigned char *out,    unsigned long *outlen,
+                                   ...) LTC_NULL_TERMINATED;
 int siv_test(void);
 
 #endif

--- a/src/headers/tomcrypt_mac.h
+++ b/src/headers/tomcrypt_mac.h
@@ -565,3 +565,15 @@ int chacha20poly1305_memory(const unsigned char *key, unsigned long keylen,
 int chacha20poly1305_test(void);
 
 #endif /* LTC_CHACHA20POLY1305_MODE */
+#ifdef LTC_SIV_MODE
+
+int siv_encrypt(int cipher,
+    const unsigned char *key,    unsigned long keylen,
+    const unsigned char **ad,    unsigned long *adlen,
+    const unsigned char *in,     unsigned long inlen,
+          unsigned char *out,    unsigned long *outlen);
+
+int siv_test(void);
+
+#endif
+

--- a/src/headers/tomcrypt_private.h
+++ b/src/headers/tomcrypt_private.h
@@ -168,6 +168,7 @@ int func_name (hash_state * md, const unsigned char *in, unsigned long inlen)   
 int ocb3_int_ntz(unsigned long x);
 void ocb3_int_xor_blocks(unsigned char *out, const unsigned char *block_a, const unsigned char *block_b, unsigned long block_len);
 
+int omac_vprocess(omac_state *omac, const unsigned char *in,  unsigned long inlen, va_list args);
 
 /* tomcrypt_math.h */
 

--- a/src/mac/omac/omac_memory_multi.c
+++ b/src/mac/omac/omac_memory_multi.c
@@ -10,6 +10,31 @@
 
 #ifdef LTC_OMAC
 
+static LTC_INLINE int s_omac_vprocess(omac_state *omac, const unsigned char *in,  unsigned long inlen, va_list args)
+{
+   const unsigned char * curptr = in;
+   unsigned long curlen = inlen;
+   int err;
+   for (;;) {
+      /* process buf */
+      if ((err = omac_process(omac, curptr, curlen)) != CRYPT_OK) {
+         return err;
+      }
+      /* step to next */
+      curptr = va_arg(args, const unsigned char*);
+      if (curptr == NULL) {
+         break;
+      }
+      curlen = va_arg(args, unsigned long);
+   }
+   return CRYPT_OK;
+}
+
+int omac_vprocess(omac_state *omac, const unsigned char *in,  unsigned long inlen, va_list args)
+{
+   return s_omac_vprocess(omac, in, inlen, args);
+}
+
 /**
    OMAC multiple blocks of memory
    @param cipher    The index of the desired cipher
@@ -30,8 +55,6 @@ int omac_memory_multi(int cipher,
    int                  err;
    omac_state          *omac;
    va_list              args;
-   const unsigned char *curptr;
-   unsigned long        curlen;
 
    LTC_ARGCHK(key    != NULL);
    LTC_ARGCHK(in     != NULL);
@@ -49,23 +72,10 @@ int omac_memory_multi(int cipher,
       goto LBL_ERR;
    }
    va_start(args, inlen);
-   curptr = in;
-   curlen = inlen;
-   for (;;) {
-      /* process buf */
-      if ((err = omac_process(omac, curptr, curlen)) != CRYPT_OK) {
-         goto LBL_ERR;
-      }
-      /* step to next */
-      curptr = va_arg(args, const unsigned char*);
-      if (curptr == NULL) {
-         break;
-      }
-      curlen = va_arg(args, unsigned long);
-   }
-   if ((err = omac_done(omac, out, outlen)) != CRYPT_OK) {
+   if ((err = s_omac_vprocess(omac, in, inlen, args)) != CRYPT_OK) {
       goto LBL_ERR;
    }
+   err = omac_done(omac, out, outlen);
 LBL_ERR:
 #ifdef LTC_CLEAN_STACK
    zeromem(omac, sizeof(omac_state));

--- a/src/misc/crypt/crypt.c
+++ b/src/misc/crypt/crypt.c
@@ -303,6 +303,9 @@ const char *crypt_build_settings =
 #if defined(LTC_CHACHA20POLY1305_MODE)
     "   CHACHA20POLY1305\n"
 #endif
+#if defined(LTC_SIV_MODE)
+    "   SIV\n"
+#endif
 
     "\nPRNG:\n"
 #if defined(LTC_YARROW)

--- a/tests/mac_test.c
+++ b/tests/mac_test.c
@@ -50,5 +50,8 @@ int mac_test(void)
 #ifdef LTC_BLAKE2BMAC
    DO(blake2bmac_test());
 #endif
+#ifdef LTC_SIV_MODE
+   DO(siv_test());
+#endif
    return 0;
 }


### PR DESCRIPTION
### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

* [x] documentation is added or updated
* [x] tests are added or updated

This is a PoC/RFC for adding the enc+auth mode [RFC5297 SIV - Synthetic Initialization Vector](https://tools.ietf.org/html/rfc5297).

Feel free to tear it apart, improvements on the API welcome.

I had to decide how to process the AD's
1. incremental
2. by passing a vararg
3. by passing an array of pointers

1 wasn't really an option AFAIU the RFC
whether 2 or 3 I was like ¯\\_(ツ)\_/¯ so I went for 3

I didn't really look if it would make sense to have the context exposed so we could split the processing up in `init()->add_ad()->{en,de}crypt()->done()`