### PR TITLE
Added missing 'const' qualifier to many functions' parameters 

### DIFF
--- a/src/ciphers/aes/aes.c
+++ b/src/ciphers/aes/aes.c
@@ -281,12 +281,13 @@ int SETUP(const unsigned char *key, int keylen, int num_rounds, symmetric_key *s
   @return CRYPT_OK if successful
 */
 #ifdef LTC_CLEAN_STACK
-static int _rijndael_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+static int _rijndael_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 #else
-int ECB_ENC(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+int ECB_ENC(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 #endif
 {
-    ulong32 s0, s1, s2, s3, t0, t1, t2, t3, *rk;
+    ulong32 s0, s1, s2, s3, t0, t1, t2, t3;
+    const ulong32 *rk;
     int Nr, r;
 
     LTC_ARGCHK(pt != NULL);
@@ -442,7 +443,7 @@ int ECB_ENC(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
 }
 
 #ifdef LTC_CLEAN_STACK
-int ECB_ENC(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+int ECB_ENC(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 {
    int err = _rijndael_ecb_encrypt(pt, ct, skey);
    burn_stack(sizeof(unsigned long)*8 + sizeof(unsigned long*) + sizeof(int)*2);
@@ -460,12 +461,13 @@ int ECB_ENC(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
   @return CRYPT_OK if successful
 */
 #ifdef LTC_CLEAN_STACK
-static int _rijndael_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+static int _rijndael_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 #else
-int ECB_DEC(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+int ECB_DEC(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 #endif
 {
-    ulong32 s0, s1, s2, s3, t0, t1, t2, t3, *rk;
+    ulong32 s0, s1, s2, s3, t0, t1, t2, t3;
+    const ulong32 *rk;
     int Nr, r;
 
     LTC_ARGCHK(pt != NULL);
@@ -622,7 +624,7 @@ int ECB_DEC(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
 
 
 #ifdef LTC_CLEAN_STACK
-int ECB_DEC(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+int ECB_DEC(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 {
    int err = _rijndael_ecb_decrypt(ct, pt, skey);
    burn_stack(sizeof(unsigned long)*8 + sizeof(unsigned long*) + sizeof(int)*2);

--- a/src/ciphers/anubis.c
+++ b/src/ciphers/anubis.c
@@ -1035,7 +1035,7 @@ int  anubis_setup(const unsigned char *key, int keylen, int num_rounds, symmetri
 
 
 static void anubis_crypt(const unsigned char *plaintext, unsigned char *ciphertext,
-                         ulong32 roundKey[18 + 1][4], int R) {
+                         const ulong32 roundKey[18 + 1][4], int R) {
    int i, pos, r;
    ulong32 state[4];
    ulong32 inter[4];
@@ -1134,7 +1134,7 @@ static void anubis_crypt(const unsigned char *plaintext, unsigned char *cipherte
   @param skey The key as scheduled
   @return CRYPT_OK if successful
 */
-int anubis_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+int anubis_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 {
    LTC_ARGCHK(pt   != NULL);
    LTC_ARGCHK(ct   != NULL);
@@ -1150,7 +1150,7 @@ int anubis_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key
   @param skey The key as scheduled
   @return CRYPT_OK if successful
 */
-int anubis_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+int anubis_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 {
    LTC_ARGCHK(pt   != NULL);
    LTC_ARGCHK(ct   != NULL);

--- a/src/ciphers/blowfish.c
+++ b/src/ciphers/blowfish.c
@@ -386,9 +386,9 @@ int blowfish_setup(const unsigned char *key, int keylen, int num_rounds,
   @return CRYPT_OK if successful
 */
 #ifdef LTC_CLEAN_STACK
-static int _blowfish_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+static int _blowfish_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 #else
-int blowfish_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+int blowfish_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 #endif
 {
    ulong32 L, R;
@@ -432,7 +432,7 @@ int blowfish_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_k
 }
 
 #ifdef LTC_CLEAN_STACK
-int blowfish_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+int blowfish_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 {
     int err = _blowfish_ecb_encrypt(pt, ct, skey);
     burn_stack(sizeof(ulong32) * 2 + sizeof(int));
@@ -448,9 +448,9 @@ int blowfish_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_k
   @return CRYPT_OK if successful
 */
 #ifdef LTC_CLEAN_STACK
-static int _blowfish_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+static int _blowfish_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 #else
-int blowfish_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+int blowfish_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 #endif
 {
    ulong32 L, R;
@@ -493,7 +493,7 @@ int blowfish_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_k
 }
 
 #ifdef LTC_CLEAN_STACK
-int blowfish_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+int blowfish_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 {
     int err = _blowfish_ecb_decrypt(ct, pt, skey);
     burn_stack(sizeof(ulong32) * 2 + sizeof(int));

--- a/src/ciphers/camellia.c
+++ b/src/ciphers/camellia.c
@@ -436,7 +436,7 @@ int camellia_setup(const unsigned char *key, int keylen, int num_rounds, symmetr
    return CRYPT_OK;
 }
 
-int camellia_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+int camellia_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 {
    ulong64 L, R;
    ulong32 a, b;
@@ -530,7 +530,7 @@ int camellia_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_k
    return CRYPT_OK;
 }
 
-int camellia_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+int camellia_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 {
    ulong64 L, R;
    ulong32 a, b;

--- a/src/ciphers/camellia.c
+++ b/src/ciphers/camellia.c
@@ -193,7 +193,7 @@ static ulong64 F(ulong64 x)
    return ((ulong64)U) | (((ulong64)D) << CONST64(32));
 }
 
-static void rot_128(unsigned char *in, unsigned count, unsigned char *out)
+static void rot_128(const unsigned char *in, unsigned count, unsigned char *out)
 {
    unsigned x, w, b;
 

--- a/src/ciphers/cast5.c
+++ b/src/ciphers/cast5.c
@@ -534,9 +534,9 @@ INLINE static ulong32 FIII(ulong32 R, ulong32 Km, ulong32 Kr)
   @param skey The key as scheduled
 */
 #ifdef LTC_CLEAN_STACK
-static int _cast5_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+static int _cast5_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 #else
-int cast5_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+int cast5_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 #endif
 {
    ulong32 R, L;
@@ -572,7 +572,7 @@ int cast5_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key 
 
 
 #ifdef LTC_CLEAN_STACK
-int cast5_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+int cast5_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 {
    int err =_cast5_ecb_encrypt(pt,ct,skey);
    burn_stack(sizeof(ulong32)*3);
@@ -587,9 +587,9 @@ int cast5_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key 
   @param skey The key as scheduled
 */
 #ifdef LTC_CLEAN_STACK
-static int _cast5_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+static int _cast5_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 #else
-int cast5_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+int cast5_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 #endif
 {
    ulong32 R, L;
@@ -625,7 +625,7 @@ int cast5_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key 
 }
 
 #ifdef LTC_CLEAN_STACK
-int cast5_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+int cast5_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 {
    int err = _cast5_ecb_decrypt(ct,pt,skey);
    burn_stack(sizeof(ulong32)*3);

--- a/src/ciphers/des.c
+++ b/src/ciphers/des.c
@@ -1592,7 +1592,7 @@ int des3_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_k
   @param skey The key as scheduled
   @return CRYPT_OK if successful
 */
-int des_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+int des_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 {
     ulong32 work[2];
     LTC_ARGCHK(pt   != NULL);
@@ -1613,7 +1613,7 @@ int des_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *s
   @param skey The key as scheduled
   @return CRYPT_OK if successful
 */
-int des_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+int des_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 {
     ulong32 work[2];
     LTC_ARGCHK(pt   != NULL);
@@ -1634,7 +1634,7 @@ int des_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *s
   @param skey The key as scheduled
   @return CRYPT_OK if successful
 */
-int des3_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+int des3_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 {
     ulong32 work[2];
 
@@ -1658,7 +1658,7 @@ int des3_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *
   @param skey The key as scheduled
   @return CRYPT_OK if successful
 */
-int des3_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+int des3_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 {
     ulong32 work[2];
     LTC_ARGCHK(pt   != NULL);

--- a/src/ciphers/idea.c
+++ b/src/ciphers/idea.c
@@ -104,7 +104,7 @@ static int _setup_key(const unsigned char *key, symmetric_key *skey)
    return CRYPT_OK;
 }
 
-static int _process_block(const unsigned char *in, unsigned char *out, ushort16 *m_key)
+static int _process_block(const unsigned char *in, unsigned char *out, const ushort16 *m_key)
 {
    int i;
    ushort16 x0, x1, x2, x3, t0, t1;

--- a/src/ciphers/idea.c
+++ b/src/ciphers/idea.c
@@ -155,7 +155,7 @@ int idea_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_k
    return _setup_key(key, skey);
 }
 
-int idea_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+int idea_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 {
    int err = _process_block(pt, ct, skey->idea.ek);
 #ifdef LTC_CLEAN_STACK
@@ -164,7 +164,7 @@ int idea_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *
    return err;
 }
 
-int idea_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+int idea_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 {
    int err = _process_block(ct, pt, skey->idea.dk);
 #ifdef LTC_CLEAN_STACK

--- a/src/ciphers/kasumi.c
+++ b/src/ciphers/kasumi.c
@@ -96,7 +96,7 @@ static u16 FI( u16 in, u16 subkey )
   return (u16)(seven<<9) + nine;
 }
 
-static ulong32 FO( ulong32 in, int round_no, symmetric_key *key)
+static ulong32 FO( ulong32 in, int round_no, const symmetric_key *key)
 {
    u16 left, right;
 
@@ -120,7 +120,7 @@ static ulong32 FO( ulong32 in, int round_no, symmetric_key *key)
   return (((ulong32)right)<<16)+left;
 }
 
-static ulong32 FL( ulong32 in, int round_no, symmetric_key *key )
+static ulong32 FL( ulong32 in, int round_no, const symmetric_key *key )
 {
     u16 l, r, a, b;
     /* split out the left and right halves */
@@ -136,7 +136,7 @@ static ulong32 FL( ulong32 in, int round_no, symmetric_key *key )
     return (((ulong32)l)<<16) + r;
 }
 
-int kasumi_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+int kasumi_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 {
     ulong32 left, right, temp;
     int n;
@@ -163,7 +163,7 @@ int kasumi_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key
     return CRYPT_OK;
 }
 
-int kasumi_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+int kasumi_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 {
     ulong32 left, right, temp;
     int n;

--- a/src/ciphers/khazad.c
+++ b/src/ciphers/khazad.c
@@ -741,7 +741,7 @@ static void khazad_crypt(const unsigned char *plaintext, unsigned char *cipherte
   @param skey The key as scheduled
   @return CRYPT_OK if successful
 */
-int khazad_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+int khazad_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 {
    LTC_ARGCHK(pt   != NULL);
    LTC_ARGCHK(ct   != NULL);
@@ -757,7 +757,7 @@ int khazad_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key
   @param skey The key as scheduled
   @return CRYPT_OK if successful
 */
-int khazad_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+int khazad_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 {
    LTC_ARGCHK(pt   != NULL);
    LTC_ARGCHK(ct   != NULL);

--- a/src/ciphers/kseed.c
+++ b/src/ciphers/kseed.c
@@ -254,7 +254,7 @@ static void rounds(ulong32 *P, const ulong32 *K)
   @param skey The key as scheduled
   @return CRYPT_OK if successful
 */
-int kseed_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+int kseed_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 {
    ulong32 P[4];
    LOAD32H(P[0], pt);
@@ -276,7 +276,7 @@ int kseed_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key 
   @param skey The key as scheduled
   @return CRYPT_OK if successful
 */
-int kseed_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+int kseed_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 {
    ulong32 P[4];
    LOAD32H(P[0], ct);

--- a/src/ciphers/kseed.c
+++ b/src/ciphers/kseed.c
@@ -236,7 +236,7 @@ int kseed_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_
    return CRYPT_OK;
 }
 
-static void rounds(ulong32 *P, ulong32 *K)
+static void rounds(ulong32 *P, const ulong32 *K)
 {
    ulong32 T, T2;
    int     i;

--- a/src/ciphers/multi2.c
+++ b/src/ciphers/multi2.c
@@ -49,7 +49,7 @@ static void pi4(ulong32 *p, const ulong32 *k)
    p[0] ^= t;
 }
 
-static void setup(const ulong32 *dk, ulong32 *k, ulong32 *uk)
+static void setup(const ulong32 *dk, const ulong32 *k, ulong32 *uk)
 {
    int n, t;
    ulong32 p[2];
@@ -77,7 +77,7 @@ static void setup(const ulong32 *dk, ulong32 *k, ulong32 *uk)
       uk[n++] = p[1];
 }
 
-static void encrypt(ulong32 *p, int N, ulong32 *uk)
+static void encrypt(ulong32 *p, int N, const ulong32 *uk)
 {
    int n, t;
    for (t = n = 0; ; ) {
@@ -89,7 +89,7 @@ static void encrypt(ulong32 *p, int N, ulong32 *uk)
    }
 }
 
-static void decrypt(ulong32 *p, int N, ulong32 *uk)
+static void decrypt(ulong32 *p, int N, const ulong32 *uk)
 {
    int n, t;
    for (t = 4*(((N-1)>>2)&1), n = N; ;  ) {
@@ -148,7 +148,7 @@ int  multi2_setup(const unsigned char *key, int keylen, int num_rounds, symmetri
   @param skey The key as scheduled
   @return CRYPT_OK if successful
 */
-int multi2_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+int multi2_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 {
    ulong32 p[2];
    LTC_ARGCHK(pt   != NULL);
@@ -169,7 +169,7 @@ int multi2_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key
   @param skey The key as scheduled
   @return CRYPT_OK if successful
 */
-int multi2_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+int multi2_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 {
    ulong32 p[2];
    LTC_ARGCHK(pt   != NULL);

--- a/src/ciphers/multi2.c
+++ b/src/ciphers/multi2.c
@@ -20,7 +20,7 @@ static void pi1(ulong32 *p)
    p[1] ^= p[0];
 }
 
-static void pi2(ulong32 *p, ulong32 *k)
+static void pi2(ulong32 *p, const ulong32 *k)
 {
    ulong32 t;
    t = (p[1] + k[0]) & 0xFFFFFFFFUL;
@@ -29,7 +29,7 @@ static void pi2(ulong32 *p, ulong32 *k)
    p[0] ^= t;
 }
 
-static void pi3(ulong32 *p, ulong32 *k)
+static void pi3(ulong32 *p, const ulong32 *k)
 {
    ulong32 t;
    t = p[0] + k[1];
@@ -41,7 +41,7 @@ static void pi3(ulong32 *p, ulong32 *k)
    p[1] ^= t;
 }
 
-static void pi4(ulong32 *p, ulong32 *k)
+static void pi4(ulong32 *p, const ulong32 *k)
 {
    ulong32 t;
    t = (p[1] + k[3])  & 0xFFFFFFFFUL;
@@ -49,7 +49,7 @@ static void pi4(ulong32 *p, ulong32 *k)
    p[0] ^= t;
 }
 
-static void setup(ulong32 *dk, ulong32 *k, ulong32 *uk)
+static void setup(const ulong32 *dk, ulong32 *k, ulong32 *uk)
 {
    int n, t;
    ulong32 p[2];

--- a/src/ciphers/noekeon.c
+++ b/src/ciphers/noekeon.c
@@ -108,9 +108,9 @@ int noekeon_setup(const unsigned char *key, int keylen, int num_rounds, symmetri
   @return CRYPT_OK if successful
 */
 #ifdef LTC_CLEAN_STACK
-static int _noekeon_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+static int _noekeon_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 #else
-int noekeon_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+int noekeon_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 #endif
 {
    ulong32 a,b,c,d,temp;
@@ -146,7 +146,7 @@ int noekeon_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_ke
 }
 
 #ifdef LTC_CLEAN_STACK
-int noekeon_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+int noekeon_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 {
    int err = _noekeon_ecb_encrypt(pt, ct, skey);
    burn_stack(sizeof(ulong32) * 5 + sizeof(int));
@@ -162,9 +162,9 @@ int noekeon_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_ke
   @return CRYPT_OK if successful
 */
 #ifdef LTC_CLEAN_STACK
-static int _noekeon_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+static int _noekeon_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 #else
-int noekeon_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+int noekeon_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 #endif
 {
    ulong32 a,b,c,d, temp;
@@ -199,7 +199,7 @@ int noekeon_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_ke
 }
 
 #ifdef LTC_CLEAN_STACK
-int noekeon_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+int noekeon_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 {
    int err = _noekeon_ecb_decrypt(ct, pt, skey);
    burn_stack(sizeof(ulong32) * 5 + sizeof(int));

--- a/src/ciphers/rc2.c
+++ b/src/ciphers/rc2.c
@@ -147,14 +147,14 @@ int rc2_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_ke
 #ifdef LTC_CLEAN_STACK
 static int _rc2_ecb_encrypt( const unsigned char *pt,
                             unsigned char *ct,
-                            symmetric_key *skey)
+                            const symmetric_key *skey)
 #else
 int rc2_ecb_encrypt( const unsigned char *pt,
                             unsigned char *ct,
-                            symmetric_key *skey)
+                            const symmetric_key *skey)
 #endif
 {
-    unsigned *xkey;
+    const unsigned *xkey;
     unsigned x76, x54, x32, x10, i;
 
     LTC_ARGCHK(pt  != NULL);
@@ -204,7 +204,7 @@ int rc2_ecb_encrypt( const unsigned char *pt,
 #ifdef LTC_CLEAN_STACK
 int rc2_ecb_encrypt( const unsigned char *pt,
                             unsigned char *ct,
-                            symmetric_key *skey)
+                            const symmetric_key *skey)
 {
     int err = _rc2_ecb_encrypt(pt, ct, skey);
     burn_stack(sizeof(unsigned *) + sizeof(unsigned) * 5);
@@ -225,15 +225,15 @@ int rc2_ecb_encrypt( const unsigned char *pt,
 #ifdef LTC_CLEAN_STACK
 static int _rc2_ecb_decrypt( const unsigned char *ct,
                             unsigned char *pt,
-                            symmetric_key *skey)
+                            const symmetric_key *skey)
 #else
 int rc2_ecb_decrypt( const unsigned char *ct,
                             unsigned char *pt,
-                            symmetric_key *skey)
+                            const symmetric_key *skey)
 #endif
 {
     unsigned x76, x54, x32, x10;
-    unsigned *xkey;
+    const unsigned *xkey;
     int i;
 
     LTC_ARGCHK(pt  != NULL);
@@ -283,7 +283,7 @@ int rc2_ecb_decrypt( const unsigned char *ct,
 #ifdef LTC_CLEAN_STACK
 int rc2_ecb_decrypt( const unsigned char *ct,
                             unsigned char *pt,
-                            symmetric_key *skey)
+                            const symmetric_key *skey)
 {
     int err = _rc2_ecb_decrypt(ct, pt, skey);
     burn_stack(sizeof(unsigned *) + sizeof(unsigned) * 4 + sizeof(int));

--- a/src/ciphers/rc5.c
+++ b/src/ciphers/rc5.c
@@ -124,12 +124,13 @@ int rc5_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_ke
   @return CRYPT_OK if successful
 */
 #ifdef LTC_CLEAN_STACK
-static int _rc5_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+static int _rc5_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 #else
-int rc5_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+int rc5_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 #endif
 {
-   ulong32 A, B, *K;
+   ulong32 A, B;
+   const ulong32 *K;
    int r;
    LTC_ARGCHK(skey != NULL);
    LTC_ARGCHK(pt   != NULL);
@@ -163,7 +164,7 @@ int rc5_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *s
 }
 
 #ifdef LTC_CLEAN_STACK
-int rc5_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+int rc5_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 {
    int err = _rc5_ecb_encrypt(pt, ct, skey);
    burn_stack(sizeof(ulong32) * 2 + sizeof(int));
@@ -179,12 +180,13 @@ int rc5_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *s
   @return CRYPT_OK if successful
 */
 #ifdef LTC_CLEAN_STACK
-static int _rc5_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+static int _rc5_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 #else
-int rc5_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+int rc5_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 #endif
 {
-   ulong32 A, B, *K;
+   ulong32 A, B;
+   const ulong32 *K;
    int r;
    LTC_ARGCHK(skey != NULL);
    LTC_ARGCHK(pt   != NULL);
@@ -219,7 +221,7 @@ int rc5_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *s
 }
 
 #ifdef LTC_CLEAN_STACK
-int rc5_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+int rc5_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 {
    int err = _rc5_ecb_decrypt(ct, pt, skey);
    burn_stack(sizeof(ulong32) * 2 + sizeof(int));

--- a/src/ciphers/rc6.c
+++ b/src/ciphers/rc6.c
@@ -118,12 +118,13 @@ int rc6_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_ke
   @param skey The key as scheduled
 */
 #ifdef LTC_CLEAN_STACK
-static int _rc6_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+static int _rc6_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 #else
-int rc6_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+int rc6_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 #endif
 {
-   ulong32 a,b,c,d,t,u, *K;
+   ulong32 a,b,c,d,t,u;
+   const ulong32 *K;
    int r;
 
    LTC_ARGCHK(skey != NULL);
@@ -157,7 +158,7 @@ int rc6_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *s
 }
 
 #ifdef LTC_CLEAN_STACK
-int rc6_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+int rc6_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 {
    int err = _rc6_ecb_encrypt(pt, ct, skey);
    burn_stack(sizeof(ulong32) * 6 + sizeof(int));
@@ -172,12 +173,13 @@ int rc6_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *s
   @param skey The key as scheduled
 */
 #ifdef LTC_CLEAN_STACK
-static int _rc6_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+static int _rc6_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 #else
-int rc6_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+int rc6_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 #endif
 {
-   ulong32 a,b,c,d,t,u, *K;
+   ulong32 a,b,c,d,t,u;
+   const ulong32 *K;
    int r;
 
    LTC_ARGCHK(skey != NULL);
@@ -213,7 +215,7 @@ int rc6_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *s
 }
 
 #ifdef LTC_CLEAN_STACK
-int rc6_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+int rc6_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 {
    int err = _rc6_ecb_decrypt(ct, pt, skey);
    burn_stack(sizeof(ulong32) * 6 + sizeof(int));

--- a/src/ciphers/safer/safer.c
+++ b/src/ciphers/safer/safer.c
@@ -247,15 +247,15 @@ int safer_sk128_setup(const unsigned char *key, int keylen, int numrounds, symme
 #ifdef LTC_CLEAN_STACK
 static int _safer_ecb_encrypt(const unsigned char *block_in,
                              unsigned char *block_out,
-                             symmetric_key *skey)
+                             const symmetric_key *skey)
 #else
 int safer_ecb_encrypt(const unsigned char *block_in,
                              unsigned char *block_out,
-                             symmetric_key *skey)
+                             const symmetric_key *skey)
 #endif
 {   unsigned char a, b, c, d, e, f, g, h, t;
     unsigned int round;
-    unsigned char *key;
+    const unsigned char *key;
 
     LTC_ARGCHK(block_in != NULL);
     LTC_ARGCHK(block_out != NULL);
@@ -290,7 +290,7 @@ int safer_ecb_encrypt(const unsigned char *block_in,
 #ifdef LTC_CLEAN_STACK
 int safer_ecb_encrypt(const unsigned char *block_in,
                              unsigned char *block_out,
-                             symmetric_key *skey)
+                             const symmetric_key *skey)
 {
     int err = _safer_ecb_encrypt(block_in, block_out, skey);
     burn_stack(sizeof(unsigned char) * 9 + sizeof(unsigned int) + sizeof(unsigned char *));
@@ -301,15 +301,15 @@ int safer_ecb_encrypt(const unsigned char *block_in,
 #ifdef LTC_CLEAN_STACK
 static int _safer_ecb_decrypt(const unsigned char *block_in,
                              unsigned char *block_out,
-                             symmetric_key *skey)
+                             const symmetric_key *skey)
 #else
 int safer_ecb_decrypt(const unsigned char *block_in,
                              unsigned char *block_out,
-                             symmetric_key *skey)
+                             const symmetric_key *skey)
 #endif
 {   unsigned char a, b, c, d, e, f, g, h, t;
     unsigned int round;
-    unsigned char *key;
+    const unsigned char *key;
 
     LTC_ARGCHK(block_in != NULL);
     LTC_ARGCHK(block_out != NULL);
@@ -345,7 +345,7 @@ int safer_ecb_decrypt(const unsigned char *block_in,
 #ifdef LTC_CLEAN_STACK
 int safer_ecb_decrypt(const unsigned char *block_in,
                              unsigned char *block_out,
-                             symmetric_key *skey)
+                             const symmetric_key *skey)
 {
     int err = _safer_ecb_decrypt(block_in, block_out, skey);
     burn_stack(sizeof(unsigned char) * 9 + sizeof(unsigned int) + sizeof(unsigned char *));

--- a/src/ciphers/safer/saferp.c
+++ b/src/ciphers/safer/saferp.c
@@ -143,12 +143,12 @@ const struct ltc_cipher_descriptor saferp_desc =
 
 #ifdef LTC_SMALL_CODE
 
-static void _round(unsigned char *b, int i, symmetric_key *skey)
+static void _round(unsigned char *b, int i, const symmetric_key *skey)
 {
    ROUND(b, i);
 }
 
-static void _iround(unsigned char *b, int i, symmetric_key *skey)
+static void _iround(unsigned char *b, int i, const symmetric_key *skey)
 {
    iROUND(b, i);
 }
@@ -338,7 +338,7 @@ int saferp_setup(const unsigned char *key, int keylen, int num_rounds, symmetric
   @param skey The key as scheduled
   @return CRYPT_OK if successful
 */
-int saferp_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+int saferp_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 {
    unsigned char b[16];
    int x;
@@ -402,7 +402,7 @@ int saferp_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key
   @param skey The key as scheduled
   @return CRYPT_OK if successful
 */
-int saferp_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+int saferp_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 {
    unsigned char b[16];
    int x;

--- a/src/ciphers/serpent.c
+++ b/src/ciphers/serpent.c
@@ -588,7 +588,7 @@ int serpent_setup(const unsigned char *key, int keylen, int num_rounds, symmetri
    return err;
 }
 
-int serpent_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+int serpent_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 {
    int err = _enc_block(pt, ct, skey->serpent.k);
 #ifdef LTC_CLEAN_STACK
@@ -597,7 +597,7 @@ int serpent_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_ke
    return err;
 }
 
-int serpent_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+int serpent_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 {
    int err = _dec_block(ct, pt, skey->serpent.k);
 #ifdef LTC_CLEAN_STACK

--- a/src/ciphers/serpent.c
+++ b/src/ciphers/serpent.c
@@ -488,7 +488,7 @@ static int _setup_key(const unsigned char *key, int keylen, int rounds, ulong32 
    return CRYPT_OK;
 }
 
-static int _enc_block(const unsigned char *in, unsigned char *out, ulong32 *k)
+static int _enc_block(const unsigned char *in, unsigned char *out, const ulong32 *k)
 {
    ulong32 a, b, c, d, e;
    unsigned int i = 1;
@@ -530,7 +530,7 @@ static int _enc_block(const unsigned char *in, unsigned char *out, ulong32 *k)
    return CRYPT_OK;
 }
 
-static int _dec_block(const unsigned char *in, unsigned char *out, ulong32 *k)
+static int _dec_block(const unsigned char *in, unsigned char *out, const ulong32 *k)
 {
    ulong32 a, b, c, d, e;
    unsigned int i;

--- a/src/ciphers/skipjack.c
+++ b/src/ciphers/skipjack.c
@@ -107,7 +107,7 @@ int skipjack_setup(const unsigned char *key, int keylen, int num_rounds, symmetr
    w2  = tmp ^ w3 ^ x;                            \
    w3  = w4; w4 = w1; w1 = tmp;
 
-static unsigned g_func(unsigned w, int *kp, unsigned char *key)
+static unsigned g_func(unsigned w, int *kp, const unsigned char *key)
 {
    unsigned char g1,g2;
 
@@ -119,7 +119,7 @@ static unsigned g_func(unsigned w, int *kp, unsigned char *key)
    return ((unsigned)g1<<8)|(unsigned)g2;
 }
 
-static unsigned ig_func(unsigned w, int *kp, unsigned char *key)
+static unsigned ig_func(unsigned w, int *kp, const unsigned char *key)
 {
    unsigned char g1,g2;
 

--- a/src/ciphers/skipjack.c
+++ b/src/ciphers/skipjack.c
@@ -139,9 +139,9 @@ static unsigned ig_func(unsigned w, int *kp, const unsigned char *key)
   @return CRYPT_OK if successful
 */
 #ifdef LTC_CLEAN_STACK
-static int _skipjack_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+static int _skipjack_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 #else
-int skipjack_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+int skipjack_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 #endif
 {
    unsigned w1,w2,w3,w4,tmp,tmp1;
@@ -187,7 +187,7 @@ int skipjack_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_k
 }
 
 #ifdef LTC_CLEAN_STACK
-int skipjack_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+int skipjack_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 {
    int err = _skipjack_ecb_encrypt(pt, ct, skey);
    burn_stack(sizeof(unsigned) * 8 + sizeof(int) * 2);
@@ -203,9 +203,9 @@ int skipjack_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_k
   @return CRYPT_OK if successful
 */
 #ifdef LTC_CLEAN_STACK
-static int _skipjack_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+static int _skipjack_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 #else
-int skipjack_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+int skipjack_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 #endif
 {
    unsigned w1,w2,w3,w4,tmp;
@@ -255,7 +255,7 @@ int skipjack_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_k
 }
 
 #ifdef LTC_CLEAN_STACK
-int skipjack_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+int skipjack_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 {
    int err = _skipjack_ecb_decrypt(ct, pt, skey);
    burn_stack(sizeof(unsigned) * 7 + sizeof(int) * 2);

--- a/src/ciphers/twofish/twofish.c
+++ b/src/ciphers/twofish/twofish.c
@@ -237,7 +237,7 @@ static void rs_mult(const unsigned char *in, unsigned char *out)
 #endif
 
 /* computes h(x) */
-static void h_func(const unsigned char *in, unsigned char *out, unsigned char *M, int k, int offset)
+static void h_func(const unsigned char *in, unsigned char *out, const unsigned char *M, int k, int offset)
 {
   int x;
   unsigned char y[4];

--- a/src/ciphers/twofish/twofish.c
+++ b/src/ciphers/twofish/twofish.c
@@ -284,9 +284,9 @@ static void h_func(const unsigned char *in, unsigned char *out, const unsigned c
 #else
 
 #ifdef LTC_CLEAN_STACK
-static ulong32 _g_func(ulong32 x, symmetric_key *key)
+static ulong32 _g_func(ulong32 x, const symmetric_key *key)
 #else
-static ulong32 g_func(ulong32 x, symmetric_key *key)
+static ulong32 g_func(ulong32 x, const symmetric_key *key)
 #endif
 {
    unsigned char g, i, y, z;
@@ -317,7 +317,7 @@ static ulong32 g_func(ulong32 x, symmetric_key *key)
 #define g1_func(x, key) g_func(ROLc(x, 8), key)
 
 #ifdef LTC_CLEAN_STACK
-static ulong32 g_func(ulong32 x, symmetric_key *key)
+static ulong32 g_func(ulong32 x, const symmetric_key *key)
 {
     ulong32 y;
     y = _g_func(x, key);
@@ -464,12 +464,13 @@ int twofish_setup(const unsigned char *key, int keylen, int num_rounds, symmetri
   @return CRYPT_OK if successful
 */
 #ifdef LTC_CLEAN_STACK
-static int _twofish_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+static int _twofish_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 #else
-int twofish_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+int twofish_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 #endif
 {
-    ulong32 a,b,c,d,ta,tb,tc,td,t1,t2, *k;
+    ulong32 a,b,c,d,ta,tb,tc,td,t1,t2;
+    const ulong32 *k;
     int r;
 #if !defined(LTC_TWOFISH_SMALL) && !defined(__GNUC__)
     ulong32 *S1, *S2, *S3, *S4;
@@ -521,7 +522,7 @@ int twofish_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_ke
 }
 
 #ifdef LTC_CLEAN_STACK
-int twofish_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+int twofish_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 {
    int err = _twofish_ecb_encrypt(pt, ct, skey);
    burn_stack(sizeof(ulong32) * 10 + sizeof(int));
@@ -537,12 +538,13 @@ int twofish_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_ke
   @return CRYPT_OK if successful
 */
 #ifdef LTC_CLEAN_STACK
-static int _twofish_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+static int _twofish_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 #else
-int twofish_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+int twofish_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 #endif
 {
-    ulong32 a,b,c,d,ta,tb,tc,td,t1,t2, *k;
+    ulong32 a,b,c,d,ta,tb,tc,td,t1,t2;
+    const ulong32 *k;
     int r;
 #if !defined(LTC_TWOFISH_SMALL) && !defined(__GNUC__)
     ulong32 *S1, *S2, *S3, *S4;
@@ -596,7 +598,7 @@ int twofish_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_ke
 }
 
 #ifdef LTC_CLEAN_STACK
-int twofish_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+int twofish_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 {
    int err =_twofish_ecb_decrypt(ct, pt, skey);
    burn_stack(sizeof(ulong32) * 10 + sizeof(int));

--- a/src/ciphers/xtea.c
+++ b/src/ciphers/xtea.c
@@ -71,7 +71,7 @@ int xtea_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_k
   @param skey The key as scheduled
   @return CRYPT_OK if successful
 */
-int xtea_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey)
+int xtea_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey)
 {
    ulong32 y, z;
    int r;
@@ -107,7 +107,7 @@ int xtea_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *
   @param skey The key as scheduled
   @return CRYPT_OK if successful
 */
-int xtea_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey)
+int xtea_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey)
 {
    ulong32 y, z;
    int r;

--- a/src/encauth/eax/eax_decrypt_verify_memory.c
+++ b/src/encauth/eax/eax_decrypt_verify_memory.c
@@ -38,7 +38,7 @@ int eax_decrypt_verify_memory(int cipher,
     const unsigned char *header, unsigned long headerlen,
     const unsigned char *ct,     unsigned long ctlen,
           unsigned char *pt,
-          unsigned char *tag,    unsigned long taglen,
+    const unsigned char *tag,    unsigned long taglen,
           int           *stat)
 {
    int            err;

--- a/src/encauth/gcm/gcm_mult_h.c
+++ b/src/encauth/gcm/gcm_mult_h.c
@@ -19,7 +19,7 @@
   @param gcm   The GCM state which holds the H value
   @param I     The value to multiply H by
  */
-void gcm_mult_h(gcm_state *gcm, unsigned char *I)
+void gcm_mult_h(const gcm_state *gcm, unsigned char *I)
 {
    unsigned char T[16];
 #ifdef LTC_GCM_TABLES

--- a/src/hashes/chc/chc.c
+++ b/src/hashes/chc/chc.c
@@ -127,7 +127,7 @@ int chc_init(hash_state *md)
    T0     <= encrypt T0
    state  <= state xor T0 xor T1
 */
-static int chc_compress(hash_state *md, unsigned char *buf)
+static int chc_compress(hash_state *md, const unsigned char *buf)
 {
    unsigned char  T[2][MAXBLOCKSIZE];
    symmetric_key *key;

--- a/src/hashes/md4.c
+++ b/src/hashes/md4.c
@@ -73,7 +73,7 @@ const struct ltc_hash_descriptor md4_desc =
 #ifdef LTC_CLEAN_STACK
 static int _md4_compress(hash_state *md, unsigned char *buf)
 #else
-static int  md4_compress(hash_state *md, unsigned char *buf)
+static int  md4_compress(hash_state *md, const unsigned char *buf)
 #endif
 {
     ulong32 x[16], a, b, c, d;

--- a/src/hashes/md5.c
+++ b/src/hashes/md5.c
@@ -98,7 +98,7 @@ static const ulong32 Korder[64] = {
 #ifdef LTC_CLEAN_STACK
 static int _md5_compress(hash_state *md, unsigned char *buf)
 #else
-static int  md5_compress(hash_state *md, unsigned char *buf)
+static int  md5_compress(hash_state *md, const unsigned char *buf)
 #endif
 {
     ulong32 i, W[16], a, b, c, d;

--- a/src/hashes/rmd128.c
+++ b/src/hashes/rmd128.c
@@ -81,7 +81,7 @@ const struct ltc_hash_descriptor rmd128_desc =
 #ifdef LTC_CLEAN_STACK
 static int _rmd128_compress(hash_state *md, unsigned char *buf)
 #else
-static int  rmd128_compress(hash_state *md, unsigned char *buf)
+static int  rmd128_compress(hash_state *md, const unsigned char *buf)
 #endif
 {
    ulong32 aa,bb,cc,dd,aaa,bbb,ccc,ddd,X[16];

--- a/src/hashes/rmd160.c
+++ b/src/hashes/rmd160.c
@@ -101,7 +101,7 @@ const struct ltc_hash_descriptor rmd160_desc =
 #ifdef LTC_CLEAN_STACK
 static int _rmd160_compress(hash_state *md, unsigned char *buf)
 #else
-static int  rmd160_compress(hash_state *md, unsigned char *buf)
+static int  rmd160_compress(hash_state *md, const unsigned char *buf)
 #endif
 {
    ulong32 aa,bb,cc,dd,ee,aaa,bbb,ccc,ddd,eee,X[16];

--- a/src/hashes/rmd256.c
+++ b/src/hashes/rmd256.c
@@ -75,7 +75,7 @@ const struct ltc_hash_descriptor rmd256_desc =
 #ifdef LTC_CLEAN_STACK
 static int _rmd256_compress(hash_state *md, unsigned char *buf)
 #else
-static int  rmd256_compress(hash_state *md, unsigned char *buf)
+static int  rmd256_compress(hash_state *md, const unsigned char *buf)
 #endif
 {
    ulong32 aa,bb,cc,dd,aaa,bbb,ccc,ddd,tmp,X[16];

--- a/src/hashes/rmd320.c
+++ b/src/hashes/rmd320.c
@@ -96,7 +96,7 @@ const struct ltc_hash_descriptor rmd320_desc =
 #ifdef LTC_CLEAN_STACK
 static int _rmd320_compress(hash_state *md, unsigned char *buf)
 #else
-static int  rmd320_compress(hash_state *md, unsigned char *buf)
+static int  rmd320_compress(hash_state *md, const unsigned char *buf)
 #endif
 {
    ulong32 aa,bb,cc,dd,ee,aaa,bbb,ccc,ddd,eee,tmp,X[16];

--- a/src/hashes/sha1.c
+++ b/src/hashes/sha1.c
@@ -42,7 +42,7 @@ const struct ltc_hash_descriptor sha1_desc =
 #ifdef LTC_CLEAN_STACK
 static int _sha1_compress(hash_state *md, unsigned char *buf)
 #else
-static int  sha1_compress(hash_state *md, unsigned char *buf)
+static int  sha1_compress(hash_state *md, const unsigned char *buf)
 #endif
 {
     ulong32 a,b,c,d,e,W[80],i;

--- a/src/hashes/sha2/sha256.c
+++ b/src/hashes/sha2/sha256.c
@@ -66,7 +66,7 @@ static const ulong32 K[64] = {
 #ifdef LTC_CLEAN_STACK
 static int _sha256_compress(hash_state * md, unsigned char *buf)
 #else
-static int  sha256_compress(hash_state * md, unsigned char *buf)
+static int  sha256_compress(hash_state * md, const unsigned char *buf)
 #endif
 {
     ulong32 S[8], W[64], t0, t1;

--- a/src/hashes/sha2/sha512.c
+++ b/src/hashes/sha2/sha512.c
@@ -91,7 +91,7 @@ CONST64(0x5fcb6fab3ad6faec), CONST64(0x6c44198c4a475817)
 #ifdef LTC_CLEAN_STACK
 static int _sha512_compress(hash_state * md, unsigned char *buf)
 #else
-static int  sha512_compress(hash_state * md, unsigned char *buf)
+static int  sha512_compress(hash_state * md, const unsigned char *buf)
 #endif
 {
     ulong64 S[8], W[80], t0, t1;

--- a/src/hashes/sha3.c
+++ b/src/hashes/sha3.c
@@ -364,7 +364,7 @@ int sha3_shake_done(hash_state *md, unsigned char *out, unsigned long outlen)
    return CRYPT_OK;
 }
 
-int sha3_shake_memory(int num, const unsigned char *in, unsigned long inlen, unsigned char *out, unsigned long *outlen)
+int sha3_shake_memory(int num, const unsigned char *in, unsigned long inlen, unsigned char *out, const unsigned long *outlen)
 {
    hash_state md;
    int err;

--- a/src/hashes/tiger.c
+++ b/src/hashes/tiger.c
@@ -608,9 +608,9 @@ static void key_schedule(ulong64 *x)
 }
 
 #ifdef LTC_CLEAN_STACK
-static int _tiger_compress(hash_state *md, unsigned char *buf)
+static int _tiger_compress(hash_state *md, const unsigned char *buf)
 #else
-static int  tiger_compress(hash_state *md, unsigned char *buf)
+static int  tiger_compress(hash_state *md, const unsigned char *buf)
 #endif
 {
     ulong64 a, b, c, x[8];

--- a/src/hashes/tiger.c
+++ b/src/hashes/tiger.c
@@ -574,7 +574,7 @@ INLINE static void tiger_round(ulong64 *a, ulong64 *b, ulong64 *c, ulong64 x, in
 }
 
 /* one complete pass */
-static void pass(ulong64 *a, ulong64 *b, ulong64 *c, ulong64 *x, int mul)
+static void pass(ulong64 *a, ulong64 *b, ulong64 *c, const ulong64 *x, int mul)
 {
    tiger_round(a,b,c,x[0],mul);
    tiger_round(b,c,a,x[1],mul);

--- a/src/hashes/whirl/whirl.c
+++ b/src/hashes/whirl/whirl.c
@@ -53,9 +53,9 @@ const struct ltc_hash_descriptor whirlpool_desc =
     SB7(GB(a, i-7, 0)))
 
 #ifdef LTC_CLEAN_STACK
-static int _whirlpool_compress(hash_state *md, unsigned char *buf)
+static int _whirlpool_compress(hash_state *md, const unsigned char *buf)
 #else
-static int whirlpool_compress(hash_state *md, unsigned char *buf)
+static int whirlpool_compress(hash_state *md, const unsigned char *buf)
 #endif
 {
    ulong64 K[2][8], T[3][8];

--- a/src/headers/tomcrypt_cipher.h
+++ b/src/headers/tomcrypt_cipher.h
@@ -397,14 +397,14 @@ extern struct ltc_cipher_descriptor {
       @param skey    The scheduled key
       @return CRYPT_OK if successful
    */
-   int (*ecb_encrypt)(const unsigned char *pt, unsigned char *ct, symmetric_key *skey);
+   int (*ecb_encrypt)(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey);
    /** Decrypt a block
       @param ct      The ciphertext
       @param pt      [out] The plaintext
       @param skey    The scheduled key
       @return CRYPT_OK if successful
    */
-   int (*ecb_decrypt)(const unsigned char *ct, unsigned char *pt, symmetric_key *skey);
+   int (*ecb_decrypt)(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey);
    /** Test the block cipher
        @return CRYPT_OK if successful, CRYPT_NOP if self-testing has been disabled
    */
@@ -598,8 +598,8 @@ extern struct ltc_cipher_descriptor {
        @return CRYPT_OK if successful
     */
     int (*accel_xts_encrypt)(const unsigned char *pt, unsigned char *ct,
-        unsigned long blocks, unsigned char *tweak, symmetric_key *skey1,
-        symmetric_key *skey2);
+        unsigned long blocks, unsigned char *tweak,
+        const symmetric_key *skey1, const symmetric_key *skey2);
 
     /** Accelerated XTS decryption
         @param ct      Ciphertext
@@ -613,14 +613,14 @@ extern struct ltc_cipher_descriptor {
         @return CRYPT_OK if successful
      */
      int (*accel_xts_decrypt)(const unsigned char *ct, unsigned char *pt,
-         unsigned long blocks, unsigned char *tweak, symmetric_key *skey1,
-         symmetric_key *skey2);
+         unsigned long blocks, unsigned char *tweak,
+         const symmetric_key *skey1, const symmetric_key *skey2);
 } cipher_descriptor[];
 
 #ifdef LTC_BLOWFISH
 int blowfish_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey);
-int blowfish_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey);
-int blowfish_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey);
+int blowfish_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey);
+int blowfish_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey);
 int blowfish_test(void);
 void blowfish_done(symmetric_key *skey);
 int blowfish_keysize(int *keysize);
@@ -629,8 +629,8 @@ extern const struct ltc_cipher_descriptor blowfish_desc;
 
 #ifdef LTC_RC5
 int rc5_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey);
-int rc5_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey);
-int rc5_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey);
+int rc5_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey);
+int rc5_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey);
 int rc5_test(void);
 void rc5_done(symmetric_key *skey);
 int rc5_keysize(int *keysize);
@@ -639,8 +639,8 @@ extern const struct ltc_cipher_descriptor rc5_desc;
 
 #ifdef LTC_RC6
 int rc6_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey);
-int rc6_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey);
-int rc6_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey);
+int rc6_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey);
+int rc6_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey);
 int rc6_test(void);
 void rc6_done(symmetric_key *skey);
 int rc6_keysize(int *keysize);
@@ -650,8 +650,8 @@ extern const struct ltc_cipher_descriptor rc6_desc;
 #ifdef LTC_RC2
 int rc2_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey);
 int rc2_setup_ex(const unsigned char *key, int keylen, int bits, int num_rounds, symmetric_key *skey);
-int rc2_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey);
-int rc2_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey);
+int rc2_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey);
+int rc2_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey);
 int rc2_test(void);
 void rc2_done(symmetric_key *skey);
 int rc2_keysize(int *keysize);
@@ -660,8 +660,8 @@ extern const struct ltc_cipher_descriptor rc2_desc;
 
 #ifdef LTC_SAFERP
 int saferp_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey);
-int saferp_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey);
-int saferp_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey);
+int saferp_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey);
+int saferp_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey);
 int saferp_test(void);
 void saferp_done(symmetric_key *skey);
 int saferp_keysize(int *keysize);
@@ -673,8 +673,8 @@ int safer_k64_setup(const unsigned char *key, int keylen, int num_rounds, symmet
 int safer_sk64_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey);
 int safer_k128_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey);
 int safer_sk128_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey);
-int safer_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *key);
-int safer_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *key);
+int safer_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *key);
+int safer_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *key);
 int safer_k64_test(void);
 int safer_sk64_test(void);
 int safer_sk128_test(void);
@@ -699,13 +699,13 @@ extern const struct ltc_cipher_descriptor safer_k64_desc, safer_k128_desc, safer
 #define aes_enc_keysize         rijndael_enc_keysize
 
 int rijndael_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey);
-int rijndael_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey);
-int rijndael_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey);
+int rijndael_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey);
+int rijndael_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey);
 int rijndael_test(void);
 void rijndael_done(symmetric_key *skey);
 int rijndael_keysize(int *keysize);
 int rijndael_enc_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey);
-int rijndael_enc_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey);
+int rijndael_enc_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey);
 void rijndael_enc_done(symmetric_key *skey);
 int rijndael_enc_keysize(int *keysize);
 extern const struct ltc_cipher_descriptor rijndael_desc, aes_desc;
@@ -714,8 +714,8 @@ extern const struct ltc_cipher_descriptor rijndael_enc_desc, aes_enc_desc;
 
 #ifdef LTC_XTEA
 int xtea_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey);
-int xtea_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey);
-int xtea_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey);
+int xtea_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey);
+int xtea_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey);
 int xtea_test(void);
 void xtea_done(symmetric_key *skey);
 int xtea_keysize(int *keysize);
@@ -724,8 +724,8 @@ extern const struct ltc_cipher_descriptor xtea_desc;
 
 #ifdef LTC_TWOFISH
 int twofish_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey);
-int twofish_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey);
-int twofish_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey);
+int twofish_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey);
+int twofish_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey);
 int twofish_test(void);
 void twofish_done(symmetric_key *skey);
 int twofish_keysize(int *keysize);
@@ -734,14 +734,14 @@ extern const struct ltc_cipher_descriptor twofish_desc;
 
 #ifdef LTC_DES
 int des_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey);
-int des_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey);
-int des_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey);
+int des_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey);
+int des_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey);
 int des_test(void);
 void des_done(symmetric_key *skey);
 int des_keysize(int *keysize);
 int des3_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey);
-int des3_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey);
-int des3_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey);
+int des3_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey);
+int des3_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey);
 int des3_test(void);
 void des3_done(symmetric_key *skey);
 int des3_keysize(int *keysize);
@@ -750,8 +750,8 @@ extern const struct ltc_cipher_descriptor des_desc, des3_desc;
 
 #ifdef LTC_CAST5
 int cast5_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey);
-int cast5_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey);
-int cast5_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey);
+int cast5_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey);
+int cast5_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey);
 int cast5_test(void);
 void cast5_done(symmetric_key *skey);
 int cast5_keysize(int *keysize);
@@ -760,8 +760,8 @@ extern const struct ltc_cipher_descriptor cast5_desc;
 
 #ifdef LTC_NOEKEON
 int noekeon_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey);
-int noekeon_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey);
-int noekeon_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey);
+int noekeon_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey);
+int noekeon_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey);
 int noekeon_test(void);
 void noekeon_done(symmetric_key *skey);
 int noekeon_keysize(int *keysize);
@@ -770,8 +770,8 @@ extern const struct ltc_cipher_descriptor noekeon_desc;
 
 #ifdef LTC_SKIPJACK
 int skipjack_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey);
-int skipjack_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey);
-int skipjack_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey);
+int skipjack_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey);
+int skipjack_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey);
 int skipjack_test(void);
 void skipjack_done(symmetric_key *skey);
 int skipjack_keysize(int *keysize);
@@ -780,8 +780,8 @@ extern const struct ltc_cipher_descriptor skipjack_desc;
 
 #ifdef LTC_KHAZAD
 int khazad_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey);
-int khazad_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey);
-int khazad_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey);
+int khazad_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey);
+int khazad_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey);
 int khazad_test(void);
 void khazad_done(symmetric_key *skey);
 int khazad_keysize(int *keysize);
@@ -790,8 +790,8 @@ extern const struct ltc_cipher_descriptor khazad_desc;
 
 #ifdef LTC_ANUBIS
 int anubis_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey);
-int anubis_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey);
-int anubis_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey);
+int anubis_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey);
+int anubis_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey);
 int anubis_test(void);
 void anubis_done(symmetric_key *skey);
 int anubis_keysize(int *keysize);
@@ -800,8 +800,8 @@ extern const struct ltc_cipher_descriptor anubis_desc;
 
 #ifdef LTC_KSEED
 int kseed_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey);
-int kseed_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey);
-int kseed_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey);
+int kseed_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey);
+int kseed_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey);
 int kseed_test(void);
 void kseed_done(symmetric_key *skey);
 int kseed_keysize(int *keysize);
@@ -810,8 +810,8 @@ extern const struct ltc_cipher_descriptor kseed_desc;
 
 #ifdef LTC_KASUMI
 int kasumi_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey);
-int kasumi_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey);
-int kasumi_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey);
+int kasumi_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey);
+int kasumi_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey);
 int kasumi_test(void);
 void kasumi_done(symmetric_key *skey);
 int kasumi_keysize(int *keysize);
@@ -821,8 +821,8 @@ extern const struct ltc_cipher_descriptor kasumi_desc;
 
 #ifdef LTC_MULTI2
 int multi2_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey);
-int multi2_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey);
-int multi2_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey);
+int multi2_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey);
+int multi2_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey);
 int multi2_test(void);
 void multi2_done(symmetric_key *skey);
 int multi2_keysize(int *keysize);
@@ -831,8 +831,8 @@ extern const struct ltc_cipher_descriptor multi2_desc;
 
 #ifdef LTC_CAMELLIA
 int camellia_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey);
-int camellia_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey);
-int camellia_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey);
+int camellia_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey);
+int camellia_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey);
 int camellia_test(void);
 void camellia_done(symmetric_key *skey);
 int camellia_keysize(int *keysize);
@@ -841,8 +841,8 @@ extern const struct ltc_cipher_descriptor camellia_desc;
 
 #ifdef LTC_IDEA
 int idea_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey);
-int idea_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey);
-int idea_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey);
+int idea_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey);
+int idea_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey);
 int idea_test(void);
 void idea_done(symmetric_key *skey);
 int idea_keysize(int *keysize);
@@ -851,8 +851,8 @@ extern const struct ltc_cipher_descriptor idea_desc;
 
 #ifdef LTC_SERPENT
 int serpent_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey);
-int serpent_ecb_encrypt(const unsigned char *pt, unsigned char *ct, symmetric_key *skey);
-int serpent_ecb_decrypt(const unsigned char *ct, unsigned char *pt, symmetric_key *skey);
+int serpent_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey);
+int serpent_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey);
 int serpent_test(void);
 void serpent_done(symmetric_key *skey);
 int serpent_keysize(int *keysize);
@@ -872,7 +872,7 @@ int cfb_start(int cipher, const unsigned char *IV, const unsigned char *key,
               int keylen, int num_rounds, symmetric_CFB *cfb);
 int cfb_encrypt(const unsigned char *pt, unsigned char *ct, unsigned long len, symmetric_CFB *cfb);
 int cfb_decrypt(const unsigned char *ct, unsigned char *pt, unsigned long len, symmetric_CFB *cfb);
-int cfb_getiv(unsigned char *IV, unsigned long *len, symmetric_CFB *cfb);
+int cfb_getiv(unsigned char *IV, unsigned long *len, const symmetric_CFB *cfb);
 int cfb_setiv(const unsigned char *IV, unsigned long len, symmetric_CFB *cfb);
 int cfb_done(symmetric_CFB *cfb);
 #endif
@@ -882,7 +882,7 @@ int ofb_start(int cipher, const unsigned char *IV, const unsigned char *key,
               int keylen, int num_rounds, symmetric_OFB *ofb);
 int ofb_encrypt(const unsigned char *pt, unsigned char *ct, unsigned long len, symmetric_OFB *ofb);
 int ofb_decrypt(const unsigned char *ct, unsigned char *pt, unsigned long len, symmetric_OFB *ofb);
-int ofb_getiv(unsigned char *IV, unsigned long *len, symmetric_OFB *ofb);
+int ofb_getiv(unsigned char *IV, unsigned long *len, const symmetric_OFB *ofb);
 int ofb_setiv(const unsigned char *IV, unsigned long len, symmetric_OFB *ofb);
 int ofb_done(symmetric_OFB *ofb);
 #endif
@@ -892,7 +892,7 @@ int cbc_start(int cipher, const unsigned char *IV, const unsigned char *key,
                int keylen, int num_rounds, symmetric_CBC *cbc);
 int cbc_encrypt(const unsigned char *pt, unsigned char *ct, unsigned long len, symmetric_CBC *cbc);
 int cbc_decrypt(const unsigned char *ct, unsigned char *pt, unsigned long len, symmetric_CBC *cbc);
-int cbc_getiv(unsigned char *IV, unsigned long *len, symmetric_CBC *cbc);
+int cbc_getiv(unsigned char *IV, unsigned long *len, const symmetric_CBC *cbc);
 int cbc_setiv(const unsigned char *IV, unsigned long len, symmetric_CBC *cbc);
 int cbc_done(symmetric_CBC *cbc);
 #endif
@@ -910,7 +910,7 @@ int ctr_start(               int   cipher,
                    symmetric_CTR *ctr);
 int ctr_encrypt(const unsigned char *pt, unsigned char *ct, unsigned long len, symmetric_CTR *ctr);
 int ctr_decrypt(const unsigned char *ct, unsigned char *pt, unsigned long len, symmetric_CTR *ctr);
-int ctr_getiv(unsigned char *IV, unsigned long *len, symmetric_CTR *ctr);
+int ctr_getiv(unsigned char *IV, unsigned long *len, const symmetric_CTR *ctr);
 int ctr_setiv(const unsigned char *IV, unsigned long len, symmetric_CTR *ctr);
 int ctr_done(symmetric_CTR *ctr);
 int ctr_test(void);
@@ -929,7 +929,7 @@ int lrw_start(               int   cipher,
                    symmetric_LRW *lrw);
 int lrw_encrypt(const unsigned char *pt, unsigned char *ct, unsigned long len, symmetric_LRW *lrw);
 int lrw_decrypt(const unsigned char *ct, unsigned char *pt, unsigned long len, symmetric_LRW *lrw);
-int lrw_getiv(unsigned char *IV, unsigned long *len, symmetric_LRW *lrw);
+int lrw_getiv(unsigned char *IV, unsigned long *len, const symmetric_LRW *lrw);
 int lrw_setiv(const unsigned char *IV, unsigned long len, symmetric_LRW *lrw);
 int lrw_done(symmetric_LRW *lrw);
 int lrw_test(void);
@@ -945,7 +945,7 @@ int f8_start(                int  cipher, const unsigned char *IV,
                              int  num_rounds,   symmetric_F8  *f8);
 int f8_encrypt(const unsigned char *pt, unsigned char *ct, unsigned long len, symmetric_F8 *f8);
 int f8_decrypt(const unsigned char *ct, unsigned char *pt, unsigned long len, symmetric_F8 *f8);
-int f8_getiv(unsigned char *IV, unsigned long *len, symmetric_F8 *f8);
+int f8_getiv(unsigned char *IV, unsigned long *len, const symmetric_F8 *f8);
 int f8_setiv(const unsigned char *IV, unsigned long len, symmetric_F8 *f8);
 int f8_done(symmetric_F8 *f8);
 int f8_test_mode(void);
@@ -968,12 +968,12 @@ int xts_encrypt(
    const unsigned char *pt, unsigned long ptlen,
          unsigned char *ct,
          unsigned char *tweak,
-         symmetric_xts *xts);
+   const symmetric_xts *xts);
 int xts_decrypt(
    const unsigned char *ct, unsigned long ptlen,
          unsigned char *pt,
          unsigned char *tweak,
-         symmetric_xts *xts);
+   const symmetric_xts *xts);
 
 void xts_done(symmetric_xts *xts);
 int  xts_test(void);
@@ -1046,8 +1046,8 @@ typedef struct {
     unsigned ptr;
 } sosemanuk_state;
 
-int sosemanuk_setup(sosemanuk_state *ss, unsigned char *key, unsigned long keylen);
-int sosemanuk_setiv(sosemanuk_state *ss, unsigned char *iv, unsigned long ivlen);
+int sosemanuk_setup(sosemanuk_state *ss, const unsigned char *key, unsigned long keylen);
+int sosemanuk_setiv(sosemanuk_state *ss, const unsigned char *iv, unsigned long ivlen);
 int sosemanuk_crypt(sosemanuk_state *ss, const unsigned char *in, unsigned long datalen, unsigned char *out);
 int sosemanuk_keystream(sosemanuk_state *ss, unsigned char *out, unsigned long outlen);
 int sosemanuk_done(sosemanuk_state *ss);

--- a/src/headers/tomcrypt_hash.h
+++ b/src/headers/tomcrypt_hash.h
@@ -288,7 +288,7 @@ int sha3_shake_init(hash_state *md, int num);
 #define sha3_shake_process(a,b,c) sha3_process(a,b,c)
 int sha3_shake_done(hash_state *md, unsigned char *out, unsigned long outlen);
 int sha3_shake_test(void);
-int sha3_shake_memory(int num, const unsigned char *in, unsigned long inlen, unsigned char *out, unsigned long *outlen);
+int sha3_shake_memory(int num, const unsigned char *in, unsigned long inlen, unsigned char *out, const unsigned long *outlen);
 #endif
 
 #ifdef LTC_KECCAK

--- a/src/headers/tomcrypt_mac.h
+++ b/src/headers/tomcrypt_mac.h
@@ -274,7 +274,7 @@ int eax_decrypt_verify_memory(int cipher,
     const unsigned char *header, unsigned long headerlen,
     const unsigned char *ct,     unsigned long ctlen,
           unsigned char *pt,
-          unsigned char *tag,    unsigned long taglen,
+    const unsigned char *tag,    unsigned long taglen,
           int           *stat);
 
  int eax_test(void);
@@ -500,7 +500,7 @@ __attribute__ ((aligned (16)))
 #endif
 } gcm_state;
 
-void gcm_mult_h(gcm_state *gcm, unsigned char *I);
+void gcm_mult_h(const gcm_state *gcm, unsigned char *I);
 
 int gcm_init(gcm_state *gcm, int cipher,
              const unsigned char *key, int keylen);

--- a/src/headers/tomcrypt_math.h
+++ b/src/headers/tomcrypt_math.h
@@ -458,7 +458,7 @@ typedef struct {
    */
    int (*rsa_me)(const unsigned char *in,   unsigned long inlen,
                        unsigned char *out,  unsigned long *outlen, int which,
-                       rsa_key *key);
+                 const rsa_key *key);
 
 /* ---- basic math continued ---- */
 

--- a/src/headers/tomcrypt_misc.h
+++ b/src/headers/tomcrypt_misc.h
@@ -123,7 +123,7 @@ typedef struct adler32_state_s
 
 void adler32_init(adler32_state *ctx);
 void adler32_update(adler32_state *ctx, const unsigned char *input, unsigned long length);
-void adler32_finish(adler32_state *ctx, void *hash, unsigned long size);
+void adler32_finish(const adler32_state *ctx, void *hash, unsigned long size);
 int adler32_test(void);
 #endif
 
@@ -135,7 +135,7 @@ typedef struct crc32_state_s
 
 void crc32_init(crc32_state *ctx);
 void crc32_update(crc32_state *ctx, const unsigned char *input, unsigned long length);
-void crc32_finish(crc32_state *ctx, void *hash, unsigned long size);
+void crc32_finish(const crc32_state *ctx, void *hash, unsigned long size);
 int crc32_test(void);
 #endif
 
@@ -154,7 +154,7 @@ enum padding_type {
 };
 
 int padding_pad(unsigned char *data, unsigned long length, unsigned long* padded_length, unsigned long mode);
-int padding_depad(unsigned char *data, unsigned long *length, unsigned long mode);
+int padding_depad(const unsigned char *data, unsigned long *length, unsigned long mode);
 
 #ifdef LTC_SOURCE
 /* internal helper functions */

--- a/src/headers/tomcrypt_pk.h
+++ b/src/headers/tomcrypt_pk.h
@@ -67,7 +67,7 @@ typedef struct Rsa_key {
 
 int rsa_make_key(prng_state *prng, int wprng, int size, long e, rsa_key *key);
 
-int rsa_get_size(rsa_key *key);
+int rsa_get_size(const rsa_key *key);
 
 int rsa_exptmod(const unsigned char *in,   unsigned long inlen,
                       unsigned char *out,  unsigned long *outlen, int which,
@@ -119,7 +119,7 @@ int rsa_verify_hash_ex(const unsigned char *sig,      unsigned long siglen,
 int rsa_sign_saltlen_get_max_ex(int padding, int hash_idx, rsa_key *key);
 
 /* PKCS #1 import/export */
-int rsa_export(unsigned char *out, unsigned long *outlen, int type, rsa_key *key);
+int rsa_export(unsigned char *out, unsigned long *outlen, int type, const rsa_key *key);
 int rsa_import(const unsigned char *in, unsigned long inlen, rsa_key *key);
 
 int rsa_import_x509(const unsigned char *in, unsigned long inlen, rsa_key *key);
@@ -205,9 +205,9 @@ typedef struct {
     void *prime;
 } dh_key;
 
-int dh_get_groupsize(dh_key *key);
+int dh_get_groupsize(const dh_key *key);
 
-int dh_export(unsigned char *out, unsigned long *outlen, int type, dh_key *key);
+int dh_export(unsigned char *out, unsigned long *outlen, int type, const dh_key *key);
 int dh_import(const unsigned char *in, unsigned long inlen, dh_key *key);
 
 int dh_set_pg(const unsigned char *p, unsigned long plen,
@@ -219,12 +219,12 @@ int dh_set_pg_groupsize(int groupsize, dh_key *key);
 int dh_set_key(const unsigned char *in, unsigned long inlen, int type, dh_key *key);
 int dh_generate_key(prng_state *prng, int wprng, dh_key *key);
 
-int dh_shared_secret(dh_key        *private_key, dh_key        *public_key,
+int dh_shared_secret(const dh_key  *private_key, const dh_key  *public_key,
                      unsigned char *out,         unsigned long *outlen);
 
 void dh_free(dh_key *key);
 
-int dh_export_key(void *out, unsigned long *outlen, int type, dh_key *key);
+int dh_export_key(void *out, unsigned long *outlen, int type, const dh_key *key);
 
 #ifdef LTC_SOURCE
 typedef struct {
@@ -235,7 +235,7 @@ typedef struct {
 extern const ltc_dh_set_type ltc_dh_sets[];
 
 /* internal helper functions */
-int dh_check_pubkey(dh_key *key);
+int dh_check_pubkey(const dh_key *key);
 #endif
 
 #endif /* LTC_MDH */
@@ -603,8 +603,8 @@ extern const char*          der_asn1_tag_to_string_map[];
 extern const unsigned long  der_asn1_tag_to_string_map_sz;
 
 /* SEQUENCE */
-int der_encode_sequence_ex(ltc_asn1_list *list, unsigned long inlen,
-                           unsigned char *out,  unsigned long *outlen, int type_of);
+int der_encode_sequence_ex(const ltc_asn1_list *list, unsigned long inlen,
+                           unsigned char *out,        unsigned long *outlen, int type_of);
 
 #define der_encode_sequence(list, inlen, out, outlen) der_encode_sequence_ex(list, inlen, out, outlen, LTC_ASN1_SEQUENCE)
 
@@ -635,7 +635,7 @@ int der_decode_sequence_ex(const unsigned char *in, unsigned long  inlen,
 #define der_decode_sequence(in, inlen, list, outlen) der_decode_sequence_ex(in, inlen, list, outlen, LTC_DER_SEQ_SEQUENCE | LTC_DER_SEQ_RELAXED)
 #define der_decode_sequence_strict(in, inlen, list, outlen) der_decode_sequence_ex(in, inlen, list, outlen, LTC_DER_SEQ_SEQUENCE | LTC_DER_SEQ_STRICT)
 
-int der_length_sequence(ltc_asn1_list *list, unsigned long inlen,
+int der_length_sequence(const ltc_asn1_list *list, unsigned long inlen,
                         unsigned long *outlen);
 
 
@@ -664,7 +664,7 @@ int der_encode_asn1_length(unsigned long len, unsigned char* out, unsigned long*
 int der_decode_asn1_length(const unsigned char* len, unsigned long* lenlen, unsigned long* outlen);
 int der_length_asn1_length(unsigned long len, unsigned long *outlen);
 
-int der_length_sequence_ex(ltc_asn1_list *list, unsigned long inlen,
+int der_length_sequence_ex(const ltc_asn1_list *list, unsigned long inlen,
                            unsigned long *outlen, unsigned long *payloadlen);
 
 extern const ltc_asn1_type  der_asn1_tag_to_type_map[];
@@ -677,11 +677,11 @@ extern const unsigned long der_asn1_type_to_identifier_map_sz;
 /* SET */
 #define der_decode_set(in, inlen, list, outlen) der_decode_sequence_ex(in, inlen, list, outlen, LTC_DER_SEQ_SET)
 #define der_length_set der_length_sequence
-int der_encode_set(ltc_asn1_list *list, unsigned long inlen,
-                   unsigned char *out,  unsigned long *outlen);
+int der_encode_set(const ltc_asn1_list *list, unsigned long inlen,
+                   unsigned char *out,        unsigned long *outlen);
 
-int der_encode_setof(ltc_asn1_list *list, unsigned long inlen,
-                     unsigned char *out,  unsigned long *outlen);
+int der_encode_setof(const ltc_asn1_list *list, unsigned long inlen,
+                     unsigned char *out,        unsigned long *outlen);
 
 /* VA list handy helpers with triplets of <type, size, data> */
 int der_encode_sequence_multi(unsigned char *out, unsigned long *outlen, ...);
@@ -736,7 +736,7 @@ int der_encode_object_identifier(unsigned long *words, unsigned long  nwords,
                                  unsigned char *out,   unsigned long *outlen);
 int der_decode_object_identifier(const unsigned char *in,    unsigned long  inlen,
                                        unsigned long *words, unsigned long *outlen);
-int der_length_object_identifier(unsigned long *words, unsigned long nwords, unsigned long *outlen);
+int der_length_object_identifier(const unsigned long *words, unsigned long nwords, unsigned long *outlen);
 unsigned long der_object_identifier_bits(unsigned long x);
 
 /* IA5 STRING */
@@ -821,7 +821,7 @@ int der_encode_utctime(ltc_utctime *utctime,
 int der_decode_utctime(const unsigned char *in, unsigned long *inlen,
                              ltc_utctime   *out);
 
-int der_length_utctime(ltc_utctime *utctime, unsigned long *outlen);
+int der_length_utctime(const ltc_utctime *utctime, unsigned long *outlen);
 
 /* GeneralizedTime */
 typedef struct {
@@ -843,7 +843,7 @@ int der_encode_generalizedtime(ltc_generalizedtime *gtime,
 int der_decode_generalizedtime(const unsigned char *in, unsigned long *inlen,
                                ltc_generalizedtime *out);
 
-int der_length_generalizedtime(ltc_generalizedtime *gtime, unsigned long *outlen);
+int der_length_generalizedtime(const ltc_generalizedtime *gtime, unsigned long *outlen);
 
 #ifdef LTC_SOURCE
 /* internal helper functions */

--- a/src/headers/tomcrypt_pk.h
+++ b/src/headers/tomcrypt_pk.h
@@ -71,7 +71,7 @@ int rsa_get_size(const rsa_key *key);
 
 int rsa_exptmod(const unsigned char *in,   unsigned long inlen,
                       unsigned char *out,  unsigned long *outlen, int which,
-                      rsa_key *key);
+                const rsa_key *key);
 
 void rsa_free(rsa_key *key);
 
@@ -92,31 +92,33 @@ void rsa_free(rsa_key *key);
   rsa_sign_saltlen_get_max_ex(LTC_PKCS_1_PSS, _hash_idx, _key)
 
 /* These can be switched between PKCS #1 v2.x and PKCS #1 v1.5 paddings */
-int rsa_encrypt_key_ex(const unsigned char *in,     unsigned long inlen,
-                             unsigned char *out,    unsigned long *outlen,
-                       const unsigned char *lparam, unsigned long lparamlen,
-                       prng_state *prng, int prng_idx, int hash_idx, int padding, rsa_key *key);
-
-int rsa_decrypt_key_ex(const unsigned char *in,       unsigned long  inlen,
+int rsa_encrypt_key_ex(const unsigned char *in,       unsigned long  inlen,
                              unsigned char *out,      unsigned long *outlen,
                        const unsigned char *lparam,   unsigned long  lparamlen,
+                             prng_state    *prng,     int            prng_idx,
                              int            hash_idx, int            padding,
-                             int           *stat,     rsa_key       *key);
+                       const rsa_key       *key);
+
+int rsa_decrypt_key_ex(const unsigned char *in,             unsigned long  inlen,
+                             unsigned char *out,            unsigned long *outlen,
+                       const unsigned char *lparam,         unsigned long  lparamlen,
+                             int            hash_idx,       int            padding,
+                             int           *stat,     const rsa_key       *key);
 
 int rsa_sign_hash_ex(const unsigned char *in,       unsigned long  inlen,
                            unsigned char *out,      unsigned long *outlen,
                            int            padding,
                            prng_state    *prng,     int            prng_idx,
                            int            hash_idx, unsigned long  saltlen,
-                           rsa_key *key);
+                     const rsa_key       *key);
 
-int rsa_verify_hash_ex(const unsigned char *sig,      unsigned long siglen,
-                       const unsigned char *hash,     unsigned long hashlen,
+int rsa_verify_hash_ex(const unsigned char *sig,            unsigned long  siglen,
+                       const unsigned char *hash,           unsigned long  hashlen,
                              int            padding,
-                             int            hash_idx, unsigned long saltlen,
-                             int           *stat,     rsa_key      *key);
+                             int            hash_idx,       unsigned long  saltlen,
+                             int           *stat,     const rsa_key       *key);
 
-int rsa_sign_saltlen_get_max_ex(int padding, int hash_idx, rsa_key *key);
+int rsa_sign_saltlen_get_max_ex(int padding, int hash_idx, const rsa_key *key);
 
 /* PKCS #1 import/export */
 int rsa_export(unsigned char *out, unsigned long *outlen, int type, const rsa_key *key);
@@ -452,40 +454,40 @@ void dsa_free(dsa_key *key);
 
 int dsa_sign_hash_raw(const unsigned char *in,  unsigned long inlen,
                                    void *r,   void *s,
-                               prng_state *prng, int wprng, dsa_key *key);
+                               prng_state *prng, int wprng, const dsa_key *key);
 
 int dsa_sign_hash(const unsigned char *in,  unsigned long inlen,
                         unsigned char *out, unsigned long *outlen,
-                        prng_state *prng, int wprng, dsa_key *key);
+                        prng_state *prng, int wprng, const dsa_key *key);
 
 int dsa_verify_hash_raw(         void *r,          void *s,
                     const unsigned char *hash, unsigned long hashlen,
-                                    int *stat,      dsa_key *key);
+                                    int *stat, const dsa_key *key);
 
-int dsa_verify_hash(const unsigned char *sig,  unsigned long siglen,
-                    const unsigned char *hash, unsigned long hashlen,
-                          int           *stat, dsa_key       *key);
+int dsa_verify_hash(const unsigned char *sig,        unsigned long  siglen,
+                    const unsigned char *hash,       unsigned long  hashlen,
+                          int           *stat, const dsa_key       *key);
 
 int dsa_encrypt_key(const unsigned char *in,   unsigned long inlen,
                           unsigned char *out,  unsigned long *outlen,
-                          prng_state *prng, int wprng, int hash,
-                          dsa_key *key);
+                          prng_state    *prng, int wprng, int hash,
+                    const dsa_key       *key);
 
 int dsa_decrypt_key(const unsigned char *in,  unsigned long  inlen,
                           unsigned char *out, unsigned long *outlen,
-                          dsa_key *key);
+                    const dsa_key       *key);
 
 int dsa_import(const unsigned char *in, unsigned long inlen, dsa_key *key);
-int dsa_export(unsigned char *out, unsigned long *outlen, int type, dsa_key *key);
-int dsa_verify_key(dsa_key *key, int *stat);
+int dsa_export(unsigned char *out, unsigned long *outlen, int type, const dsa_key *key);
+int dsa_verify_key(const dsa_key *key, int *stat);
 #ifdef LTC_SOURCE
 /* internal helper functions */
-int dsa_int_validate_xy(dsa_key *key, int *stat);
-int dsa_int_validate_pqg(dsa_key *key, int *stat);
-int dsa_int_validate_primes(dsa_key *key, int *stat);
+int dsa_int_validate_xy(const dsa_key *key, int *stat);
+int dsa_int_validate_pqg(const dsa_key *key, int *stat);
+int dsa_int_validate_primes(const dsa_key *key, int *stat);
 #endif
 int dsa_shared_secret(void          *private_key, void *base,
-                      dsa_key       *public_key,
+                      const dsa_key *public_key,
                       unsigned char *out,         unsigned long *outlen);
 #endif
 
@@ -732,8 +734,8 @@ int der_decode_octet_string(const unsigned char *in, unsigned long inlen,
 int der_length_octet_string(unsigned long noctets, unsigned long *outlen);
 
 /* OBJECT IDENTIFIER */
-int der_encode_object_identifier(unsigned long *words, unsigned long  nwords,
-                                 unsigned char *out,   unsigned long *outlen);
+int der_encode_object_identifier(const unsigned long *words, unsigned long  nwords,
+                                       unsigned char *out,   unsigned long *outlen);
 int der_decode_object_identifier(const unsigned char *in,    unsigned long  inlen,
                                        unsigned long *words, unsigned long *outlen);
 int der_length_object_identifier(const unsigned long *words, unsigned long nwords, unsigned long *outlen);
@@ -815,8 +817,8 @@ typedef struct {
             off_mm; /* timezone offset minutes */
 } ltc_utctime;
 
-int der_encode_utctime(ltc_utctime *utctime,
-                       unsigned char *out,   unsigned long *outlen);
+int der_encode_utctime(const ltc_utctime   *utctime,
+                             unsigned char *out,   unsigned long *outlen);
 
 int der_decode_utctime(const unsigned char *in, unsigned long *inlen,
                              ltc_utctime   *out);
@@ -837,8 +839,8 @@ typedef struct {
             off_mm; /* timezone offset minutes */
 } ltc_generalizedtime;
 
-int der_encode_generalizedtime(ltc_generalizedtime *gtime,
-                               unsigned char       *out, unsigned long *outlen);
+int der_encode_generalizedtime(const ltc_generalizedtime *gtime,
+                                     unsigned char       *out, unsigned long *outlen);
 
 int der_decode_generalizedtime(const unsigned char *in, unsigned long *inlen,
                                ltc_generalizedtime *out);

--- a/src/misc/adler32.c
+++ b/src/misc/adler32.c
@@ -79,7 +79,7 @@ void adler32_update(adler32_state *ctx, const unsigned char *input, unsigned lon
    ctx->s[1] = (unsigned short)s2;
 }
 
-void adler32_finish(adler32_state *ctx, void *hash, unsigned long size)
+void adler32_finish(const adler32_state *ctx, void *hash, unsigned long size)
 {
    unsigned char* h;
 

--- a/src/misc/crc32.c
+++ b/src/misc/crc32.c
@@ -159,7 +159,7 @@ void crc32_update(crc32_state *ctx, const unsigned char *input, unsigned long le
    ctx->crc = crc;
 }
 
-void crc32_finish(crc32_state *ctx, void *hash, unsigned long size)
+void crc32_finish(const crc32_state *ctx, void *hash, unsigned long size)
 {
    unsigned long i;
    unsigned char* h;

--- a/src/misc/padding/padding_depad.c
+++ b/src/misc/padding/padding_depad.c
@@ -20,7 +20,7 @@
    @param mode     One of the LTC_PAD_xx flags
    @return CRYPT_OK on success
 */
-int padding_depad(unsigned char *data, unsigned long *length, unsigned long mode)
+int padding_depad(const unsigned char *data, unsigned long *length, unsigned long mode)
 {
    unsigned long padded_length, unpadded_length, n;
    unsigned char pad;

--- a/src/modes/cbc/cbc_getiv.c
+++ b/src/modes/cbc/cbc_getiv.c
@@ -22,7 +22,7 @@
    @param cbc  The CBC state
    @return CRYPT_OK if successful
 */
-int cbc_getiv(unsigned char *IV, unsigned long *len, symmetric_CBC *cbc)
+int cbc_getiv(unsigned char *IV, unsigned long *len, const symmetric_CBC *cbc)
 {
    LTC_ARGCHK(IV  != NULL);
    LTC_ARGCHK(len != NULL);

--- a/src/modes/cfb/cfb_getiv.c
+++ b/src/modes/cfb/cfb_getiv.c
@@ -22,7 +22,7 @@
    @param cfb  The CFB state
    @return CRYPT_OK if successful
 */
-int cfb_getiv(unsigned char *IV, unsigned long *len, symmetric_CFB *cfb)
+int cfb_getiv(unsigned char *IV, unsigned long *len, const symmetric_CFB *cfb)
 {
    LTC_ARGCHK(IV  != NULL);
    LTC_ARGCHK(len != NULL);

--- a/src/modes/ctr/ctr_getiv.c
+++ b/src/modes/ctr/ctr_getiv.c
@@ -22,7 +22,7 @@
    @param ctr  The CTR state
    @return CRYPT_OK if successful
 */
-int ctr_getiv(unsigned char *IV, unsigned long *len, symmetric_CTR *ctr)
+int ctr_getiv(unsigned char *IV, unsigned long *len, const symmetric_CTR *ctr)
 {
    LTC_ARGCHK(IV  != NULL);
    LTC_ARGCHK(len != NULL);

--- a/src/modes/f8/f8_getiv.c
+++ b/src/modes/f8/f8_getiv.c
@@ -22,7 +22,7 @@
    @param f8   The F8 state
    @return CRYPT_OK if successful
 */
-int f8_getiv(unsigned char *IV, unsigned long *len, symmetric_F8 *f8)
+int f8_getiv(unsigned char *IV, unsigned long *len, const symmetric_F8 *f8)
 {
    LTC_ARGCHK(IV  != NULL);
    LTC_ARGCHK(len != NULL);

--- a/src/modes/lrw/lrw_getiv.c
+++ b/src/modes/lrw/lrw_getiv.c
@@ -22,7 +22,7 @@
   @param lrw     The LRW state to read
   @return CRYPT_OK if successful
 */
-int lrw_getiv(unsigned char *IV, unsigned long *len, symmetric_LRW *lrw)
+int lrw_getiv(unsigned char *IV, unsigned long *len, const symmetric_LRW *lrw)
 {
    LTC_ARGCHK(IV != NULL);
    LTC_ARGCHK(len != NULL);

--- a/src/modes/ofb/ofb_getiv.c
+++ b/src/modes/ofb/ofb_getiv.c
@@ -22,7 +22,7 @@
    @param ofb  The OFB state
    @return CRYPT_OK if successful
 */
-int ofb_getiv(unsigned char *IV, unsigned long *len, symmetric_OFB *ofb)
+int ofb_getiv(unsigned char *IV, unsigned long *len, const symmetric_OFB *ofb)
 {
    LTC_ARGCHK(IV  != NULL);
    LTC_ARGCHK(len != NULL);

--- a/src/modes/xts/xts_decrypt.c
+++ b/src/modes/xts/xts_decrypt.c
@@ -14,7 +14,7 @@
 
 #ifdef LTC_XTS_MODE
 
-static int _tweak_uncrypt(const unsigned char *C, unsigned char *P, unsigned char *T, symmetric_xts *xts)
+static int _tweak_uncrypt(const unsigned char *C, unsigned char *P, unsigned char *T, const symmetric_xts *xts)
 {
    unsigned long x;
    int err;
@@ -57,7 +57,7 @@ static int _tweak_uncrypt(const unsigned char *C, unsigned char *P, unsigned cha
  Returns CRYPT_OK upon success
  */
 int xts_decrypt(const unsigned char *ct, unsigned long ptlen, unsigned char *pt, unsigned char *tweak,
-                symmetric_xts *xts)
+                const symmetric_xts *xts)
 {
    unsigned char PP[16], CC[16], T[16];
    unsigned long i, m, mo, lim;

--- a/src/modes/xts/xts_encrypt.c
+++ b/src/modes/xts/xts_encrypt.c
@@ -14,7 +14,7 @@
 
 #ifdef LTC_XTS_MODE
 
-static int _tweak_crypt(const unsigned char *P, unsigned char *C, unsigned char *T, symmetric_xts *xts)
+static int _tweak_crypt(const unsigned char *P, unsigned char *C, unsigned char *T, const symmetric_xts *xts)
 {
    unsigned long x;
    int err;
@@ -59,7 +59,7 @@ static int _tweak_crypt(const unsigned char *P, unsigned char *C, unsigned char 
  Returns CRYPT_OK upon success
  */
 int xts_encrypt(const unsigned char *pt, unsigned long ptlen, unsigned char *ct, unsigned char *tweak,
-                symmetric_xts *xts)
+                const symmetric_xts *xts)
 {
    unsigned char PP[16], CC[16], T[16];
    unsigned long i, m, mo, lim;

--- a/src/modes/xts/xts_test.c
+++ b/src/modes/xts/xts_test.c
@@ -12,13 +12,13 @@
 
 #ifndef LTC_NO_TEST
 static int _xts_test_accel_xts_encrypt(const unsigned char *pt, unsigned char *ct, unsigned long blocks,
-                                       unsigned char *tweak, symmetric_key *skey1, symmetric_key *skey2)
+                                       unsigned char *tweak, const symmetric_key *skey1, const symmetric_key *skey2)
 {
    int ret;
    symmetric_xts xts;
    int (*orig)(const unsigned char *, unsigned char *,
-               unsigned long , unsigned char *, symmetric_key *,
-               symmetric_key *);
+               unsigned long , unsigned char *,
+               const symmetric_key *, const symmetric_key *);
 
    /* AES can be under rijndael or aes... try to find it */
    if ((xts.cipher = find_cipher("aes")) == -1) {
@@ -39,13 +39,13 @@ static int _xts_test_accel_xts_encrypt(const unsigned char *pt, unsigned char *c
 }
 
 static int _xts_test_accel_xts_decrypt(const unsigned char *ct, unsigned char *pt, unsigned long blocks,
-                                       unsigned char *tweak, symmetric_key *skey1, symmetric_key *skey2)
+                                       unsigned char *tweak, const symmetric_key *skey1, const symmetric_key *skey2)
 {
    int ret;
    symmetric_xts xts;
    int (*orig)(const unsigned char *, unsigned char *,
-               unsigned long , unsigned char *, symmetric_key *,
-               symmetric_key *);
+               unsigned long , unsigned char *,
+               const symmetric_key *, const symmetric_key *);
 
    /* AES can be under rijndael or aes... try to find it */
    if ((xts.cipher = find_cipher("aes")) == -1) {

--- a/src/pk/asn1/der/generalizedtime/der_encode_generalizedtime.c
+++ b/src/pk/asn1/der/generalizedtime/der_encode_generalizedtime.c
@@ -37,8 +37,8 @@ static const char * const baseten = "0123456789";
   @param outlen       [in/out] The length of the DER encoding
   @return CRYPT_OK if successful
 */
-int der_encode_generalizedtime(ltc_generalizedtime *gtime,
-                               unsigned char       *out,   unsigned long *outlen)
+int der_encode_generalizedtime(const ltc_generalizedtime *gtime,
+                                     unsigned char       *out, unsigned long *outlen)
 {
     unsigned long x, tmplen;
     int           err;

--- a/src/pk/asn1/der/generalizedtime/der_length_generalizedtime.c
+++ b/src/pk/asn1/der/generalizedtime/der_length_generalizedtime.c
@@ -22,7 +22,7 @@
   @param outlen [out] The length of the DER encoding
   @return CRYPT_OK if successful
 */
-int der_length_generalizedtime(ltc_generalizedtime *gtime, unsigned long *outlen)
+int der_length_generalizedtime(const ltc_generalizedtime *gtime, unsigned long *outlen)
 {
    LTC_ARGCHK(outlen  != NULL);
    LTC_ARGCHK(gtime != NULL);

--- a/src/pk/asn1/der/object_identifier/der_encode_object_identifier.c
+++ b/src/pk/asn1/der/object_identifier/der_encode_object_identifier.c
@@ -22,8 +22,8 @@
   @param outlen  [in/out] The max and resulting size of the OID
   @return CRYPT_OK if successful
 */
-int der_encode_object_identifier(unsigned long *words, unsigned long  nwords,
-                                 unsigned char *out,   unsigned long *outlen)
+int der_encode_object_identifier(const unsigned long *words, unsigned long  nwords,
+                                       unsigned char *out,   unsigned long *outlen)
 {
    unsigned long i, x, y, z, t, mask, wordbuf;
    int           err;

--- a/src/pk/asn1/der/object_identifier/der_length_object_identifier.c
+++ b/src/pk/asn1/der/object_identifier/der_length_object_identifier.c
@@ -35,7 +35,7 @@ unsigned long der_object_identifier_bits(unsigned long x)
   @param outlen   [out] The length of the DER encoding for the given string
   @return CRYPT_OK if successful
 */
-int der_length_object_identifier(unsigned long *words, unsigned long nwords, unsigned long *outlen)
+int der_length_object_identifier(const unsigned long *words, unsigned long nwords, unsigned long *outlen)
 {
    unsigned long y, z, t, wordbuf;
 

--- a/src/pk/asn1/der/sequence/der_encode_sequence_ex.c
+++ b/src/pk/asn1/der/sequence/der_encode_sequence_ex.c
@@ -25,8 +25,8 @@
    @param type_of   LTC_ASN1_SEQUENCE or LTC_ASN1_SET/LTC_ASN1_SETOF
    @return CRYPT_OK on success
 */
-int der_encode_sequence_ex(ltc_asn1_list *list, unsigned long inlen,
-                           unsigned char *out,  unsigned long *outlen, int type_of)
+int der_encode_sequence_ex(const ltc_asn1_list *list, unsigned long inlen,
+                           unsigned char *out,        unsigned long *outlen, int type_of)
 {
    int           err;
    ltc_asn1_type type;

--- a/src/pk/asn1/der/sequence/der_length_sequence.c
+++ b/src/pk/asn1/der/sequence/der_length_sequence.c
@@ -22,13 +22,13 @@
    @param outlen [out] The length required in octets to store it
    @return CRYPT_OK on success
 */
-int der_length_sequence(ltc_asn1_list *list, unsigned long inlen,
+int der_length_sequence(const ltc_asn1_list *list, unsigned long inlen,
                         unsigned long *outlen)
 {
    return der_length_sequence_ex(list, inlen, outlen, NULL);
 }
 
-int der_length_sequence_ex(ltc_asn1_list *list, unsigned long inlen,
+int der_length_sequence_ex(const ltc_asn1_list *list, unsigned long inlen,
                            unsigned long *outlen, unsigned long *payloadlen)
 {
    int           err;

--- a/src/pk/asn1/der/set/der_encode_set.c
+++ b/src/pk/asn1/der/set/der_encode_set.c
@@ -46,8 +46,8 @@ static int _qsort_helper(const void *a, const void *b)
    @param outlen    [in/out] The size of the output
    @return CRYPT_OK on success
 */
-int der_encode_set(ltc_asn1_list *list, unsigned long inlen,
-                   unsigned char *out,  unsigned long *outlen)
+int der_encode_set(const ltc_asn1_list *list, unsigned long inlen,
+                   unsigned char *out,        unsigned long *outlen)
 {
    ltc_asn1_list  *copy;
    unsigned long   x;

--- a/src/pk/asn1/der/set/der_encode_setof.c
+++ b/src/pk/asn1/der/set/der_encode_setof.c
@@ -56,8 +56,8 @@ static int _qsort_helper(const void *a, const void *b)
    @param outlen    [in/out] The size of the output
    @return CRYPT_OK on success
 */
-int der_encode_setof(ltc_asn1_list *list, unsigned long inlen,
-                     unsigned char *out,  unsigned long *outlen)
+int der_encode_setof(const ltc_asn1_list *list, unsigned long inlen,
+                     unsigned char *out,        unsigned long *outlen)
 {
    unsigned long  x, y, z;
    ptrdiff_t hdrlen;

--- a/src/pk/asn1/der/utctime/der_encode_utctime.c
+++ b/src/pk/asn1/der/utctime/der_encode_utctime.c
@@ -28,8 +28,8 @@ static const char * const baseten = "0123456789";
   @param outlen       [in/out] The length of the DER encoding
   @return CRYPT_OK if successful
 */
-int der_encode_utctime(ltc_utctime *utctime,
-                       unsigned char *out,   unsigned long *outlen)
+int der_encode_utctime(const ltc_utctime   *utctime,
+                             unsigned char *out,   unsigned long *outlen)
 {
     unsigned long x, tmplen;
     int           err;

--- a/src/pk/asn1/der/utctime/der_length_utctime.c
+++ b/src/pk/asn1/der/utctime/der_length_utctime.c
@@ -21,7 +21,7 @@
   @param outlen [out] The length of the DER encoding
   @return CRYPT_OK if successful
 */
-int der_length_utctime(ltc_utctime *utctime, unsigned long *outlen)
+int der_length_utctime(const ltc_utctime *utctime, unsigned long *outlen)
 {
    LTC_ARGCHK(outlen  != NULL);
    LTC_ARGCHK(utctime != NULL);

--- a/src/pk/dh/dh.c
+++ b/src/pk/dh/dh.c
@@ -224,7 +224,7 @@ const ltc_dh_set_type ltc_dh_sets[] = {
   @param key   The DH key to get the size of
   @return The group size in octets (0 on error)
  */
-int dh_get_groupsize(dh_key *key)
+int dh_get_groupsize(const dh_key *key)
 {
    if (key == NULL) return 0;
    return mp_unsigned_bin_size(key->prime);

--- a/src/pk/dh/dh_check_pubkey.c
+++ b/src/pk/dh/dh_check_pubkey.c
@@ -16,7 +16,7 @@
   @param key    The key you wish to test
   @return CRYPT_OK if successful
 */
-int dh_check_pubkey(dh_key *key)
+int dh_check_pubkey(const dh_key *key)
 {
    void *p_minus1;
    ltc_mp_digit digit;

--- a/src/pk/dh/dh_export.c
+++ b/src/pk/dh/dh_export.c
@@ -19,7 +19,7 @@
   @param key    The key you wish to export
   @return CRYPT_OK if successful
 */
-int dh_export(unsigned char *out, unsigned long *outlen, int type, dh_key *key)
+int dh_export(unsigned char *out, unsigned long *outlen, int type, const dh_key *key)
 {
    unsigned char flags[1];
    int err;

--- a/src/pk/dh/dh_export_key.c
+++ b/src/pk/dh/dh_export_key.c
@@ -19,7 +19,7 @@
   @param key    The key you wish to export
   @return CRYPT_OK if successful
 */
-int dh_export_key(void *out, unsigned long *outlen, int type, dh_key *key)
+int dh_export_key(void *out, unsigned long *outlen, int type, const dh_key *key)
 {
    unsigned long len;
    void *k;

--- a/src/pk/dh/dh_shared_secret.c
+++ b/src/pk/dh/dh_shared_secret.c
@@ -19,7 +19,7 @@
    @param outlen          [in/out] The max size and resulting size of the shared data.
    @return CRYPT_OK if successful
 */
-int dh_shared_secret(dh_key *private_key, dh_key *public_key,
+int dh_shared_secret(const dh_key *private_key, const dh_key *public_key,
                      unsigned char *out, unsigned long *outlen)
 {
    void *tmp;

--- a/src/pk/dsa/dsa_decrypt_key.c
+++ b/src/pk/dsa/dsa_decrypt_key.c
@@ -26,7 +26,7 @@
 */
 int dsa_decrypt_key(const unsigned char *in,  unsigned long  inlen,
                           unsigned char *out, unsigned long *outlen,
-                          dsa_key *key)
+                    const dsa_key       *key)
 {
    unsigned char  *skey, *expt;
    void           *g_pub;

--- a/src/pk/dsa/dsa_encrypt_key.c
+++ b/src/pk/dsa/dsa_encrypt_key.c
@@ -29,8 +29,8 @@
 */
 int dsa_encrypt_key(const unsigned char *in,   unsigned long inlen,
                           unsigned char *out,  unsigned long *outlen,
-                          prng_state *prng, int wprng, int hash,
-                          dsa_key *key)
+                          prng_state    *prng, int wprng, int hash,
+                    const dsa_key       *key)
 {
     unsigned char *expt, *skey;
     void          *g_pub, *g_priv;

--- a/src/pk/dsa/dsa_export.c
+++ b/src/pk/dsa/dsa_export.c
@@ -23,7 +23,7 @@
   @param key    The key to export
   @return CRYPT_OK if successful
 */
-int dsa_export(unsigned char *out, unsigned long *outlen, int type, dsa_key *key)
+int dsa_export(unsigned char *out, unsigned long *outlen, int type, const dsa_key *key)
 {
    unsigned long zero=0;
    int err, std;

--- a/src/pk/dsa/dsa_shared_secret.c
+++ b/src/pk/dsa/dsa_shared_secret.c
@@ -25,7 +25,7 @@
   @return CRYPT_OK if successful
 */
 int dsa_shared_secret(void          *private_key, void *base,
-                      dsa_key       *public_key,
+                      const dsa_key *public_key,
                       unsigned char *out,         unsigned long *outlen)
 {
    unsigned long  x;

--- a/src/pk/dsa/dsa_sign_hash.c
+++ b/src/pk/dsa/dsa_sign_hash.c
@@ -28,7 +28,7 @@
 */
 int dsa_sign_hash_raw(const unsigned char *in,  unsigned long inlen,
                                    void   *r,   void *s,
-                               prng_state *prng, int wprng, dsa_key *key)
+                               prng_state *prng, int wprng, const dsa_key *key)
 {
    void         *k, *kinv, *tmp;
    unsigned char *buf;
@@ -117,7 +117,7 @@ ERRBUF:
 */
 int dsa_sign_hash(const unsigned char *in,  unsigned long inlen,
                         unsigned char *out, unsigned long *outlen,
-                        prng_state *prng, int wprng, dsa_key *key)
+                        prng_state *prng, int wprng, const dsa_key *key)
 {
    void         *r, *s;
    int           err;

--- a/src/pk/dsa/dsa_verify_hash.c
+++ b/src/pk/dsa/dsa_verify_hash.c
@@ -28,7 +28,7 @@
 */
 int dsa_verify_hash_raw(         void   *r,          void   *s,
                     const unsigned char *hash, unsigned long hashlen,
-                                    int *stat,      dsa_key *key)
+                                    int *stat, const dsa_key *key)
 {
    void          *w, *v, *u1, *u2;
    int           err;
@@ -92,9 +92,9 @@ error:
   @param key      The corresponding public DSA key
   @return CRYPT_OK if successful (even if the signature is invalid)
 */
-int dsa_verify_hash(const unsigned char *sig, unsigned long siglen,
-                    const unsigned char *hash, unsigned long hashlen,
-                    int *stat, dsa_key *key)
+int dsa_verify_hash(const unsigned char *sig,        unsigned long  siglen,
+                    const unsigned char *hash,       unsigned long  hashlen,
+                          int           *stat, const dsa_key       *key)
 {
    int    err;
    void   *r, *s;

--- a/src/pk/dsa/dsa_verify_key.c
+++ b/src/pk/dsa/dsa_verify_key.c
@@ -26,7 +26,7 @@
    @param stat  [out]  Result of test, 1==valid, 0==invalid
    @return CRYPT_OK if successful
 */
-int dsa_verify_key(dsa_key *key, int *stat)
+int dsa_verify_key(const dsa_key *key, int *stat)
 {
    int err;
 
@@ -47,7 +47,7 @@ int dsa_verify_key(dsa_key *key, int *stat)
    @param stat  [out]  Result of test, 1==valid, 0==invalid
    @return CRYPT_OK if successful
 */
-int dsa_int_validate_pqg(dsa_key *key, int *stat)
+int dsa_int_validate_pqg(const dsa_key *key, int *stat)
 {
    void *tmp1, *tmp2;
    int  err;
@@ -101,7 +101,7 @@ error:
    @param stat  [out]  Result of test, 1==valid, 0==invalid
    @return CRYPT_OK if successful
 */
-int dsa_int_validate_primes(dsa_key *key, int *stat)
+int dsa_int_validate_primes(const dsa_key *key, int *stat)
 {
    int err, res;
 
@@ -136,7 +136,7 @@ int dsa_int_validate_primes(dsa_key *key, int *stat)
    @param stat  [out]  Result of test, 1==valid, 0==invalid
    @return CRYPT_OK if successful
 */
-int dsa_int_validate_xy(dsa_key *key, int *stat)
+int dsa_int_validate_xy(const dsa_key *key, int *stat)
 {
    void *tmp;
    int  err;

--- a/src/pk/rsa/rsa_decrypt_key.c
+++ b/src/pk/rsa/rsa_decrypt_key.c
@@ -29,11 +29,11 @@
    @param key         The corresponding private RSA key
    @return CRYPT_OK if succcessul (even if invalid)
 */
-int rsa_decrypt_key_ex(const unsigned char *in,       unsigned long  inlen,
-                             unsigned char *out,      unsigned long *outlen,
-                       const unsigned char *lparam,   unsigned long  lparamlen,
-                             int            hash_idx, int            padding,
-                             int           *stat,     rsa_key       *key)
+int rsa_decrypt_key_ex(const unsigned char *in,             unsigned long  inlen,
+                             unsigned char *out,            unsigned long *outlen,
+                       const unsigned char *lparam,         unsigned long  lparamlen,
+                             int            hash_idx,       int            padding,
+                             int           *stat,     const rsa_key       *key)
 {
   unsigned long modulus_bitlen, modulus_bytelen, x;
   int           err;

--- a/src/pk/rsa/rsa_encrypt_key.c
+++ b/src/pk/rsa/rsa_encrypt_key.c
@@ -30,10 +30,12 @@
     @param key         The RSA key to encrypt to
     @return CRYPT_OK if successful
 */
-int rsa_encrypt_key_ex(const unsigned char *in,     unsigned long inlen,
-                             unsigned char *out,    unsigned long *outlen,
-                       const unsigned char *lparam, unsigned long lparamlen,
-                       prng_state *prng, int prng_idx, int hash_idx, int padding, rsa_key *key)
+int rsa_encrypt_key_ex(const unsigned char *in,       unsigned long  inlen,
+                             unsigned char *out,      unsigned long *outlen,
+                       const unsigned char *lparam,   unsigned long  lparamlen,
+                             prng_state    *prng,     int            prng_idx,
+                             int            hash_idx, int            padding,
+                       const rsa_key       *key)
 {
   unsigned long modulus_bitlen, modulus_bytelen, x;
   int           err;

--- a/src/pk/rsa/rsa_export.c
+++ b/src/pk/rsa/rsa_export.c
@@ -23,7 +23,7 @@
     @param key       The RSA key to export
     @return CRYPT_OK if successful
 */
-int rsa_export(unsigned char *out, unsigned long *outlen, int type, rsa_key *key)
+int rsa_export(unsigned char *out, unsigned long *outlen, int type, const rsa_key *key)
 {
    unsigned long zero=0;
    int err;

--- a/src/pk/rsa/rsa_exptmod.c
+++ b/src/pk/rsa/rsa_exptmod.c
@@ -28,7 +28,7 @@
 */
 int rsa_exptmod(const unsigned char *in,   unsigned long inlen,
                       unsigned char *out,  unsigned long *outlen, int which,
-                      rsa_key *key)
+                const rsa_key *key)
 {
    void        *tmp, *tmpa, *tmpb;
    #ifdef LTC_RSA_BLINDING

--- a/src/pk/rsa/rsa_get_size.c
+++ b/src/pk/rsa/rsa_get_size.c
@@ -20,7 +20,7 @@
   @param key      The RSA key
   @return The size in bytes of the RSA key or INT_MAX on error.
 */
-int rsa_get_size(rsa_key *key)
+int rsa_get_size(const rsa_key *key)
 {
   int ret = INT_MAX;
   LTC_ARGCHK(key != NULL);

--- a/src/pk/rsa/rsa_sign_hash.c
+++ b/src/pk/rsa/rsa_sign_hash.c
@@ -34,7 +34,7 @@ int rsa_sign_hash_ex(const unsigned char *in,       unsigned long  inlen,
                            int            padding,
                            prng_state    *prng,     int            prng_idx,
                            int            hash_idx, unsigned long  saltlen,
-                           rsa_key *key)
+                     const rsa_key *key)
 {
    unsigned long modulus_bitlen, modulus_bytelen, x, y;
    int           err;

--- a/src/pk/rsa/rsa_sign_saltlen_get.c
+++ b/src/pk/rsa/rsa_sign_saltlen_get.c
@@ -22,7 +22,7 @@
   @param key        The RSA key
   @return The maximum salt length in bytes or INT_MAX on error.
 */
-int rsa_sign_saltlen_get_max_ex(int padding, int hash_idx, rsa_key *key)
+int rsa_sign_saltlen_get_max_ex(int padding, int hash_idx, const rsa_key *key)
 {
   int ret = INT_MAX;
   LTC_ARGCHK(key != NULL);

--- a/src/pk/rsa/rsa_verify_hash.c
+++ b/src/pk/rsa/rsa_verify_hash.c
@@ -28,11 +28,11 @@
   @param key              The public RSA key corresponding to the key that performed the signature
   @return CRYPT_OK on success (even if the signature is invalid)
 */
-int rsa_verify_hash_ex(const unsigned char *sig,      unsigned long siglen,
-                       const unsigned char *hash,     unsigned long hashlen,
+int rsa_verify_hash_ex(const unsigned char *sig,            unsigned long  siglen,
+                       const unsigned char *hash,           unsigned long  hashlen,
                              int            padding,
-                             int            hash_idx, unsigned long saltlen,
-                             int           *stat,     rsa_key      *key)
+                             int            hash_idx,       unsigned long  saltlen,
+                             int           *stat,     const rsa_key       *key)
 {
   unsigned long modulus_bitlen, modulus_bytelen, x;
   int           err;

--- a/src/stream/sober128/sober128_stream.c
+++ b/src/stream/sober128/sober128_stream.c
@@ -78,7 +78,7 @@ static void cycle(ulong32 *R)
     t = t + c->R[OFF(z,13)]; \
 }
 
-static ulong32 nltap(sober128_state *c)
+static ulong32 nltap(const sober128_state *c)
 {
     ulong32 t;
     NLFUNC(c, 0);

--- a/src/stream/sober128/sober128_stream.c
+++ b/src/stream/sober128/sober128_stream.c
@@ -28,7 +28,7 @@
 
 #define B(x,i) ((unsigned char)(((x) >> (8*i)) & 0xFF))
 
-static ulong32 BYTE2WORD(unsigned char *b)
+static ulong32 BYTE2WORD(const unsigned char *b)
 {
    ulong32 t;
    LOAD32L(t, b);

--- a/src/stream/sosemanuk/sosemanuk.c
+++ b/src/stream/sosemanuk/sosemanuk.c
@@ -201,7 +201,7 @@
  * @param keylen   Length of key in bytes
  * @return CRYPT_OK on success
  */
-int sosemanuk_setup(sosemanuk_state *ss, unsigned char *key, unsigned long keylen)
+int sosemanuk_setup(sosemanuk_state *ss, const unsigned char *key, unsigned long keylen)
 {
     /*
      * This key schedule is actually a truncated Serpent key schedule.
@@ -341,7 +341,7 @@ int sosemanuk_setup(sosemanuk_state *ss, unsigned char *key, unsigned long keyle
  * @param ivlen    Length of iv in bytes
  * @return CRYPT_OK on success
  */
-int sosemanuk_setiv(sosemanuk_state *ss, unsigned char *iv, unsigned long ivlen)
+int sosemanuk_setiv(sosemanuk_state *ss, const unsigned char *iv, unsigned long ivlen)
 {
 
     /*


### PR DESCRIPTION
I have found several functions taking non-cost pointers, while the only thing they do is return size of some keys. 

I believe that functions like these really should take their arguments as `const rsa_key*` to preserve const-correctness and not being forced to write (i. e. in C++) things like

`inline int GetKeySize() const { return ::rsa_get_size(const_cast<rsa_key*>(&key_)); }`

If someone comes across another function(s) which should have `const` parameter but do not, you can write here and we can fix them all at once instead of splitting that into several commits.

Thanks!

**_EDIT:_** As was pointed out by several commenters, there are many more functions in which
a non-const pointer parameter is not used to change the pointed-to object, therefore the pointer can be declared as a const pointer. See below for the full discussion.