### PR TITLE
Fix ccm_memory() cleaning user-supplied key

### DIFF
--- a/src/encauth/ccm/ccm_memory.c
+++ b/src/encauth/ccm/ccm_memory.c
@@ -333,6 +333,9 @@ int ccm_memory(int cipher,
 
    if (skey != uskey) {
       cipher_descriptor[cipher].done(skey);
+#ifdef LTC_CLEAN_STACK
+      zeromem(skey,   sizeof(*skey));
+#endif
    }
 
    if (direction == CCM_ENCRYPT) {
@@ -380,7 +383,6 @@ int ccm_memory(int cipher,
    fastMask = 0;
 #endif
    mask = 0;
-   zeromem(skey,   sizeof(*skey));
    zeromem(PAD,    sizeof(PAD));
    zeromem(CTRPAD, sizeof(CTRPAD));
    if (pt_work != NULL) {

--- a/src/encauth/ccm/ccm_test.c
+++ b/src/encauth/ccm/ccm_test.c
@@ -145,6 +145,17 @@ int ccm_test(void)
                                tag, &taglen, 0)) != CRYPT_OK) {
             return err;
          }
+         /* run a second time to make sure skey is not touched */
+         if ((err = ccm_memory(idx,
+                               tests[x].key, 16,
+                               &skey,
+                               tests[x].nonce, tests[x].noncelen,
+                               tests[x].header, tests[x].headerlen,
+                               (unsigned char*)tests[x].pt, tests[x].ptlen,
+                               buf,
+                               tag, &taglen, 0)) != CRYPT_OK) {
+            return err;
+         }
       } else {
          if ((err = ccm_init(&ccm, idx, tests[x].key, 16, tests[x].ptlen, tests[x].taglen, tests[x].headerlen)) != CRYPT_OK) {
             return err;


### PR DESCRIPTION
* [x] tests are added or updated

This fixes a segfault caused by `ccm_memory()` with `LTC_CLEAN_STACK` enabled.