### PR TITLE
Fix docs build in Sosemanuk section.

### DIFF
--- a/doc/crypt.tex
+++ b/doc/crypt.tex
@@ -1388,8 +1388,8 @@ err = sosemanuk_done(&kc, &rc);
 \end{verbatim}
 
 To do multiple encryptions and decryptions with the same key, you can reset the algorithm
-using sosemanuk_init() if you saved the key context and did not wipe it with sosemanuk_done().
-You will want to use a different iv but you do not need to re-run sosemanuk_schedule() again.
+using \textit{sosemanuk\_init()} if you saved the key context and did not wipe it with \textit{sosemanuk\_done()}.
+You will want to use a different iv but you do not need to re-run \textit{sosemanuk\_schedule()} again.
 
 \mysection{RC4}
 


### PR DESCRIPTION
The latex build of `doc/crypt.tex` is currently broken by unescaped `_` characters in the Sosemanuk section of it, this fixes the docs.