### PR TITLE
Compile static library with fPIC, so it can be linked into a shared one.

### DIFF
--- a/makefile
+++ b/makefile
@@ -30,6 +30,8 @@ endif
 
 include makefile_include.mk
 
+LTC_CFLAGS += -fPIC
+
 ifeq ($(COVERAGE),1)
 all_test: LIB_PRE = -Wl,--whole-archive
 all_test: LIB_POST = -Wl,--no-whole-archive


### PR DESCRIPTION
When linking a static version of libtomcrypt into a shared library on an x86-64 system, gcc is unable to [relocate](https://eli.thegreenplace.net/2011/11/03/position-independent-code-pic-in-shared-libraries/) parts of libtomcrypt, because it was not built with `-fPIC` enabled.

For example:
```
/usr/bin/ld: ./libtomcrypt.a(crypt_find_prng.o): relocation R_X86_64_PC32 against symbol `prng_descriptor' can not be used when making a shared object; recompile with -fPIC

```

This should fix said error(which cannot be solved from the user of the static lib easily), and hopefully not break anything else. However, I know very little of linkers so take this with a grain of salt.