### PR TITLE
prevent undefined behavior with LTC_PTHREAD

### DIFF
--- a/src/headers/tomcrypt_custom.h
+++ b/src/headers/tomcrypt_custom.h
@@ -555,6 +555,7 @@
 #define LTC_MUTEX_INIT(x)     LTC_ARGCHK(pthread_mutex_init(x, NULL) == 0);
 #define LTC_MUTEX_LOCK(x)     LTC_ARGCHK(pthread_mutex_lock(x) == 0);
 #define LTC_MUTEX_UNLOCK(x)   LTC_ARGCHK(pthread_mutex_unlock(x) == 0);
+#define LTC_MUTEX_DESTROY(x)  LTC_ARGCHK(pthread_mutex_destroy(x) == 0);
 
 #else
 
@@ -565,6 +566,7 @@
 #define LTC_MUTEX_INIT(x)
 #define LTC_MUTEX_LOCK(x)
 #define LTC_MUTEX_UNLOCK(x)
+#define LTC_MUTEX_DESTROY(x)
 
 #endif
 

--- a/src/prngs/chacha20.c
+++ b/src/prngs/chacha20.c
@@ -139,6 +139,7 @@ int chacha20_prng_done(prng_state *prng)
    prng->ready = 0;
    err = chacha_done(&prng->chacha.s);
    LTC_MUTEX_UNLOCK(&prng->lock);
+   LTC_MUTEX_DESTROY(&prng->lock);
    return err;
 }
 

--- a/src/prngs/fortuna.c
+++ b/src/prngs/fortuna.c
@@ -318,6 +318,7 @@ LBL_UNLOCK:
    zeromem(tmp, sizeof(tmp));
 #endif
    LTC_MUTEX_UNLOCK(&prng->lock);
+   LTC_MUTEX_DESTROY(&prng->lock);
    return err;
 }
 

--- a/src/prngs/rc4.c
+++ b/src/prngs/rc4.c
@@ -142,6 +142,7 @@ int rc4_done(prng_state *prng)
    prng->ready = 0;
    err = rc4_stream_done(&prng->rc4.s);
    LTC_MUTEX_UNLOCK(&prng->lock);
+   LTC_MUTEX_DESTROY(&prng->lock);
    return err;
 }
 

--- a/src/prngs/sober128.c
+++ b/src/prngs/sober128.c
@@ -141,6 +141,7 @@ int sober128_done(prng_state *prng)
    prng->ready = 0;
    err = sober128_stream_done(&prng->sober128.s);
    LTC_MUTEX_UNLOCK(&prng->lock);
+   LTC_MUTEX_DESTROY(&prng->lock);
    return err;
 }
 

--- a/src/prngs/yarrow.c
+++ b/src/prngs/yarrow.c
@@ -262,6 +262,7 @@ int yarrow_done(prng_state *prng)
    err = ctr_done(&prng->yarrow.ctr);
 
    LTC_MUTEX_UNLOCK(&prng->lock);
+   LTC_MUTEX_DESTROY(&prng->lock);
    return err;
 }
 


### PR DESCRIPTION
While reading through through [`man pthread_mutex_init`](https://linux.die.net/man/3/pthread_mutex_init) I stumbled over this:
"Attempting to initialize an already initialized mutex results in undefined behavior."

This patch should prevent this undefined behavior.