### PR TITLE
LTC_EASY & time_cipher_lrw

### DIFF
--- a/demos/timing.c
+++ b/demos/timing.c
@@ -466,7 +466,7 @@ static void time_cipher_lrw(void)
    tally_results(1);
 }
 #else
-static void time_cipher_lrw(void) { fprintf(stderr, "NO LRW\n"); return 0; }
+static void time_cipher_lrw(void) { fprintf(stderr, "NO LRW\n"); }
 #endif
 
 


### PR DESCRIPTION
The compiler warning/error was:
```
demos/timing.c: In function ‘time_cipher_lrw’:
demos/timing.c:469:73: error: ‘return’ with a value, in function returning void [-Werror]
 static void time_cipher_lrw(void) { fprintf(stderr, "NO LRW\n"); return 0; }
                                                                         ^
demos/timing.c:469:13: note: declared here
 static void time_cipher_lrw(void) { fprintf(stderr, "NO LRW\n"); return 0; }
             ^~~~~~~~~~~~~~~
```