### PR TITLE
some linting after ecc-asn1-minimal-part merge

### DIFF
--- a/src/pk/asn1/der/custom_type/der_decode_custom_type.c
+++ b/src/pk/asn1/der/custom_type/der_decode_custom_type.c
@@ -165,10 +165,10 @@ int der_decode_custom_type_ex(const unsigned char *in,   unsigned long  inlen,
                z = inlen;
                if ((err = der_decode_boolean(in + x, z, ((int *)data))) != CRYPT_OK) {
                   if (!ordered || list[i].optional) { continue; }
-                   goto LBL_ERR;
+                  goto LBL_ERR;
                }
                if ((err = der_length_boolean(&z)) != CRYPT_OK) {
-                   goto LBL_ERR;
+                  goto LBL_ERR;
                }
                break;
 

--- a/src/pk/asn1/der/general/der_encode_asn1_length.c
+++ b/src/pk/asn1/der/general/der_encode_asn1_length.c
@@ -63,13 +63,21 @@ int der_encode_asn1_length(unsigned long len, unsigned char *out, unsigned long 
          out[x++] = (unsigned char)((len>>16UL)&255);
          out[x++] = (unsigned char)((len>>8UL)&255);
          out[x++] = (unsigned char)(len&255);
+      #if ULONG_MAX != ULLONG_MAX
+      } else {
+         out[x++] = 0x84;
+         out[x++] = (unsigned char)((len>>24UL)&255);
+         out[x++] = (unsigned char)((len>>16UL)&255);
+         out[x++] = (unsigned char)((len>>8UL)&255);
+         out[x++] = (unsigned char)(len&255);
+      }
+      #else
       } else if (len <= 0xffffffffUL) {
          out[x++] = 0x84;
          out[x++] = (unsigned char)((len>>24UL)&255);
          out[x++] = (unsigned char)((len>>16UL)&255);
          out[x++] = (unsigned char)((len>>8UL)&255);
          out[x++] = (unsigned char)(len&255);
-   #if ULONG_MAX == ULLONG_MAX
       } else if (len <= 0xffffffffffULL) {
          out[x++] = 0x85;
          out[x++] = (unsigned char)((len>>32ULL)&255);
@@ -94,7 +102,7 @@ int der_encode_asn1_length(unsigned long len, unsigned char *out, unsigned long 
          out[x++] = (unsigned char)((len>>16ULL)&255);
          out[x++] = (unsigned char)((len>>8ULL)&255);
          out[x++] = (unsigned char)(len&255);
-      } else if (len <= 0xffffffffffffffffULL) {
+      } else {
          out[x++] = 0x88;
          out[x++] = (unsigned char)((len>>56ULL)&255);
          out[x++] = (unsigned char)((len>>48ULL)&255);
@@ -104,10 +112,8 @@ int der_encode_asn1_length(unsigned long len, unsigned char *out, unsigned long 
          out[x++] = (unsigned char)((len>>16ULL)&255);
          out[x++] = (unsigned char)((len>>8ULL)&255);
          out[x++] = (unsigned char)(len&255);
-   #endif
-      } else {
-         return CRYPT_INPUT_TOO_LONG;
       }
+      #endif
    }
    *outlen = x;
 

--- a/src/pk/asn1/der/sequence/der_decode_sequence_flexi.c
+++ b/src/pk/asn1/der/sequence/der_decode_sequence_flexi.c
@@ -122,6 +122,7 @@ int der_decode_sequence_flexi(const unsigned char *in, unsigned long *inlen, ltc
           * switch-case should go to default anyway...
           */
          data_offset = 0;
+         len = 0;
       }
 
      /* now switch on type */


### PR DESCRIPTION
here, some warnings which need analysis :
```
--- Module:   src/pk/asn1/der/general/der_encode_asn1_length.c (C)
                                             _
      } else if (len <= 0xffffffffffffffffULL) {
src/pk/asn1/der/general/der_encode_asn1_length.c  97  Warning 685: Relational operator '<=' always evaluates to 'true'

--- Module:   src/pk/asn1/der/general/der_encode_asn1_identifier.c (C)
                                                                              _
      if (id->class < LTC_ASN1_CL_UNIVERSAL || id->class > LTC_ASN1_CL_PRIVATE) {
src/pk/asn1/der/general/der_encode_asn1_identifier.c  45  Warning 685: Relational operator '>' always evaluates to 'false'
                                                                            _
      if (id->pc < LTC_ASN1_PC_PRIMITIVE || id->pc > LTC_ASN1_PC_CONSTRUCTED) {
src/pk/asn1/der/general/der_encode_asn1_identifier.c  48  Warning 685: Relational operator '>' always evaluates to 'false'

--- Module:   src/misc/base32/base32_decode.c (C)
                                    _
#...  { if (!(id <= BASE32_CROCKFORD)) { crypt_argchk("id <= BASE32_CROCKFORD",
   LTC_ARGCHK(id <= BASE32_CROCKFORD);
src/misc/base32/base32_decode.c  63  Warning 685: Relational operator '<=' always evaluates to 'true'
```