### PR TITLE
base64 - use `char *` for Base64 strings

### DIFF
--- a/demos/tv_gen.c
+++ b/demos/tv_gen.c
@@ -638,7 +638,8 @@ void gcm_gen(void)
 void base64_gen(void)
 {
    FILE *out;
-   unsigned char dst[256], src[32], ch;
+   unsigned char src[32], ch;
+   char dst[256];
    unsigned long x, len;
 
    out = fopen("base64_tv.txt", "w");

--- a/doc/crypt.tex
+++ b/doc/crypt.tex
@@ -6535,7 +6535,7 @@ To encode a binary string in base64 call:
 \begin{verbatim}
 int base64_encode(const unsigned char *in,
                         unsigned long  len,
-                        unsigned char *out,
+                                 char *out,
                         unsigned long *outlen);
 \end{verbatim}
 Where \textit{in} is the binary string and \textit{out} is where the ASCII output is placed.  You must set the value of \textit{outlen} prior
@@ -6543,20 +6543,20 @@ to calling this function and it sets the length of the base64 output in \textit{
 string call:
 \index{base64\_decode()}
 \begin{verbatim}
-int base64_decode(const unsigned char *in,
-                        unsigned long  len,
-                        unsigned char *out,
-                        unsigned long *outlen);
+int base64_decode(   const char *in,
+                  unsigned long  len,
+                  unsigned char *out,
+                  unsigned long *outlen);
 \end{verbatim}
 
 The function \textit{base64\_decode} works in a relaxed way which allows decoding some inputs that do not strictly follow the standard.
 If you want to be strict during decoding you can use:
 \index{base64\_strict\_decode()}
 \begin{verbatim}
-int base64_strict_decode(const unsigned char *in,
-                               unsigned long  len,
-                               unsigned char *out,
-                               unsigned long *outlen);
+int base64_strict_decode(   const char *in,
+                         unsigned long  len,
+                         unsigned char *out,
+                         unsigned long *outlen);
 \end{verbatim}
 
 \subsection{URL--safe 'base64url' encoding}
@@ -6569,16 +6569,16 @@ The interface is analogous to \textit{base64\_xxxx} functions in previous chapte
 
 \begin{verbatim}
 int base64url_encode(const unsigned char *in,  unsigned long len,
-                           unsigned char *out, unsigned long *outlen);
+                                    char *out, unsigned long *outlen);
 
 int base64url_strict_encode(const unsigned char *in,  unsigned long inlen,
-                                  unsigned char *out, unsigned long *outlen);
+                                           char *out, unsigned long *outlen);
 
-int base64url_decode(const unsigned char *in,  unsigned long len,
-                           unsigned char *out, unsigned long *outlen);
+int base64url_decode(   const char *in,  unsigned long len,
+                     unsigned char *out, unsigned long *outlen);
 
-int base64url_strict_decode(const unsigned char *in,  unsigned long len,
-                                  unsigned char *out, unsigned long *outlen);
+int base64url_strict_decode(   const char *in,  unsigned long len,
+                            unsigned char *out, unsigned long *outlen);
 \end{verbatim}
 
 \mysection{Base32 Encoding and Decoding}

--- a/src/headers/tomcrypt_misc.h
+++ b/src/headers/tomcrypt_misc.h
@@ -10,23 +10,23 @@
 /* ---- LTC_BASE64 Routines ---- */
 #ifdef LTC_BASE64
 int base64_encode(const unsigned char *in,  unsigned long len,
-                        unsigned char *out, unsigned long *outlen);
+                                 char *out, unsigned long *outlen);
 
-int base64_decode(const unsigned char *in,  unsigned long len,
+int base64_decode(const char *in,  unsigned long len,
                         unsigned char *out, unsigned long *outlen);
-int base64_strict_decode(const unsigned char *in,  unsigned long len,
+int base64_strict_decode(const char *in,  unsigned long len,
                         unsigned char *out, unsigned long *outlen);
 #endif
 
 #ifdef LTC_BASE64_URL
 int base64url_encode(const unsigned char *in,  unsigned long len,
-                        unsigned char *out, unsigned long *outlen);
+                                    char *out, unsigned long *outlen);
 int base64url_strict_encode(const unsigned char *in,  unsigned long inlen,
-                        unsigned char *out, unsigned long *outlen);
+                                           char *out, unsigned long *outlen);
 
-int base64url_decode(const unsigned char *in,  unsigned long len,
+int base64url_decode(const char *in,  unsigned long len,
                         unsigned char *out, unsigned long *outlen);
-int base64url_strict_decode(const unsigned char *in,  unsigned long len,
+int base64url_strict_decode(const char *in,  unsigned long len,
                         unsigned char *out, unsigned long *outlen);
 #endif
 

--- a/src/misc/base64/base64_decode.c
+++ b/src/misc/base64/base64_decode.c
@@ -75,7 +75,7 @@ enum {
    strict = 1
 };
 
-static int _base64_decode_internal(const unsigned char *in,  unsigned long inlen,
+static int _base64_decode_internal(const char *in,  unsigned long inlen,
                                  unsigned char *out, unsigned long *outlen,
                            const unsigned char *map, int is_strict)
 {
@@ -89,7 +89,7 @@ static int _base64_decode_internal(const unsigned char *in,  unsigned long inlen
 
    g = 0; /* '=' counter */
    for (x = y = z = t = 0; x < inlen; x++) {
-       c = map[in[x]&0xFF];
+       c = map[(unsigned char)in[x]&0xFF];
        if (c == 254) {
           g++;
           continue;
@@ -137,7 +137,7 @@ static int _base64_decode_internal(const unsigned char *in,  unsigned long inlen
    @param outlen   [in/out] The max size and resulting size of the decoded data
    @return CRYPT_OK if successful
 */
-int base64_decode(const unsigned char *in,  unsigned long inlen,
+int base64_decode(const char *in,  unsigned long inlen,
                         unsigned char *out, unsigned long *outlen)
 {
     return _base64_decode_internal(in, inlen, out, outlen, map_base64, relaxed);
@@ -151,7 +151,7 @@ int base64_decode(const unsigned char *in,  unsigned long inlen,
    @param outlen   [in/out] The max size and resulting size of the decoded data
    @return CRYPT_OK if successful
 */
-int base64_strict_decode(const unsigned char *in,  unsigned long inlen,
+int base64_strict_decode(const char *in,  unsigned long inlen,
                         unsigned char *out, unsigned long *outlen)
 {
    return _base64_decode_internal(in, inlen, out, outlen, map_base64, strict);
@@ -167,7 +167,7 @@ int base64_strict_decode(const unsigned char *in,  unsigned long inlen,
    @param outlen   [in/out] The max size and resulting size of the decoded data
    @return CRYPT_OK if successful
 */
-int base64url_decode(const unsigned char *in,  unsigned long inlen,
+int base64url_decode(const char *in,  unsigned long inlen,
                            unsigned char *out, unsigned long *outlen)
 {
     return _base64_decode_internal(in, inlen, out, outlen, map_base64url, relaxed);
@@ -181,7 +181,7 @@ int base64url_decode(const unsigned char *in,  unsigned long inlen,
    @param outlen   [in/out] The max size and resulting size of the decoded data
    @return CRYPT_OK if successful
 */
-int base64url_strict_decode(const unsigned char *in,  unsigned long inlen,
+int base64url_strict_decode(const char *in,  unsigned long inlen,
                            unsigned char *out, unsigned long *outlen)
 {
     return _base64_decode_internal(in, inlen, out, outlen, map_base64url, strict);

--- a/src/misc/base64/base64_encode.c
+++ b/src/misc/base64/base64_encode.c
@@ -28,11 +28,11 @@ static const char * const codes_base64url =
 #endif /* LTC_BASE64_URL */
 
 static int _base64_encode_internal(const unsigned char *in,  unsigned long inlen,
-                                 unsigned char *out, unsigned long *outlen,
+                                 char *out, unsigned long *outlen,
                                  const char *codes, int pad)
 {
    unsigned long i, len2, leven;
-   unsigned char *p;
+   char *p;
 
    LTC_ARGCHK(in     != NULL);
    LTC_ARGCHK(out    != NULL);
@@ -87,7 +87,7 @@ static int _base64_encode_internal(const unsigned char *in,  unsigned long inlen
    @return CRYPT_OK if successful
 */
 int base64_encode(const unsigned char *in,  unsigned long inlen,
-                        unsigned char *out, unsigned long *outlen)
+                                 char *out, unsigned long *outlen)
 {
     return _base64_encode_internal(in, inlen, out, outlen, codes_base64, 1);
 }
@@ -104,13 +104,13 @@ int base64_encode(const unsigned char *in,  unsigned long inlen,
    @return CRYPT_OK if successful
 */
 int base64url_encode(const unsigned char *in,  unsigned long inlen,
-                           unsigned char *out, unsigned long *outlen)
+                                    char *out, unsigned long *outlen)
 {
     return _base64_encode_internal(in, inlen, out, outlen, codes_base64url, 0);
 }
 
 int base64url_strict_encode(const unsigned char *in,  unsigned long inlen,
-                           unsigned char *out, unsigned long *outlen)
+                                           char *out, unsigned long *outlen)
 {
     return _base64_encode_internal(in, inlen, out, outlen, codes_base64url, 1);
 }

--- a/tests/base64_test.c
+++ b/tests/base64_test.c
@@ -11,7 +11,8 @@
 #if defined(LTC_BASE64) || defined(LTC_BASE64_URL)
 int base64_test(void)
 {
-   unsigned char in[64], out[256], tmp[64];
+   unsigned char in[64], tmp[64];
+   char out[256];
    unsigned long x, l1, l2, slen1;
 
    const unsigned char special_case[] = {
@@ -62,23 +63,23 @@ int base64_test(void)
 
    for (x = 0; x < sizeof(url_cases)/sizeof(url_cases[0]); ++x) {
        slen1 = strlen(url_cases[x].s);
-       l1 = sizeof(out);
+       l1 = sizeof(tmp);
        if(url_cases[x].is_strict)
-          DO(base64url_strict_decode((unsigned char*)url_cases[x].s, slen1, out, &l1));
+          DO(base64url_strict_decode(url_cases[x].s, slen1, tmp, &l1));
        else
-          DO(base64url_decode((unsigned char*)url_cases[x].s, slen1, out, &l1));
-       DO(do_compare_testvector(out, l1, special_case, sizeof(special_case) - 1, "base64url decode", x));
+          DO(base64url_decode(url_cases[x].s, slen1, tmp, &l1));
+       DO(do_compare_testvector(tmp, l1, special_case, sizeof(special_case) - 1, "base64url decode", x));
        if(x < 2) {
-          l2 = sizeof(tmp);
+          l2 = sizeof(out);
           if(x == 0)
-             DO(base64url_encode(out, l1, tmp, &l2));
+             DO(base64url_encode(tmp, l1, out, &l2));
           else
-             DO(base64url_strict_encode(out, l1, tmp, &l2));
-          DO(do_compare_testvector(tmp, l2, url_cases[x].s, strlen(url_cases[x].s), "base64url encode", x));
+             DO(base64url_strict_encode(tmp, l1, out, &l2));
+          DO(do_compare_testvector(out, l2, url_cases[x].s, strlen(url_cases[x].s), "base64url encode", x));
        }
    }
 
-   DO(base64url_strict_decode((unsigned char*)url_cases[4].s, slen1, out, &l1) == CRYPT_INVALID_PACKET ? CRYPT_OK : CRYPT_INVALID_PACKET);
+   DO(base64url_strict_decode(url_cases[4].s, slen1, tmp, &l1) == CRYPT_INVALID_PACKET ? CRYPT_OK : CRYPT_INVALID_PACKET);
 #endif
 
 #if defined(LTC_BASE64)

--- a/tests/der_test.c
+++ b/tests/der_test.c
@@ -21,7 +21,7 @@ int der_test(void)
 #define LTC_DER_TESTS_PRINT_FLEXI
 #endif
 
-static const unsigned char _der_tests_stinky_root_cert[] =
+static const char _der_tests_stinky_root_cert[] =
    "MIIFETCCA/mgAwIBAgIQbv53JNmv518t5lkCHE272jANBgkqhkiG9w0BAQUFADCB"
    "lTELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAlVUMRcwFQYDVQQHEw5TYWx0IExha2Ug"
    "Q2l0eTEeMBwGA1UEChMVVGhlIFVTRVJUUlVTVCBOZXR3b3JrMSEwHwYDVQQLExho"
@@ -50,7 +50,7 @@ static const unsigned char _der_tests_stinky_root_cert[] =
    "JeXwdFaRjbamiz3Irl+u7x/mhxdza6RvgBYylXRFMudANpeGsV7gDXlnfzpFDKHQ"
    "niVwB7P5sbPFIlmIc+4/xRItkLIRjCVXaepgN9KYu3VOgiSDI6wXiTwP44/LUXQM"
    "hetwa7s=";
-const unsigned char _der_tests_cacert_root_cert[] =
+const char _der_tests_cacert_root_cert[] =
    "MIIHPTCCBSWgAwIBAgIBADANBgkqhkiG9w0BAQQFADB5MRAwDgYDVQQKEwdSb290"
    "IENBMR4wHAYDVQQLExVodHRwOi8vd3d3LmNhY2VydC5vcmcxIjAgBgNVBAMTGUNB"
    "IENlcnQgU2lnbmluZyBBdXRob3JpdHkxITAfBgkqhkiG9w0BCQEWEnN1cHBvcnRA"

--- a/tests/dsa_test.c
+++ b/tests/dsa_test.c
@@ -271,7 +271,7 @@ static int _dsa_wycheproof_test(void)
    dsa_key key;
    int stat;
 
-   DO(base64_decode((unsigned char*)b64key, strlen(b64key), derkey, &derlen));
+   DO(base64_decode(b64key, strlen(b64key), derkey, &derlen));
    if (derlen != 838) {
       fprintf(stderr, "base64_decode failed, derlen=%lu (expected 838)\n", derlen);
       return CRYPT_FAIL_TESTVECTOR;

--- a/tests/rsa_test.c
+++ b/tests/rsa_test.c
@@ -54,7 +54,7 @@ static const unsigned char openssl_private_rsa[] = {
    0x78, 0x18, 0x5a, 0x79, 0x3d, 0x2e, 0x8e, 0x7e, 0x86, 0x0a, 0xe6, 0xa8, 0x33, 0xc1, 0x04, 0x17,
    0x4a, 0x9f,  };
 
-static const unsigned char x509_public_rsa[] =
+static const char x509_public_rsa[] =
     "MIICdTCCAd4CCQCYjCwz0l9JpjANBgkqhkiG9w0BAQsFADB+MQswCQYDVQQGEwJD\
      WjEPMA0GA1UECAwGTW9yYXZhMQ0wCwYDVQQHDARCcm5vMRAwDgYDVQQKDAdMVEMg\
      THRkMQ8wDQYDVQQLDAZDcnlwdG8xEjAQBgNVBAMMCVRlc3QgQ2VydDEYMBYGCSqG\
@@ -175,7 +175,7 @@ static const unsigned char openssl_rsautl_pkcs[] = {
    0xef, 0x57, 0x23, 0x4b, 0x3a, 0xa3, 0x24, 0x91, 0x4d, 0xfb, 0xb2, 0xd4, 0xe7, 0x5e, 0x41, 0x7e,
 };
 
-extern const unsigned char _der_tests_cacert_root_cert[];
+extern const char _der_tests_cacert_root_cert[];
 extern const unsigned long _der_tests_cacert_root_cert_size;
 
 static int rsa_compat_test(void)


### PR DESCRIPTION
### Checklist

* [x] documentation is added or updated
* [x] tests are added or updated
