### PR TITLE
consistent NUL byte handling in baseNN_encode

### DIFF
--- a/src/misc/base16/base16_encode.c
+++ b/src/misc/base16/base16_encode.c
@@ -49,12 +49,12 @@ int base16_encode(const unsigned char *in,  unsigned long  inlen,
       *outlen = x;
       return CRYPT_BUFFER_OVERFLOW;
    }
-   *outlen = x;
+   x--;
+   *outlen = x; /* returning the length without terminating NUL */
 
    if (caps == 0) alphabet = alphabets[0];
    else alphabet = alphabets[1];
 
-   x -= 1;
    for (i = 0; i < x; i += 2) {
       out[i]   = alphabet[(in[i/2] >> 4) & 0x0f];
       out[i+1] = alphabet[in[i/2] & 0x0f];

--- a/src/misc/base32/base32_encode.c
+++ b/src/misc/base32/base32_encode.c
@@ -45,7 +45,7 @@ int base32_encode(const unsigned char *in,  unsigned long inlen,
       *outlen = x;
       return CRYPT_BUFFER_OVERFLOW;
    }
-   *outlen = x;
+   *outlen = x - 1; /* returning the length without terminating NUL */
 
    /* no input, nothing to do */
    if (inlen == 0) {

--- a/src/misc/base64/base64_encode.c
+++ b/src/misc/base64/base64_encode.c
@@ -73,7 +73,7 @@ static int _base64_encode_internal(const unsigned char *in,  unsigned long inlen
    *p = '\0';
 
    /* return ok */
-   *outlen = (unsigned long)(p - out);
+   *outlen = (unsigned long)(p - out); /* the length without terminating NUL */
    return CRYPT_OK;
 }
 

--- a/tests/base16_test.c
+++ b/tests/base16_test.c
@@ -29,7 +29,6 @@ int base16_test(void)
          yarrow_read(in, x, &yarrow_prng);
          l1 = sizeof(out);
          DO(base16_encode(in, x, out, &l1, idx));
-         l1--;
          l2 = sizeof(tmp);
          DO(base16_decode(out, l1, tmp, &l2));
          DO(do_compare_testvector(tmp, l2, in, x, "random base16", idx * 100 + x));
@@ -40,7 +39,6 @@ int base16_test(void)
       l1 = sizeof(out);
       DO(base16_encode(testin, sizeof(testin), out, &l1, idx));
       DO(do_compare_testvector(out, strlen(out), testout[idx], strlen(testout[idx]), "testout base16", idx));
-      l1--;
       l2 = sizeof(tmp);
       DO(base16_decode(out, l1, tmp, &l2));
       DO(do_compare_testvector(tmp, l2, testin, sizeof(testin), "testin base16", idx));

--- a/tests/base32_test.c
+++ b/tests/base32_test.c
@@ -37,7 +37,7 @@ int base32_test(void)
          l1 = sizeof(out);
          DO(base32_encode(in, x, out, &l1, testid[idx]));
          l2 = sizeof(tmp);
-         DO(base32_decode(out, strlen(out), tmp, &l2, testid[idx]));
+         DO(base32_decode(out, l1, tmp, &l2, testid[idx]));
          DO(do_compare_testvector(tmp, l2, in, x, "random base32", idx * 100 + x));
       }
    }
@@ -45,9 +45,9 @@ int base32_test(void)
    for (idx = 0; idx < 4; idx++) {
       l1 = sizeof(out);
       DO(base32_encode(testin, sizeof(testin), out, &l1, testid[idx]));
-      DO(do_compare_testvector(out, strlen(out), testout[idx], strlen(testout[idx]), "testout base32", idx));
+      DO(do_compare_testvector(out, l1, testout[idx], strlen(testout[idx]), "testout base32", idx));
       l2 = sizeof(tmp);
-      DO(base32_decode(out, strlen(out), tmp, &l2, testid[idx]));
+      DO(base32_decode(out, l1, tmp, &l2, testid[idx]));
       DO(do_compare_testvector(tmp, l2, testin, sizeof(testin), "testin base32", idx));
    }
 


### PR DESCRIPTION
alternative to #370 