### PR TITLE
clang-tidy: readability-redundant-control-flow

### DIFF
--- a/src/math/multi.c
+++ b/src/math/multi.c
@@ -67,7 +67,6 @@ void ltc_cleanup_multi(void **a, ...)
       cur = va_arg(args, void**);
    }
    va_end(args);
-   return;
 }
 
 #endif


### PR DESCRIPTION
the warning was:
```
libtomcrypt/src/math/multi.c:70:4: warning: redundant return statement at the end of a function with a void return type [readability-redundant-control-flow]
   return;
   ^
```