### PR TITLE
clang-tidy: misc-suspicious-string-compare

### DIFF
--- a/src/pk/asn1/x509/x509_decode_subject_public_key_info.c
+++ b/src/pk/asn1/x509/x509_decode_subject_public_key_info.c
@@ -93,7 +93,7 @@ int x509_decode_subject_public_key_info(const unsigned char *in, unsigned long i
    }
 
    if ((alg_id[0].size != oid.OIDlen) ||
-        XMEMCMP(oid.OID, alg_id[0].data, oid.OIDlen * sizeof(oid.OID[0]))) {
+        XMEMCMP(oid.OID, alg_id[0].data, oid.OIDlen * sizeof(oid.OID[0])) != 0) {
         /* OID mismatch */
         err = CRYPT_PK_INVALID_TYPE;
         goto LBL_ERR;

--- a/src/pk/rsa/rsa_import_pkcs8.c
+++ b/src/pk/rsa/rsa_import_pkcs8.c
@@ -114,7 +114,7 @@ int rsa_import_pkcs8(const unsigned char *in, unsigned long inlen,
 
    /* check alg oid */
    if ((alg_seq[0].size != rsaoid.OIDlen) ||
-      XMEMCMP(rsaoid.OID, alg_seq[0].data, rsaoid.OIDlen * sizeof(rsaoid.OID[0]))) {
+      XMEMCMP(rsaoid.OID, alg_seq[0].data, rsaoid.OIDlen * sizeof(rsaoid.OID[0])) != 0) {
       err = CRYPT_PK_INVALID_TYPE;
       goto LBL_ERR;
    }


### PR DESCRIPTION
The warning was:
```
src/pk/rsa/rsa_import_pkcs8.c:117:7: warning: function 'memcmp' is called without explicitly comparing result [misc-suspicious-string-compare]
      XMEMCMP(rsaoid.OID, alg_seq[0].data, rsaoid.OIDlen * sizeof(rsaoid.OID[0]))) {
      ^
                                                                                  != 0
src/headers/tomcrypt_custom.h:37:18: note: expanded from macro 'XMEMCMP'
#define XMEMCMP  memcmp
                 ^
src/pk/asn1/x509/x509_decode_subject_public_key_info.c:96:9: warning: function 'memcmp' is called without explicitly comparing result [misc-suspicious-string-compare]
        XMEMCMP(oid.OID, alg_id[0].data, oid.OIDlen * sizeof(oid.OID[0]))) {
        ^
                                                                          != 0
src/headers/tomcrypt_custom.h:37:18: note: expanded from macro 'XMEMCMP'
#define XMEMCMP  memcmp
```