### PR TITLE
clang-tidy: misc-misplaced-widening-cast

### DIFF
--- a/src/misc/copy_or_zeromem.c
+++ b/src/misc/copy_or_zeromem.c
@@ -25,7 +25,7 @@ void copy_or_zeromem(const unsigned char* src, unsigned char* dest, unsigned lon
    unsigned long y;
 #ifdef LTC_FAST
    unsigned long z;
-   LTC_FAST_TYPE fastMask = ~0; /* initialize fastMask at all ones */
+   LTC_FAST_TYPE fastMask = ~(LTC_FAST_TYPE)0; /* initialize fastMask at all ones */
 #endif
    unsigned char mask = 0xff; /* initialize mask at all ones */
 

--- a/src/pk/dsa/dsa_export.c
+++ b/src/pk/dsa/dsa_export.c
@@ -69,7 +69,7 @@ int dsa_export(unsigned char *out, unsigned long *outlen, int type, dsa_key *key
       }
    } else {
       if (std) {
-          unsigned long tmplen = (mp_count_bits(key->y) / 8) + 8;
+          unsigned long tmplen = (unsigned long)(mp_count_bits(key->y) / 8) + 8;
           unsigned char* tmp = XMALLOC(tmplen);
           ltc_asn1_list int_list[3];
 

--- a/src/pk/dsa/dsa_generate_pqg.c
+++ b/src/pk/dsa/dsa_generate_pqg.c
@@ -72,8 +72,8 @@ static int _dsa_make_params(prng_state *prng, int wprng, int group_size, int mod
   */
 
   seedbytes = group_size;
-  L = modulus_size * 8;
-  N = group_size * 8;
+  L = (unsigned long)modulus_size * 8;
+  N = (unsigned long)group_size * 8;
 
   /* XXX-TODO no Lucas test */
 #ifdef LTC_MPI_HAS_LUCAS_TEST

--- a/src/pk/rsa/rsa_export.c
+++ b/src/pk/rsa/rsa_export.c
@@ -58,7 +58,7 @@ int rsa_export(unsigned char *out, unsigned long *outlen, int type, rsa_key *key
       unsigned char* tmp = NULL;
 
       if (type & PK_STD) {
-          tmplen = (mp_count_bits(key->N)/8)*2+8;
+          tmplen = (unsigned long)(mp_count_bits(key->N) / 8) * 2 + 8;
           tmp = XMALLOC(tmplen);
           ptmplen = &tmplen;
           if (tmp == NULL) {


### PR DESCRIPTION
The warning was:

```
src/misc/copy_or_zeromem.c:28:29: warning: either cast from 'int' to 'LTC_FAST_TYPE' (aka 'unsigned long long') is ineffective, or there is loss of precision before the conversion [misc-misplaced-widening-cast]
   LTC_FAST_TYPE fastMask = ~0; /* initialize fastMask at all ones */
                            ^
src/pk/dsa/dsa_export.c:72:34: warning: either cast from 'int' to 'unsigned long' is ineffective, or there is loss of precision before the conversion [misc-misplaced-widening-cast]
          unsigned long tmplen = (mp_count_bits(key->y) / 8) + 8;
                                 ^
src/pk/dsa/dsa_generate_pqg.c:75:7: warning: either cast from 'int' to 'unsigned long' is ineffective, or there is loss of precision before the conversion [misc-misplaced-widening-cast]
  L = modulus_size * 8;
      ^
src/pk/dsa/dsa_generate_pqg.c:76:7: warning: either cast from 'int' to 'unsigned long' is ineffective, or there is loss of precision before the conversion [misc-misplaced-widening-cast]
  N = group_size * 8;
      ^
src/pk/rsa/rsa_export.c:61:20: warning: either cast from 'int' to 'unsigned long' is ineffective, or there is loss of precision before the conversion [misc-misplaced-widening-cast]
          tmplen = (mp_count_bits(key->N)/8)*2+8;
                   ^
```
