### PR TITLE
add const to the hashes' compress functions

### DIFF
--- a/src/hashes/chc/chc.c
+++ b/src/hashes/chc/chc.c
@@ -127,7 +127,7 @@ int chc_init(hash_state *md)
    T0     <= encrypt T0
    state  <= state xor T0 xor T1
 */
-static int chc_compress(hash_state *md, unsigned char *buf)
+static int chc_compress(hash_state *md, const unsigned char *buf)
 {
    unsigned char  T[2][MAXBLOCKSIZE];
    symmetric_key *key;

--- a/src/hashes/md4.c
+++ b/src/hashes/md4.c
@@ -71,9 +71,9 @@ const struct ltc_hash_descriptor md4_desc =
   }
 
 #ifdef LTC_CLEAN_STACK
-static int _md4_compress(hash_state *md, unsigned char *buf)
+static int _md4_compress(hash_state *md, const unsigned char *buf)
 #else
-static int  md4_compress(hash_state *md, unsigned char *buf)
+static int  md4_compress(hash_state *md, const unsigned char *buf)
 #endif
 {
     ulong32 x[16], a, b, c, d;
@@ -155,7 +155,7 @@ static int  md4_compress(hash_state *md, unsigned char *buf)
 }
 
 #ifdef LTC_CLEAN_STACK
-static int md4_compress(hash_state *md, unsigned char *buf)
+static int md4_compress(hash_state *md, const unsigned char *buf)
 {
    int err;
    err = _md4_compress(md, buf);

--- a/src/hashes/md5.c
+++ b/src/hashes/md5.c
@@ -96,9 +96,9 @@ static const ulong32 Korder[64] = {
 #endif
 
 #ifdef LTC_CLEAN_STACK
-static int _md5_compress(hash_state *md, unsigned char *buf)
+static int _md5_compress(hash_state *md, const unsigned char *buf)
 #else
-static int  md5_compress(hash_state *md, unsigned char *buf)
+static int  md5_compress(hash_state *md, const unsigned char *buf)
 #endif
 {
     ulong32 i, W[16], a, b, c, d;
@@ -214,7 +214,7 @@ static int  md5_compress(hash_state *md, unsigned char *buf)
 }
 
 #ifdef LTC_CLEAN_STACK
-static int md5_compress(hash_state *md, unsigned char *buf)
+static int md5_compress(hash_state *md, const unsigned char *buf)
 {
    int err;
    err = _md5_compress(md, buf);

--- a/src/hashes/rmd128.c
+++ b/src/hashes/rmd128.c
@@ -79,9 +79,9 @@ const struct ltc_hash_descriptor rmd128_desc =
       (a) = ROLc((a), (s));
 
 #ifdef LTC_CLEAN_STACK
-static int _rmd128_compress(hash_state *md, unsigned char *buf)
+static int _rmd128_compress(hash_state *md, const unsigned char *buf)
 #else
-static int  rmd128_compress(hash_state *md, unsigned char *buf)
+static int  rmd128_compress(hash_state *md, const unsigned char *buf)
 #endif
 {
    ulong32 aa,bb,cc,dd,aaa,bbb,ccc,ddd,X[16];
@@ -253,7 +253,7 @@ static int  rmd128_compress(hash_state *md, unsigned char *buf)
 }
 
 #ifdef LTC_CLEAN_STACK
-static int rmd128_compress(hash_state *md, unsigned char *buf)
+static int rmd128_compress(hash_state *md, const unsigned char *buf)
 {
    int err;
    err = _rmd128_compress(md, buf);

--- a/src/hashes/rmd160.c
+++ b/src/hashes/rmd160.c
@@ -99,9 +99,9 @@ const struct ltc_hash_descriptor rmd160_desc =
 
 
 #ifdef LTC_CLEAN_STACK
-static int _rmd160_compress(hash_state *md, unsigned char *buf)
+static int _rmd160_compress(hash_state *md, const unsigned char *buf)
 #else
-static int  rmd160_compress(hash_state *md, unsigned char *buf)
+static int  rmd160_compress(hash_state *md, const unsigned char *buf)
 #endif
 {
    ulong32 aa,bb,cc,dd,ee,aaa,bbb,ccc,ddd,eee,X[16];
@@ -311,7 +311,7 @@ static int  rmd160_compress(hash_state *md, unsigned char *buf)
 }
 
 #ifdef LTC_CLEAN_STACK
-static int rmd160_compress(hash_state *md, unsigned char *buf)
+static int rmd160_compress(hash_state *md, const unsigned char *buf)
 {
    int err;
    err = _rmd160_compress(md, buf);

--- a/src/hashes/rmd256.c
+++ b/src/hashes/rmd256.c
@@ -73,9 +73,9 @@ const struct ltc_hash_descriptor rmd256_desc =
       (a) = ROLc((a), (s));
 
 #ifdef LTC_CLEAN_STACK
-static int _rmd256_compress(hash_state *md, unsigned char *buf)
+static int _rmd256_compress(hash_state *md, const unsigned char *buf)
 #else
-static int  rmd256_compress(hash_state *md, unsigned char *buf)
+static int  rmd256_compress(hash_state *md, const unsigned char *buf)
 #endif
 {
    ulong32 aa,bb,cc,dd,aaa,bbb,ccc,ddd,tmp,X[16];
@@ -262,7 +262,7 @@ static int  rmd256_compress(hash_state *md, unsigned char *buf)
 }
 
 #ifdef LTC_CLEAN_STACK
-static int rmd256_compress(hash_state *md, unsigned char *buf)
+static int rmd256_compress(hash_state *md, const unsigned char *buf)
 {
    int err;
    err = _rmd256_compress(md, buf);

--- a/src/hashes/rmd320.c
+++ b/src/hashes/rmd320.c
@@ -94,9 +94,9 @@ const struct ltc_hash_descriptor rmd320_desc =
 
 
 #ifdef LTC_CLEAN_STACK
-static int _rmd320_compress(hash_state *md, unsigned char *buf)
+static int _rmd320_compress(hash_state *md, const unsigned char *buf)
 #else
-static int  rmd320_compress(hash_state *md, unsigned char *buf)
+static int  rmd320_compress(hash_state *md, const unsigned char *buf)
 #endif
 {
    ulong32 aa,bb,cc,dd,ee,aaa,bbb,ccc,ddd,eee,tmp,X[16];
@@ -325,7 +325,7 @@ static int  rmd320_compress(hash_state *md, unsigned char *buf)
 }
 
 #ifdef LTC_CLEAN_STACK
-static int rmd320_compress(hash_state *md, unsigned char *buf)
+static int rmd320_compress(hash_state *md, const unsigned char *buf)
 {
    int err;
    err = _rmd320_compress(md, buf);

--- a/src/hashes/sha1.c
+++ b/src/hashes/sha1.c
@@ -40,9 +40,9 @@ const struct ltc_hash_descriptor sha1_desc =
 #define F3(x,y,z)  (x ^ y ^ z)
 
 #ifdef LTC_CLEAN_STACK
-static int _sha1_compress(hash_state *md, unsigned char *buf)
+static int _sha1_compress(hash_state *md, const unsigned char *buf)
 #else
-static int  sha1_compress(hash_state *md, unsigned char *buf)
+static int  sha1_compress(hash_state *md, const unsigned char *buf)
 #endif
 {
     ulong32 a,b,c,d,e,W[80],i;
@@ -146,7 +146,7 @@ static int  sha1_compress(hash_state *md, unsigned char *buf)
 }
 
 #ifdef LTC_CLEAN_STACK
-static int sha1_compress(hash_state *md, unsigned char *buf)
+static int sha1_compress(hash_state *md, const unsigned char *buf)
 {
    int err;
    err = _sha1_compress(md, buf);

--- a/src/hashes/sha2/sha256.c
+++ b/src/hashes/sha2/sha256.c
@@ -64,9 +64,9 @@ static const ulong32 K[64] = {
 
 /* compress 512-bits */
 #ifdef LTC_CLEAN_STACK
-static int _sha256_compress(hash_state * md, unsigned char *buf)
+static int _sha256_compress(hash_state * md, const unsigned char *buf)
 #else
-static int  sha256_compress(hash_state * md, unsigned char *buf)
+static int  sha256_compress(hash_state * md, const unsigned char *buf)
 #endif
 {
     ulong32 S[8], W[64], t0, t1;
@@ -187,7 +187,7 @@ static int  sha256_compress(hash_state * md, unsigned char *buf)
 }
 
 #ifdef LTC_CLEAN_STACK
-static int sha256_compress(hash_state * md, unsigned char *buf)
+static int sha256_compress(hash_state * md, const unsigned char *buf)
 {
     int err;
     err = _sha256_compress(md, buf);

--- a/src/hashes/sha2/sha512.c
+++ b/src/hashes/sha2/sha512.c
@@ -89,9 +89,9 @@ CONST64(0x5fcb6fab3ad6faec), CONST64(0x6c44198c4a475817)
 
 /* compress 1024-bits */
 #ifdef LTC_CLEAN_STACK
-static int _sha512_compress(hash_state * md, unsigned char *buf)
+static int _sha512_compress(hash_state * md, const unsigned char *buf)
 #else
-static int  sha512_compress(hash_state * md, unsigned char *buf)
+static int  sha512_compress(hash_state * md, const unsigned char *buf)
 #endif
 {
     ulong64 S[8], W[80], t0, t1;
@@ -156,7 +156,7 @@ static int  sha512_compress(hash_state * md, unsigned char *buf)
 
 /* compress 1024-bits */
 #ifdef LTC_CLEAN_STACK
-static int sha512_compress(hash_state * md, unsigned char *buf)
+static int sha512_compress(hash_state * md, const unsigned char *buf)
 {
     int err;
     err = _sha512_compress(md, buf);

--- a/src/hashes/tiger.c
+++ b/src/hashes/tiger.c
@@ -608,9 +608,9 @@ static void key_schedule(ulong64 *x)
 }
 
 #ifdef LTC_CLEAN_STACK
-static int _tiger_compress(hash_state *md, unsigned char *buf)
+static int _tiger_compress(hash_state *md, const unsigned char *buf)
 #else
-static int  tiger_compress(hash_state *md, unsigned char *buf)
+static int  tiger_compress(hash_state *md, const unsigned char *buf)
 #endif
 {
     ulong64 a, b, c, x[8];
@@ -639,7 +639,7 @@ static int  tiger_compress(hash_state *md, unsigned char *buf)
 }
 
 #ifdef LTC_CLEAN_STACK
-static int tiger_compress(hash_state *md, unsigned char *buf)
+static int tiger_compress(hash_state *md, const unsigned char *buf)
 {
    int err;
    err = _tiger_compress(md, buf);

--- a/src/hashes/whirl/whirl.c
+++ b/src/hashes/whirl/whirl.c
@@ -53,9 +53,9 @@ const struct ltc_hash_descriptor whirlpool_desc =
     SB7(GB(a, i-7, 0)))
 
 #ifdef LTC_CLEAN_STACK
-static int _whirlpool_compress(hash_state *md, unsigned char *buf)
+static int _whirlpool_compress(hash_state *md, const unsigned char *buf)
 #else
-static int whirlpool_compress(hash_state *md, unsigned char *buf)
+static int whirlpool_compress(hash_state *md, const unsigned char *buf)
 #endif
 {
    ulong64 K[2][8], T[3][8];
@@ -109,7 +109,7 @@ static int whirlpool_compress(hash_state *md, unsigned char *buf)
 
 
 #ifdef LTC_CLEAN_STACK
-static int whirlpool_compress(hash_state *md, unsigned char *buf)
+static int whirlpool_compress(hash_state *md, const unsigned char *buf)
 {
    int err;
    err = _whirlpool_compress(md, buf);

--- a/src/headers/tomcrypt_hash.h
+++ b/src/headers/tomcrypt_hash.h
@@ -502,7 +502,7 @@ int func_name (hash_state * md, const unsigned char *in, unsigned long inlen)   
     }                                                                                       \
     while (inlen > 0) {                                                                     \
         if (md-> state_var .curlen == 0 && inlen >= block_size) {                           \
-           if ((err = compress_name (md, (unsigned char *)in)) != CRYPT_OK) {               \
+           if ((err = compress_name (md, in)) != CRYPT_OK) {                                \
               return err;                                                                   \
            }                                                                                \
            md-> state_var .length += block_size * 8;                                        \


### PR DESCRIPTION
Adds a const qualifer to all hashes compress functions and thus removing the necessity for the const-cast in tomcrypt_hash.h