### PR TITLE
new fortuna: fix getting current time

### DIFF
--- a/src/headers/tomcrypt_custom.h
+++ b/src/headers/tomcrypt_custom.h
@@ -364,6 +364,15 @@
 /* time-based rate limit of the reseeding */
 #define LTC_FORTUNA_RESEED_RATELIMIT_TIMED
 
+/* with non-glibc or glibc 2.17+ prefer clock_gettime over gettimeofday */
+#if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
+#if __GLIBC_PREREQ(2, 17)
+  #define LTC_CLOCK_GETTIME
+#endif
+#elif defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
+  #define LTC_CLOCK_GETTIME
+#endif
+
 #else
 
 #ifndef LTC_FORTUNA_WD

--- a/src/headers/tomcrypt_prng.h
+++ b/src/headers/tomcrypt_prng.h
@@ -40,9 +40,8 @@ struct fortuna_prng {
                   IV[16];     /* IV for CTR mode */
 
     unsigned long pool_idx,   /* current pool we will add to */
-                  pool0_len,  /* length of 0'th pool */
-                  wd;
-
+                  pool0_len;  /* length of 0'th pool */
+    ulong64       wd;
     ulong64       reset_cnt;  /* number of times we have reseeded */
 };
 #endif

--- a/src/misc/crypt/crypt.c
+++ b/src/misc/crypt/crypt.c
@@ -515,10 +515,13 @@ const char *crypt_build_settings =
     " LTC_MECC_ACCEL "
 #endif
 #if defined(LTC_MECC_FP)
-   " LTC_MECC_FP "
+    " LTC_MECC_FP "
 #endif
 #if defined(LTC_ECC_SHAMIR)
-   " LTC_ECC_SHAMIR "
+    " LTC_ECC_SHAMIR "
+#endif
+#if defined(LTC_CLOCK_GETTIME)
+    " LTC_CLOCK_GETTIME "
 #endif
     "\n"
     ;

--- a/src/prngs/fortuna.c
+++ b/src/prngs/fortuna.c
@@ -93,7 +93,7 @@ static int _fortuna_reseed(prng_state *prng)
    int           err, x;
 
 #ifdef LTC_FORTUNA_RESEED_RATELIMIT_TIMED
-   unsigned long now = _fortuna_current_time();
+   ulong64 now = _fortuna_current_time();
    if (now == prng->fortuna.wd)
       return CRYPT_OK;
 #else

--- a/src/prngs/fortuna.c
+++ b/src/prngs/fortuna.c
@@ -8,6 +8,16 @@
  */
 #include "tomcrypt.h"
 
+#ifdef LTC_FORTUNA_RESEED_RATELIMIT_TIMED
+#if defined(_WIN32)
+  #include <windows.h>
+#elif defined(LTC_CLOCK_GETTIME)
+  #include <time.h> /* struct timespec + clock_gettime */
+#else
+  #include <sys/time.h> /* struct timeval + gettimeofday */
+#endif
+#endif
+
 /**
   @file fortuna.c
   Fortuna PRNG, Tom St Denis
@@ -66,19 +76,23 @@ static void _fortuna_update_iv(prng_state *prng)
 static ulong64 _fortuna_current_time(void)
 {
    ulong64 cur_time;
-#if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
-   struct timespec ts;
-   clock_gettime(CLOCK_MONOTONIC, &ts);
-   cur_time = (ulong64)(ts.tv_sec) * 1000000 + (ulong64)(ts.tv_nsec) / 1000; /* get microseconds */
-#elif defined(_WIN32)
+#if defined(_WIN32)
    FILETIME CurrentTime;
    ULARGE_INTEGER ul;
    GetSystemTimeAsFileTime(&CurrentTime);
    ul.LowPart  = CurrentTime.dwLowDateTime;
    ul.HighPart = CurrentTime.dwHighDateTime;
-   cur_time = ul.QuadPart;
-   cur_time -= CONST64(116444736000000000); /* subtract epoch in microseconds */
-   cur_time /= 1000; /* nanoseconds -> microseconds */
+   cur_time = ul.QuadPart; /* now we have 100ns intervals since 1 January 1601 */
+   cur_time -= CONST64(116444736000000000); /* subtract 100ns intervals between 1601-1970 */
+   cur_time /= 10; /* 100ns intervals > microseconds */
+#elif defined(LTC_CLOCK_GETTIME)
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  cur_time = (ulong64)(ts.tv_sec) * 1000000 + (ulong64)(ts.tv_nsec) / 1000; /* get microseconds */
+#else
+  struct timeval tv;
+  gettimeofday(&tv, NULL);
+  cur_time = (ulong64)(tv.tv_sec) * 1000000 + (ulong64)(tv.tv_usec); /* get microseconds */
 #endif
    return cur_time / 100;
 }

--- a/tests/test.c
+++ b/tests/test.c
@@ -67,14 +67,18 @@ static ulong64 epoch_usec(void)
   GetSystemTimeAsFileTime(&CurrentTime);
   ul.LowPart  = CurrentTime.dwLowDateTime;
   ul.HighPart = CurrentTime.dwHighDateTime;
-  cur_time = ul.QuadPart;
-  cur_time -= CONST64(116444736000000000); /* subtract epoch in microseconds */
-  cur_time /= 10; /* nanoseconds > microseconds */
+  cur_time = ul.QuadPart; /* now we have 100ns intervals since 1 January 1601 */
+  cur_time -= CONST64(116444736000000000); /* subtract 100ns intervals between 1601-1970 */
+  cur_time /= 10; /* 100ns intervals > microseconds */
   return cur_time;
-#else
+#elif defined(LTC_CLOCK_GETTIME)
   struct timespec ts;
   clock_gettime(CLOCK_MONOTONIC, &ts);
   return (ulong64)(ts.tv_sec) * 1000000 + (ulong64)(ts.tv_nsec) / 1000; /* get microseconds */
+#else
+  struct timeval tv;
+  gettimeofday(&tv, NULL);
+  return (ulong64)(tv.tv_sec) * 1000000 + (ulong64)(tv.tv_usec); /* get microseconds */
 #endif
 }
 


### PR DESCRIPTION
Initially there was missing `#include <windows.h>` but it turned out that ns - ms conversion was not correct (fixed and explained in comments).

But there is still one issue related to the fact that `prng->fortuna.wd` is only `unsigned long` (which means 32bit on MS Windows) but we are assigning into it a number of 100ms intervals since 1 Jan 1970.

MSVC warns `conversion from 'ulong64' to 'unsigned long', possible loss of data` here:
```C
unsigned long now = _fortuna_current_time();
```