### PR TITLE
makefile.shared: Respect LIBTOOL.

### DIFF
--- a/makefile.shared
+++ b/makefile.shared
@@ -16,19 +16,19 @@
 
 PLATFORM := $(shell uname | sed -e 's/_.*//')
 
-ifndef LT
+ifndef LIBTOOL
   ifeq ($(PLATFORM), Darwin)
-    LT:=glibtool
+    LIBTOOL:=glibtool
   else
-    LT:=libtool
+    LIBTOOL:=libtool
   endif
 endif
 ifeq ($(PLATFORM), CYGWIN)
   NO_UNDEFINED:=-no-undefined
 endif
-LTCOMPILE = $(LT) --mode=compile --tag=CC $(CC)
-INSTALL_CMD = $(LT) --mode=install install
-UNINSTALL_CMD = $(LT) --mode=uninstall rm
+LTCOMPILE = $(LIBTOOL) --mode=compile --tag=CC $(CC)
+INSTALL_CMD = $(LIBTOOL) --mode=install install
+UNINSTALL_CMD = $(LIBTOOL) --mode=uninstall rm
 
 #Output filenames for various targets.
 ifndef LIBNAME
@@ -49,15 +49,15 @@ src/ciphers/aes/aes_enc.o: src/ciphers/aes/aes.c src/ciphers/aes/aes_tab.c
 LOBJECTS = $(OBJECTS:.o=.lo)
 
 $(LIBNAME): $(OBJECTS)
-	$(LT) --mode=link --tag=CC $(CC) $(LTC_LDFLAGS) $(LOBJECTS) $(EXTRALIBS) -o $@ -rpath $(LIBPATH) -version-info $(VERSION_LT) $(NO_UNDEFINED)
+	$(LIBTOOL) --mode=link --tag=CC $(CC) $(LTC_LDFLAGS) $(LOBJECTS) $(EXTRALIBS) -o $@ -rpath $(LIBPATH) -version-info $(VERSION_LT) $(NO_UNDEFINED)
 
 test: $(call print-help,test,Builds the library and the 'test' application to run all self-tests) $(LIBNAME) $(TOBJECTS)
-	$(LT) --mode=link --tag=CC $(CC) $(LTC_LDFLAGS) -o $(TEST) $(TOBJECTS) $(LIBNAME) $(EXTRALIBS)
+	$(LIBTOOL) --mode=link --tag=CC $(CC) $(LTC_LDFLAGS) -o $(TEST) $(TOBJECTS) $(LIBNAME) $(EXTRALIBS)
 
 # build the demos from a template
 define DEMO_template
 $(1): $(call print-help,$(1),Builds the library and the '$(1)' demo) demos/$(1).o $$(LIBNAME)
-	$$(LT) --mode=link --tag=CC $$(CC) $$(LTC_LDFLAGS) $$^ $$(EXTRALIBS) -o $(1)
+	$$(LIBTOOL) --mode=link --tag=CC $$(CC) $$(LTC_LDFLAGS) $$^ $$(EXTRALIBS) -o $(1)
 endef
 
 $(foreach demo, $(strip $(DEMOS)), $(eval $(call DEMO_template,$(demo))))


### PR DESCRIPTION
I am using the libtool implementation called slibtool which seems to work just fine with libtomcrypt.

https://git.midipix.org/cgit.cgi/slibtool
https://git.midipix.org/cgit.cgi/slibtool/plain/README

he problem is that the standard way to use slibtool is to export `LIBTOOL` in `MAKEFLAGS`.
```
export MAKEFLAGS='LIBTOOL=slibtool'
```
Which will work with almost all autotools builds. However libtomcrypt doesn't respect this variable and wants `LT` instead.

If the makefile.shared can use `LIBTOOL` instead of `LT` this would make it a lot easier for anyone that doesn't want the default libtool.

Please see PR https://github.com/libtom/libtommath/pull/114 for more information.

On a side note, libtomcrypt is a good example of how slibtool is faster than libtool, with an AMD FX(tm)-6350 Six-Core cpu using `-j6` and `make -f makefile.shared`.

GNU libtool
```
real	0m43.242s
user	2m9.735s
sys	0m38.435s
```
slibtool
```
real	0m12.180s
user	0m42.789s
sys	0m10.406s
```