### PR TITLE
Improve base16 api

### DIFF
--- a/doc/crypt.tex
+++ b/doc/crypt.tex
@@ -6710,12 +6710,12 @@ To encode a binary string in base16 call:
 \begin{verbatim}
 int base16_encode(const unsigned char *in,  unsigned long  inlen,
                                  char *out, unsigned long *outlen,
-                                 int  caps);
+                        unsigned int   options);
 \end{verbatim}
 
 Where \textit{in} is the binary string,
 \textit{out} is where the ASCII output is placed
-and \textit{caps} is either $0$ to use lower-letter \textit{a..f} or else to use caps \textit{A..F}.
+and \textit{options} is either $0$ to use lower-letter \textit{a..f} or else to use caps \textit{A..F}.
 
 To decode a base16 string call:
 

--- a/src/headers/tomcrypt_misc.h
+++ b/src/headers/tomcrypt_misc.h
@@ -54,7 +54,7 @@ int base32_decode(const          char *in,  unsigned long inlen,
 #ifdef LTC_BASE16
 int base16_encode(const unsigned char *in,  unsigned long  inlen,
                                  char *out, unsigned long *outlen,
-                                 int  caps);
+                        unsigned int   options);
 int base16_decode(const          char *in,  unsigned long  inlen,
                         unsigned char *out, unsigned long *outlen);
 #endif

--- a/src/misc/base16/base16_decode.c
+++ b/src/misc/base16/base16_decode.c
@@ -21,6 +21,7 @@
 /**
    Base16 decode a string
    @param in       The Base16 string to decode
+   @param inlen    The length of the Base16 data
    @param out      [out] The destination of the binary decoded data
    @param outlen   [in/out] The max size and resulting size of the decoded data
    @return CRYPT_OK if successful

--- a/src/misc/base16/base16_encode.c
+++ b/src/misc/base16/base16_encode.c
@@ -22,12 +22,12 @@
    @param inlen    The length of the input buffer
    @param out      [out] The destination of the Base16 encoded data
    @param outlen   [in/out] The max size and resulting size of the encoded data
-   @param caps     Output 'a-f' on 0 and 'A-F' otherwise.
+   @param options  Output 'a-f' on 0 and 'A-F' otherwise.
    @return CRYPT_OK if successful
 */
 int base16_encode(const unsigned char *in,  unsigned long  inlen,
                                  char *out, unsigned long *outlen,
-                                  int  caps)
+                        unsigned int   options)
 {
    unsigned long i, x;
    const char *alphabet;
@@ -52,7 +52,7 @@ int base16_encode(const unsigned char *in,  unsigned long  inlen,
    x--;
    *outlen = x; /* returning the length without terminating NUL */
 
-   if (caps == 0) alphabet = alphabets[0];
+   if (options == 0) alphabet = alphabets[0];
    else alphabet = alphabets[1];
 
    for (i = 0; i < x; i += 2) {


### PR DESCRIPTION
As said in the commit-message:

```
probably we want to add more options in the future

I could think of support for some options of `xxd` resp. `hexdump`
```

e.g. the little-endian encoding of 2**n byte values