### PR TITLE
fix der_length_custom_type - incorrect length of length

### DIFF
--- a/src/pk/asn1/der/custom_type/der_length_custom_type.c
+++ b/src/pk/asn1/der/custom_type/der_length_custom_type.c
@@ -190,7 +190,7 @@ int der_length_custom_type(const ltc_asn1_list *root, unsigned long *outlen, uns
       }
    } else {
       /* calc length of length */
-      if ((err = der_length_asn1_length(y, &x)) != CRYPT_OK) {
+      if ((err = der_length_asn1_length(y - id_len, &x)) != CRYPT_OK) {
          goto LBL_ERR;
       }
       if (payloadlen != NULL) {


### PR DESCRIPTION
The bug was identified when trying to load the following DER:
```
3081a8
   020101
   040e20df177a6f7e4bb9fecbd2d75b57
   a07f
      307d
         020101
         301a
            06072a8648ce3d0101
            020f00db7c2abf62e35e668076bead208b
         3037
            040edb7c2abf62e35e668076bead2088
            040e659ef8ba043916eede8911702b22
            03150000f50b028e4d696e676875615175290472783fb1
         040f0209487239995a5ee76b55f9c2f098
         020f00db7c2abf62e35e7628dfac6561c5
         020101
   a112
      03100003a635105c5717812580408a3fd5ac
```
The interesting bit is the custom type `a07f...020101` which is 129 bytes long; however `der_length_custom_type` calculated 130 (`7f` = 127 is the length of the payload, but the implementation calculated the length from the payload + id-byte `a0` - which is in total 128 - which does not fit to 1 length-byte - which creates the difference 129 vs. 130).