### PR TITLE
fix ecc_set_key - no check of private key input buffer size

### DIFF
--- a/src/pk/ecc/ecc_set_key.c
+++ b/src/pk/ecc/ecc_set_key.c
@@ -24,24 +24,22 @@ int ecc_set_key(const unsigned char *in, unsigned long inlen, int type, ecc_key 
    a     = key->dp.A;
    b     = key->dp.B;
 
-   if (type == PK_PRIVATE && inlen <= (unsigned long)key->dp.size) {
+   if (type == PK_PRIVATE) {
       /* load private key */
       if ((err = mp_read_unsigned_bin(key->k, (unsigned char *)in, inlen)) != CRYPT_OK) {
          goto error;
       }
-      if (mp_iszero(key->k)) {
+      if (mp_iszero(key->k) || (mp_cmp(key->k, key->dp.order) != LTC_MP_LT)) {
          err = CRYPT_INVALID_PACKET;
          goto error;
       }
       /* compute public key */
       if ((err = ltc_mp.ecc_ptmul(key->k, &key->dp.base, &key->pubkey, a, prime, 1)) != CRYPT_OK)         { goto error; }
-      key->type = type;
    }
    else if (type == PK_PUBLIC) {
       /* load public key */
       if ((err = ltc_ecc_import_point(in, inlen, prime, a, b, key->pubkey.x, key->pubkey.y)) != CRYPT_OK) { goto error; }
       if ((err = mp_set(key->pubkey.z, 1)) != CRYPT_OK)                                                   { goto error; }
-      key->type = type;
    }
    else {
       err = CRYPT_INVALID_PACKET;
@@ -53,6 +51,7 @@ int ecc_set_key(const unsigned char *in, unsigned long inlen, int type, ecc_key 
       goto error;
    }
 
+   key->type = type;
    return CRYPT_OK;
 
 error:


### PR DESCRIPTION
When trying to load the following EC / DER key (generated by openssl):
```
3081be
   0201 01
   0415 00c78b055db0706fd86b5a15e14b9e51f0043d18f9
   a074
      3072
         0201 01
         3020
            0607 2a8648ce3d0101
            0215 00fffffffffffffffffffffffffffffffeffffac73
            3006
              0401 00
              0401 07
            0429 043b4c382ce37aa192a4019e763036f4f5dd4d7ebb938cf935318fdced6bc28286531733c3f03c4fee
            0215 0100000000000000000001b8fa16dfab9aca16b6b3
            0201 01
   a12c
      032a 00040ca9f03d79907c97538177a3027970abefa351073a73120e1b5d2dab02dde37c118a44f8cb267b56
```
I have found out that the private key:
* `0415` = LTC_ASN1_RAW_BIT_STRING
* value `00c78b055db0706fd86b5a15e14b9e51f0043d18f9` (21 bytes)

is for some reason 1 byte longer (21 bytes) than the curve size (20 bytes).

Therefore I have removed the test `inlen <= key->dp.size` ~~(not sure if this is not too relaxed, perhaps we can check whether `key->k < prime` or something like that)~~