### PR TITLE
Sosemanuk - remove what is effectively a NOP

### DIFF
--- a/src/stream/sosemanuk/sosemanuk.c
+++ b/src/stream/sosemanuk/sosemanuk.c
@@ -322,7 +322,7 @@ int sosemanuk_setup(sosemanuk_state *ss, const unsigned char *key, unsigned long
      * Initialize with a zero-value iv to ensure state is correct in the
      * event user fails to call setiv().
      */
-    return sosemanuk_setiv(ss, NULL, 0);
+    return CRYPT_OK;
 }
 
 

--- a/src/stream/sosemanuk/sosemanuk.c
+++ b/src/stream/sosemanuk/sosemanuk.c
@@ -318,10 +318,6 @@ int sosemanuk_setup(sosemanuk_state *ss, const unsigned char *key, unsigned long
 #undef WUP0
 #undef WUP1
 
-    /*
-     * Initialize with a zero-value iv to ensure state is correct in the
-     * event user fails to call setiv().
-     */
     return CRYPT_OK;
 }
 


### PR DESCRIPTION
prior return stmt was a failed attempt to initialize the remaining bytes of the state which is also negated by the policy of enforcing a call to sosemanuk_setiv() before calling sosemanuk_crypt().

<!--

Thank you for your pull request.

If this fixes an existing github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.

-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

* [ ] documentation is added or updated
* [ ] tests are added or updated
