### PR TITLE
fix clang-tidy warning: readability-else-after-return

### DIFF
--- a/.ci/clang-tidy.sh
+++ b/.ci/clang-tidy.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# output version
+bash .ci/printinfo.sh
+
+# tested with clang-tidy from llvm-6.0.0
+# not tested with Travis-CI
+
+#### we use the main test sets:
+# readability
+# misc
+# clang-analyzer
+# google
+# performance
+# modernize
+# cert
+# bugprone
+# portability
+
+#### the following checks are skipped
+# google-readability-function-size
+# readability-function-size
+# google-readability-casting
+# readability-braces-around-statements
+# misc-macro-parentheses
+# clang-analyzer-valist.Uninitialized
+
+echo "Run clang-tidy version"
+
+clang-tidy --version || exit 1
+
+echo "Run clang-tidy..."
+
+clang-tidy src/*/*.c src/*/*/*.c src/*/*/*/*.c src/*/*/*/*/*.c -warnings-as-errors='*' --quiet --checks=-*,\
+readability-*,-readability-function-size,-readability-braces-around-statements,\
+misc-*,-misc-macro-parentheses,\
+clang-analyzer-*,-clang-analyzer-valist.Uninitialized,\
+google-*,-google-readability-function-size,-google-readability-casting,\
+performance-*,\
+modernize-*,\
+cert-*,\
+bugprone-*,\
+portability-* -- -DUSE_LTM -DLTM_DESC -Isrc/headers -I../libtommath || { echo "clang-tidy FAILED!"; exit 1; }
+
+echo "clang-tidy ok"
+
+exit 0
+
+# ref:         $Format:%D$
+# git commit:  $Format:%H$
+# commit time: $Format:%ai$

--- a/src/ciphers/aes/aes.c
+++ b/src/ciphers/aes/aes.c
@@ -723,18 +723,19 @@ int ECB_KS(int *keysize)
 {
    LTC_ARGCHK(keysize != NULL);
 
-   if (*keysize < 16)
+   if (*keysize < 16) {
       return CRYPT_INVALID_KEYSIZE;
+   }
    if (*keysize < 24) {
       *keysize = 16;
       return CRYPT_OK;
-   } else if (*keysize < 32) {
+   }
+   if (*keysize < 32) {
       *keysize = 24;
       return CRYPT_OK;
-   } else {
-      *keysize = 32;
-      return CRYPT_OK;
    }
+   *keysize = 32;
+   return CRYPT_OK;
 }
 
 #endif

--- a/src/ciphers/blowfish.c
+++ b/src/ciphers/blowfish.c
@@ -580,7 +580,8 @@ int blowfish_keysize(int *keysize)
 
    if (*keysize < 8) {
       return CRYPT_INVALID_KEYSIZE;
-   } else if (*keysize > 56) {
+   }
+   if (*keysize > 56) {
       *keysize = 56;
    }
    return CRYPT_OK;

--- a/src/ciphers/cast5.c
+++ b/src/ciphers/cast5.c
@@ -707,7 +707,8 @@ int cast5_keysize(int *keysize)
    LTC_ARGCHK(keysize != NULL);
    if (*keysize < 5) {
       return CRYPT_INVALID_KEYSIZE;
-   } else if (*keysize > 16) {
+   }
+   if (*keysize > 16) {
       *keysize = 16;
    }
    return CRYPT_OK;

--- a/src/ciphers/kasumi.c
+++ b/src/ciphers/kasumi.c
@@ -243,9 +243,8 @@ int kasumi_keysize(int *keysize)
    if (*keysize >= 16) {
       *keysize = 16;
       return CRYPT_OK;
-   } else {
-      return CRYPT_INVALID_KEYSIZE;
    }
+   return CRYPT_INVALID_KEYSIZE;
 }
 
 int kasumi_test(void)

--- a/src/ciphers/khazad.c
+++ b/src/ciphers/khazad.c
@@ -843,9 +843,8 @@ int khazad_keysize(int *keysize)
    if (*keysize >= 16) {
       *keysize = 16;
       return CRYPT_OK;
-   } else {
-      return CRYPT_INVALID_KEYSIZE;
    }
+   return CRYPT_INVALID_KEYSIZE;
 }
 
 #endif

--- a/src/ciphers/noekeon.c
+++ b/src/ciphers/noekeon.c
@@ -314,10 +314,9 @@ int noekeon_keysize(int *keysize)
    LTC_ARGCHK(keysize != NULL);
    if (*keysize < 16) {
       return CRYPT_INVALID_KEYSIZE;
-   } else {
-      *keysize = 16;
-      return CRYPT_OK;
    }
+   *keysize = 16;
+   return CRYPT_OK;
 }
 
 #endif

--- a/src/ciphers/rc2.c
+++ b/src/ciphers/rc2.c
@@ -401,7 +401,8 @@ int rc2_keysize(int *keysize)
    LTC_ARGCHK(keysize != NULL);
    if (*keysize < 1) {
        return CRYPT_INVALID_KEYSIZE;
-   } else if (*keysize > 128) {
+   }
+   if (*keysize > 128) {
        *keysize = 128;
    }
    return CRYPT_OK;

--- a/src/ciphers/rc5.c
+++ b/src/ciphers/rc5.c
@@ -308,7 +308,8 @@ int rc5_keysize(int *keysize)
    LTC_ARGCHK(keysize != NULL);
    if (*keysize < 8) {
       return CRYPT_INVALID_KEYSIZE;
-   } else if (*keysize > 128) {
+   }
+   if (*keysize > 128) {
       *keysize = 128;
    }
    return CRYPT_OK;

--- a/src/ciphers/rc6.c
+++ b/src/ciphers/rc6.c
@@ -318,7 +318,8 @@ int rc6_keysize(int *keysize)
    LTC_ARGCHK(keysize != NULL);
    if (*keysize < 8) {
       return CRYPT_INVALID_KEYSIZE;
-   } else if (*keysize > 128) {
+   }
+   if (*keysize > 128) {
       *keysize = 128;
    }
    return CRYPT_OK;

--- a/src/ciphers/safer/safer.c
+++ b/src/ciphers/safer/safer.c
@@ -358,10 +358,9 @@ int safer_64_keysize(int *keysize)
    LTC_ARGCHK(keysize != NULL);
    if (*keysize < 8) {
       return CRYPT_INVALID_KEYSIZE;
-   } else {
-      *keysize = 8;
-      return CRYPT_OK;
    }
+   *keysize = 8;
+   return CRYPT_OK;
 }
 
 int safer_128_keysize(int *keysize)
@@ -369,10 +368,9 @@ int safer_128_keysize(int *keysize)
    LTC_ARGCHK(keysize != NULL);
    if (*keysize < 16) {
       return CRYPT_INVALID_KEYSIZE;
-   } else {
-      *keysize = 16;
-      return CRYPT_OK;
    }
+   *keysize = 16;
+   return CRYPT_OK;
 }
 
 int safer_k64_test(void)

--- a/src/ciphers/skipjack.c
+++ b/src/ciphers/skipjack.c
@@ -330,7 +330,8 @@ int skipjack_keysize(int *keysize)
    LTC_ARGCHK(keysize != NULL);
    if (*keysize < 10) {
       return CRYPT_INVALID_KEYSIZE;
-   } else if (*keysize > 10) {
+   }
+   if (*keysize > 10) {
       *keysize = 10;
    }
    return CRYPT_OK;

--- a/src/ciphers/twofish/twofish.c
+++ b/src/ciphers/twofish/twofish.c
@@ -689,23 +689,22 @@ void twofish_done(symmetric_key *skey)
 int twofish_keysize(int *keysize)
 {
    LTC_ARGCHK(keysize);
-   if (*keysize < 16)
+   if (*keysize < 16) {
       return CRYPT_INVALID_KEYSIZE;
+   }
    if (*keysize < 24) {
       *keysize = 16;
       return CRYPT_OK;
-   } else if (*keysize < 32) {
+   }
+   if (*keysize < 32) {
       *keysize = 24;
       return CRYPT_OK;
-   } else {
-      *keysize = 32;
-      return CRYPT_OK;
    }
+   *keysize = 32;
+   return CRYPT_OK;
 }
 
 #endif
-
-
 
 
 /* ref:         $Format:%D$ */

--- a/src/mac/hmac/hmac_test.c
+++ b/src/mac/hmac/hmac_test.c
@@ -614,11 +614,11 @@ int hmac_test(void)
 
     if (failed != 0) {
         return CRYPT_FAIL_TESTVECTOR;
-    } else if (tested == 0) {
-        return CRYPT_NOP;
-    } else {
-        return CRYPT_OK;
     }
+    if (tested == 0) {
+        return CRYPT_NOP;
+    }
+    return CRYPT_OK;
  #endif
 }
 

--- a/src/misc/base64/base64_decode.c
+++ b/src/misc/base64/base64_decode.c
@@ -104,16 +104,16 @@ static int _base64_decode_internal(const char *in,  unsigned long inlen,
           continue;
        }
        if (c == 253) {
-          if (mode == strict)
+          if (mode == strict) {
              return CRYPT_INVALID_PACKET;
-          else
-             continue; /* allow to ignore white-spaces (relaxed+insane) */
+          }
+          continue; /* allow to ignore white-spaces (relaxed+insane) */
        }
        if (c == 255) {
-          if (mode == insane)
+          if (mode == insane) {
              continue; /* allow to ignore invalid garbage (insane) */
-          else
-             return CRYPT_INVALID_PACKET;
+          }
+          return CRYPT_INVALID_PACKET;
        }
        if ((g > 0) && (mode != insane)) {
           /* we only allow '=' to be at the end (strict+relaxed) */

--- a/src/misc/error_to_string.c
+++ b/src/misc/error_to_string.c
@@ -68,9 +68,8 @@ const char *error_to_string(int err)
 {
    if (err < 0 || err >= (int)(sizeof(err_2_str)/sizeof(err_2_str[0]))) {
       return "Invalid error code.";
-   } else {
-      return err_2_str[err];
    }
+   return err_2_str[err];
 }
 
 

--- a/src/misc/hkdf/hkdf.c
+++ b/src/misc/hkdf/hkdf.c
@@ -30,9 +30,8 @@ int hkdf_extract(int hash_idx, const unsigned char *salt, unsigned long  saltlen
       valid results for HKDF. */
    if (salt == NULL || saltlen == 0) {
       return hmac_memory(hash_idx, (const unsigned char *)"",   1,       in, inlen, out, outlen);
-   } else {
-      return hmac_memory(hash_idx, salt, saltlen, in, inlen, out, outlen);
    }
+   return hmac_memory(hash_idx, salt, saltlen, in, inlen, out, outlen);
 }
 
 int hkdf_expand(int hash_idx, const unsigned char *info, unsigned long infolen,

--- a/src/misc/hkdf/hkdf_test.c
+++ b/src/misc/hkdf/hkdf_test.c
@@ -278,11 +278,11 @@ int hkdf_test(void)
 
     if (failed != 0) {
         return CRYPT_FAIL_TESTVECTOR;
-    } else if (tested == 0) {
-        return CRYPT_NOP;
-    } else {
-        return CRYPT_OK;
     }
+    if (tested == 0) {
+        return CRYPT_NOP;
+    }
+    return CRYPT_OK;
  #endif
 }
 

--- a/src/modes/cbc/cbc_decrypt.c
+++ b/src/modes/cbc/cbc_decrypt.c
@@ -58,32 +58,31 @@ int cbc_decrypt(const unsigned char *ct, unsigned char *pt, unsigned long len, s
 
    if (cipher_descriptor[cbc->cipher].accel_cbc_decrypt != NULL) {
       return cipher_descriptor[cbc->cipher].accel_cbc_decrypt(ct, pt, len / cbc->blocklen, cbc->IV, &cbc->key);
-   } else {
-      while (len) {
-         /* decrypt */
-         if ((err = cipher_descriptor[cbc->cipher].ecb_decrypt(ct, tmp, &cbc->key)) != CRYPT_OK) {
-            return err;
-         }
-
-         /* xor IV against plaintext */
-         #if defined(LTC_FAST)
-         for (x = 0; x < cbc->blocklen; x += sizeof(LTC_FAST_TYPE)) {
-            tmpy = *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)cbc->IV + x)) ^ *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)tmp + x));
-            *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)cbc->IV + x)) = *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)ct + x));
-            *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)pt + x)) = tmpy;
-         }
-    #else
-         for (x = 0; x < cbc->blocklen; x++) {
-            tmpy       = tmp[x] ^ cbc->IV[x];
-            cbc->IV[x] = ct[x];
-            pt[x]      = tmpy;
-         }
-    #endif
-
-         ct  += cbc->blocklen;
-         pt  += cbc->blocklen;
-         len -= cbc->blocklen;
+   }
+   while (len) {
+      /* decrypt */
+      if ((err = cipher_descriptor[cbc->cipher].ecb_decrypt(ct, tmp, &cbc->key)) != CRYPT_OK) {
+         return err;
       }
+
+      /* xor IV against plaintext */
+#if defined(LTC_FAST)
+      for (x = 0; x < cbc->blocklen; x += sizeof(LTC_FAST_TYPE)) {
+         tmpy = *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)cbc->IV + x)) ^ *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)tmp + x));
+         *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)cbc->IV + x)) = *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)ct + x));
+         *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)pt + x)) = tmpy;
+      }
+#else
+      for (x = 0; x < cbc->blocklen; x++) {
+         tmpy       = tmp[x] ^ cbc->IV[x];
+         cbc->IV[x] = ct[x];
+         pt[x]      = tmpy;
+      }
+#endif
+
+      ct  += cbc->blocklen;
+      pt  += cbc->blocklen;
+      len -= cbc->blocklen;
    }
    return CRYPT_OK;
 }

--- a/src/modes/cbc/cbc_encrypt.c
+++ b/src/modes/cbc/cbc_encrypt.c
@@ -52,39 +52,38 @@ int cbc_encrypt(const unsigned char *pt, unsigned char *ct, unsigned long len, s
 
    if (cipher_descriptor[cbc->cipher].accel_cbc_encrypt != NULL) {
       return cipher_descriptor[cbc->cipher].accel_cbc_encrypt(pt, ct, len / cbc->blocklen, cbc->IV, &cbc->key);
-   } else {
-      while (len) {
-         /* xor IV against plaintext */
-         #if defined(LTC_FAST)
-         for (x = 0; x < cbc->blocklen; x += sizeof(LTC_FAST_TYPE)) {
-            *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)cbc->IV + x)) ^= *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)pt + x));
-         }
-    #else
-         for (x = 0; x < cbc->blocklen; x++) {
-            cbc->IV[x] ^= pt[x];
-         }
-    #endif
-
-         /* encrypt */
-         if ((err = cipher_descriptor[cbc->cipher].ecb_encrypt(cbc->IV, ct, &cbc->key)) != CRYPT_OK) {
-            return err;
-         }
-
-         /* store IV [ciphertext] for a future block */
-         #if defined(LTC_FAST)
-         for (x = 0; x < cbc->blocklen; x += sizeof(LTC_FAST_TYPE)) {
-            *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)cbc->IV + x)) = *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)ct + x));
-         }
-    #else
-         for (x = 0; x < cbc->blocklen; x++) {
-            cbc->IV[x] = ct[x];
-         }
-    #endif
-
-         ct  += cbc->blocklen;
-         pt  += cbc->blocklen;
-         len -= cbc->blocklen;
+   }
+   while (len) {
+      /* xor IV against plaintext */
+#if defined(LTC_FAST)
+      for (x = 0; x < cbc->blocklen; x += sizeof(LTC_FAST_TYPE)) {
+         *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)cbc->IV + x)) ^= *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)pt + x));
       }
+#else
+      for (x = 0; x < cbc->blocklen; x++) {
+         cbc->IV[x] ^= pt[x];
+      }
+#endif
+
+      /* encrypt */
+      if ((err = cipher_descriptor[cbc->cipher].ecb_encrypt(cbc->IV, ct, &cbc->key)) != CRYPT_OK) {
+         return err;
+      }
+
+      /* store IV [ciphertext] for a future block */
+#if defined(LTC_FAST)
+      for (x = 0; x < cbc->blocklen; x += sizeof(LTC_FAST_TYPE)) {
+         *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)cbc->IV + x)) = *(LTC_FAST_TYPE_PTR_CAST((unsigned char *)ct + x));
+      }
+#else
+      for (x = 0; x < cbc->blocklen; x++) {
+         cbc->IV[x] = ct[x];
+      }
+#endif
+
+      ct  += cbc->blocklen;
+      pt  += cbc->blocklen;
+      len -= cbc->blocklen;
    }
    return CRYPT_OK;
 }

--- a/src/modes/ecb/ecb_decrypt.c
+++ b/src/modes/ecb/ecb_decrypt.c
@@ -39,15 +39,14 @@ int ecb_decrypt(const unsigned char *ct, unsigned char *pt, unsigned long len, s
    /* check for accel */
    if (cipher_descriptor[ecb->cipher].accel_ecb_decrypt != NULL) {
       return cipher_descriptor[ecb->cipher].accel_ecb_decrypt(ct, pt, len / cipher_descriptor[ecb->cipher].block_length, &ecb->key);
-   } else {
-      while (len) {
-         if ((err = cipher_descriptor[ecb->cipher].ecb_decrypt(ct, pt, &ecb->key)) != CRYPT_OK) {
-            return err;
-         }
-         pt  += cipher_descriptor[ecb->cipher].block_length;
-         ct  += cipher_descriptor[ecb->cipher].block_length;
-         len -= cipher_descriptor[ecb->cipher].block_length;
+   }
+   while (len) {
+      if ((err = cipher_descriptor[ecb->cipher].ecb_decrypt(ct, pt, &ecb->key)) != CRYPT_OK) {
+         return err;
       }
+      pt  += cipher_descriptor[ecb->cipher].block_length;
+      ct  += cipher_descriptor[ecb->cipher].block_length;
+      len -= cipher_descriptor[ecb->cipher].block_length;
    }
    return CRYPT_OK;
 }

--- a/src/modes/ecb/ecb_encrypt.c
+++ b/src/modes/ecb/ecb_encrypt.c
@@ -39,15 +39,14 @@ int ecb_encrypt(const unsigned char *pt, unsigned char *ct, unsigned long len, s
    /* check for accel */
    if (cipher_descriptor[ecb->cipher].accel_ecb_encrypt != NULL) {
       return cipher_descriptor[ecb->cipher].accel_ecb_encrypt(pt, ct, len / cipher_descriptor[ecb->cipher].block_length, &ecb->key);
-   } else {
-      while (len) {
-         if ((err = cipher_descriptor[ecb->cipher].ecb_encrypt(pt, ct, &ecb->key)) != CRYPT_OK) {
-            return err;
-         }
-         pt  += cipher_descriptor[ecb->cipher].block_length;
-         ct  += cipher_descriptor[ecb->cipher].block_length;
-         len -= cipher_descriptor[ecb->cipher].block_length;
+   }
+   while (len) {
+      if ((err = cipher_descriptor[ecb->cipher].ecb_encrypt(pt, ct, &ecb->key)) != CRYPT_OK) {
+         return err;
       }
+      pt  += cipher_descriptor[ecb->cipher].block_length;
+      ct  += cipher_descriptor[ecb->cipher].block_length;
+      len -= cipher_descriptor[ecb->cipher].block_length;
    }
    return CRYPT_OK;
 }

--- a/src/pk/asn1/der/general/der_decode_asn1_length.c
+++ b/src/pk/asn1/der/general/der_decode_asn1_length.c
@@ -41,9 +41,11 @@ int der_decode_asn1_length(const unsigned char *in, unsigned long *inlen, unsign
       real_len &= 0x7F;
       if (real_len == 0) {
          return CRYPT_PK_ASN1_ERROR;
-      } else if (real_len > sizeof(decoded_len)) {
+      }
+      if (real_len > sizeof(decoded_len)) {
          return CRYPT_OVERFLOW;
-      } else if (real_len > (*inlen - 1)) {
+      }
+      if (real_len > (*inlen - 1)) {
          return CRYPT_BUFFER_OVERFLOW;
       }
       decoded_len = 0;

--- a/src/pk/asn1/der/general/der_encode_asn1_identifier.c
+++ b/src/pk/asn1/der/general/der_encode_asn1_identifier.c
@@ -41,16 +41,15 @@ int der_encode_asn1_identifier(const ltc_asn1_list *id, unsigned char *out, unsi
       }
       *outlen = 1;
       return CRYPT_OK;
-   } else {
-      if (id->klass < LTC_ASN1_CL_UNIVERSAL || id->klass > LTC_ASN1_CL_PRIVATE) {
-         return CRYPT_INVALID_ARG;
-      }
-      if (id->pc < LTC_ASN1_PC_PRIMITIVE || id->pc > LTC_ASN1_PC_CONSTRUCTED) {
-         return CRYPT_INVALID_ARG;
-      }
-      if (id->tag > (ULONG_MAX >> (8 + 7))) {
-         return CRYPT_INVALID_ARG;
-      }
+   }
+   if (id->klass < LTC_ASN1_CL_UNIVERSAL || id->klass > LTC_ASN1_CL_PRIVATE) {
+      return CRYPT_INVALID_ARG;
+   }
+   if (id->pc < LTC_ASN1_PC_PRIMITIVE || id->pc > LTC_ASN1_PC_CONSTRUCTED) {
+      return CRYPT_INVALID_ARG;
+   }
+   if (id->tag > (ULONG_MAX >> (8 + 7))) {
+      return CRYPT_INVALID_ARG;
    }
 
    if (out != NULL) {

--- a/src/pk/asn1/der/generalizedtime/der_decode_generalizedtime.c
+++ b/src/pk/asn1/der/generalizedtime/der_decode_generalizedtime.c
@@ -112,7 +112,8 @@ YYYYMMDDhhmmss.fs-hh'mm'
     /* now is it Z or . */
     if (buf[x] == 'Z') {
        return CRYPT_OK;
-    } else if (buf[x] == '.') {
+    }
+    if (buf[x] == '.') {
        x++;
        while (buf[x] >= '0' && buf[x] <= '9') {
           unsigned fs = out->fs;
@@ -127,14 +128,14 @@ YYYYMMDDhhmmss.fs-hh'mm'
     /* now is it Z, +, - */
     if (buf[x] == 'Z') {
        return CRYPT_OK;
-    } else if (buf[x] == '+' || buf[x] == '-') {
+    }
+    if (buf[x] == '+' || buf[x] == '-') {
        out->off_dir = (buf[x++] == '+') ? 0 : 1;
        DECODE_V(out->off_hh, 24);
        DECODE_V(out->off_mm, 60);
        return CRYPT_OK;
-    } else {
-       return CRYPT_INVALID_PACKET;
     }
+    return CRYPT_INVALID_PACKET;
 }
 
 #endif

--- a/src/pk/asn1/der/set/der_encode_set.c
+++ b/src/pk/asn1/der/set/der_encode_set.c
@@ -33,9 +33,8 @@ static int _qsort_helper(const void *a, const void *b)
    if (r == 0) {
       /* their order in the original list now determines the position */
       return A->used - B->used;
-   } else {
-      return r;
    }
+   return r;
 }
 
 /*

--- a/src/pk/asn1/der/utctime/der_decode_utctime.c
+++ b/src/pk/asn1/der/utctime/der_decode_utctime.c
@@ -95,7 +95,8 @@ YYMMDDhhmmss-hh'mm'
     /* now is it Z, +, - or 0-9 */
     if (buf[x] == 'Z') {
        return CRYPT_OK;
-    } else if (buf[x] == '+' || buf[x] == '-') {
+    }
+    if (buf[x] == '+' || buf[x] == '-') {
        out->off_dir = (buf[x++] == '+') ? 0 : 1;
        DECODE_V(out->off_hh, 24);
        DECODE_V(out->off_mm, 60);
@@ -108,14 +109,14 @@ YYMMDDhhmmss-hh'mm'
     /* now is it Z, +, - */
     if (buf[x] == 'Z') {
        return CRYPT_OK;
-    } else if (buf[x] == '+' || buf[x] == '-') {
+    }
+    if (buf[x] == '+' || buf[x] == '-') {
        out->off_dir = (buf[x++] == '+') ? 0 : 1;
        DECODE_V(out->off_hh, 24);
        DECODE_V(out->off_mm, 60);
        return CRYPT_OK;
-    } else {
-       return CRYPT_INVALID_PACKET;
     }
+    return CRYPT_INVALID_PACKET;
 }
 
 #endif

--- a/src/pk/asn1/der/utf8/der_length_utf8_string.c
+++ b/src/pk/asn1/der/utf8/der_length_utf8_string.c
@@ -23,18 +23,17 @@ unsigned long der_utf8_charsize(const wchar_t c)
 {
    if (c <= 0x7F) {
       return 1;
-   } else if (c <= 0x7FF) {
+   }
+   if (c <= 0x7FF) {
       return 2;
+   }
 #if LTC_WCHAR_MAX == 0xFFFF
-   } else {
-      return 3;
-   }
+   return 3;
 #else
-   } else if (c <= 0xFFFF) {
+   if (c <= 0xFFFF) {
       return 3;
-   } else {
-      return 4;
    }
+   return 4;
 #endif
 }
 

--- a/src/pk/dh/dh_generate_key.c
+++ b/src/pk/dh/dh_generate_key.c
@@ -19,27 +19,25 @@ static int _dh_groupsize_to_keysize(int groupsize)
    if (groupsize <= 0) {
       return 0;
    }
-   else if (groupsize <= 192) {
+   if (groupsize <= 192) {
       return 30;     /* 1536-bit => key size 240-bit */
    }
-   else if (groupsize <= 256) {
+   if (groupsize <= 256) {
       return 40;     /* 2048-bit => key size 320-bit */
    }
-   else if (groupsize <= 384) {
+   if (groupsize <= 384) {
       return 52;     /* 3072-bit => key size 416-bit */
    }
-   else if (groupsize <= 512) {
+   if (groupsize <= 512) {
       return 60;     /* 4096-bit => key size 480-bit */
    }
-   else if (groupsize <= 768) {
+   if (groupsize <= 768) {
       return 67;     /* 6144-bit => key size 536-bit */
    }
-   else if (groupsize <= 1024) {
+   if (groupsize <= 1024) {
       return 77;     /* 8192-bit => key size 616-bit */
    }
-   else {
-      return 0;
-   }
+   return 0;
 }
 
 int dh_generate_key(prng_state *prng, int wprng, dh_key *key)

--- a/src/pk/dsa/dsa_export.c
+++ b/src/pk/dsa/dsa_export.c
@@ -26,6 +26,7 @@
 int dsa_export(unsigned char *out, unsigned long *outlen, int type, const dsa_key *key)
 {
    unsigned long zero=0;
+   unsigned char flags[1];
    int err, std;
 
    LTC_ARGCHK(out    != NULL);
@@ -35,13 +36,8 @@ int dsa_export(unsigned char *out, unsigned long *outlen, int type, const dsa_ke
    std = type & PK_STD;
    type &= ~PK_STD;
 
-   /* can we store the static header?  */
    if (type == PK_PRIVATE && key->type != PK_PRIVATE) {
       return CRYPT_PK_TYPE_MISMATCH;
-   }
-
-   if (type != PK_PUBLIC && type != PK_PRIVATE) {
-      return CRYPT_INVALID_ARG;
    }
 
    if (type == PK_PRIVATE) {
@@ -55,10 +51,8 @@ int dsa_export(unsigned char *out, unsigned long *outlen, int type, const dsa_ke
                                          LTC_ASN1_INTEGER,      1UL, key->x,
                                          LTC_ASN1_EOL,          0UL, NULL);
       }
-      else {
-          unsigned char flags[1];
-          flags[0] = 1;
-          return der_encode_sequence_multi(out, outlen,
+      flags[0] = 1;
+      return der_encode_sequence_multi(out, outlen,
                                          LTC_ASN1_BIT_STRING,   1UL, flags,
                                          LTC_ASN1_INTEGER,      1UL, key->g,
                                          LTC_ASN1_INTEGER,      1UL, key->p,
@@ -66,8 +60,9 @@ int dsa_export(unsigned char *out, unsigned long *outlen, int type, const dsa_ke
                                          LTC_ASN1_INTEGER,      1UL, key->y,
                                          LTC_ASN1_INTEGER,      1UL, key->x,
                                          LTC_ASN1_EOL,          0UL, NULL);
-      }
-   } else {
+   }
+
+   if (type == PK_PUBLIC) {
       if (std) {
           unsigned long tmplen = (unsigned long)(mp_count_bits(key->y) / 8) + 8;
           unsigned char* tmp = XMALLOC(tmplen);
@@ -94,18 +89,17 @@ error:
           XFREE(tmp);
           return err;
       }
-      else {
-          unsigned char flags[1];
-          flags[0] = 0;
-          return der_encode_sequence_multi(out, outlen,
+      flags[0] = 0;
+      return der_encode_sequence_multi(out, outlen,
                                      LTC_ASN1_BIT_STRING,   1UL, flags,
                                      LTC_ASN1_INTEGER,      1UL, key->g,
                                      LTC_ASN1_INTEGER,      1UL, key->p,
                                      LTC_ASN1_INTEGER,      1UL, key->q,
                                      LTC_ASN1_INTEGER,      1UL, key->y,
                                      LTC_ASN1_EOL,          0UL, NULL);
-      }
    }
+
+   return CRYPT_INVALID_ARG;
 }
 
 #endif

--- a/src/pk/ecc/ecc_get_curve.c
+++ b/src/pk/ecc/ecc_get_curve.c
@@ -208,10 +208,8 @@ static int _name_match(const char *left, const char *right)
       right++;
    }
 
-   if ((*left == '\0') && (*right == '\0'))
-      return 1;
-   else
-      return 0;
+   if ((*left == '\0') && (*right == '\0')) return 1;
+   return 0;
 }
 
 int ecc_get_curve(const char *name_or_oid, const ltc_ecc_curve **cu)

--- a/src/pk/rsa/rsa_export.c
+++ b/src/pk/rsa/rsa_export.c
@@ -26,14 +26,16 @@
 int rsa_export(unsigned char *out, unsigned long *outlen, int type, const rsa_key *key)
 {
    unsigned long zero=0;
-   int err;
+   int err, std;
    LTC_ARGCHK(out    != NULL);
    LTC_ARGCHK(outlen != NULL);
    LTC_ARGCHK(key    != NULL);
 
-   /* type valid? */
-   if (!(key->type == PK_PRIVATE) && (type == PK_PRIVATE)) {
-      return CRYPT_PK_INVALID_TYPE;
+   std = type & PK_STD;
+   type &= ~PK_STD;
+
+   if (type == PK_PRIVATE && key->type != PK_PRIVATE) {
+      return CRYPT_PK_TYPE_MISMATCH;
    }
 
    if (type == PK_PRIVATE) {
@@ -52,12 +54,14 @@ int rsa_export(unsigned char *out, unsigned long *outlen, int type, const rsa_ke
                           LTC_ASN1_INTEGER, 1UL,  key->dQ,
                           LTC_ASN1_INTEGER, 1UL,  key->qP,
                           LTC_ASN1_EOL,     0UL, NULL);
-   } else {
+   }
+
+   if (type == PK_PUBLIC) {
       /* public key */
       unsigned long tmplen, *ptmplen;
       unsigned char* tmp = NULL;
 
-      if (type & PK_STD) {
+      if (std) {
           tmplen = (unsigned long)(mp_count_bits(key->N) / 8) * 2 + 8;
           tmp = XMALLOC(tmplen);
           ptmplen = &tmplen;
@@ -75,7 +79,7 @@ int rsa_export(unsigned char *out, unsigned long *outlen, int type, const rsa_ke
                                  LTC_ASN1_INTEGER, 1UL,  key->e,
                                  LTC_ASN1_EOL,     0UL, NULL);
 
-      if ((err != CRYPT_OK) || !(type & PK_STD)) {
+      if ((err != CRYPT_OK) || !std) {
           goto finish;
       }
 
@@ -86,8 +90,9 @@ finish:
       if (tmp != out)
         XFREE(tmp);
       return err;
-
    }
+
+   return CRYPT_INVALID_ARG;
 }
 
 #endif /* LTC_MRSA */

--- a/src/stream/rabbit/rabbit.c
+++ b/src/stream/rabbit/rabbit.c
@@ -297,13 +297,12 @@ int rabbit_crypt(rabbit_state* st, const unsigned char *in, unsigned long inlen,
        /* copy remainder to block */
        for (i = inlen; i < 16; ++i) st->block[i] = buf[i];
        return CRYPT_OK;
-     } else {
-       /* XOR entire buf and send to out */
-       for (i = 0; i < 16; ++i) out[i] = in[i] ^ buf[i];
-       inlen -= 16;
-       out += 16;
-       in  += 16;
      }
+     /* XOR entire buf and send to out */
+     for (i = 0; i < 16; ++i) out[i] = in[i] ^ buf[i];
+     inlen -= 16;
+     out += 16;
+     in  += 16;
    }
 }
 


### PR DESCRIPTION
The warnings:
```
libtomcrypt/src/ciphers/blowfish.c:583:6: warning: do not use 'else' after 'return' [readability-else-after-return]
   } else if (*keysize > 56) {
     ^~~~~~~~
libtomcrypt/src/ciphers/cast5.c:710:6: warning: do not use 'else' after 'return' [readability-else-after-return]
   } else if (*keysize > 16) {
     ^~~~~~~~
libtomcrypt/src/ciphers/kasumi.c:246:6: warning: do not use 'else' after 'return' [readability-else-after-return]
   } else {
     ^~~~~~
libtomcrypt/src/ciphers/khazad.c:846:6: warning: do not use 'else' after 'return' [readability-else-after-return]
   } else {
     ^~~~~~
libtomcrypt/src/ciphers/noekeon.c:317:6: warning: do not use 'else' after 'return' [readability-else-after-return]
   } else {
     ^~~~~~
libtomcrypt/src/ciphers/rc2.c:404:6: warning: do not use 'else' after 'return' [readability-else-after-return]
   } else if (*keysize > 128) {
     ^~~~~~~~
libtomcrypt/src/ciphers/rc5.c:311:6: warning: do not use 'else' after 'return' [readability-else-after-return]
   } else if (*keysize > 128) {
     ^~~~~~~~
libtomcrypt/src/ciphers/rc6.c:321:6: warning: do not use 'else' after 'return' [readability-else-after-return]
   } else if (*keysize > 128) {
     ^~~~~~~~
libtomcrypt/src/ciphers/skipjack.c:333:6: warning: do not use 'else' after 'return' [readability-else-after-return]
   } else if (*keysize > 10) {
     ^~~~~~~~
libtomcrypt/src/misc/error_to_string.c:71:6: warning: do not use 'else' after 'return' [readability-else-after-return]
   } else {
     ^~~~~~
libtomcrypt/src/ciphers/aes/aes.c:731:6: warning: do not use 'else' after 'return' [readability-else-after-return]
   } else if (*keysize < 32) {
     ^~~~~~~~
libtomcrypt/src/ciphers/safer/safer.c:361:6: warning: do not use 'else' after 'return' [readability-else-after-return]
   } else {
     ^~~~~~
libtomcrypt/src/ciphers/safer/safer.c:372:6: warning: do not use 'else' after 'return' [readability-else-after-return]
   } else {
     ^~~~~~
libtomcrypt/src/ciphers/twofish/twofish.c:697:6: warning: do not use 'else' after 'return' [readability-else-after-return]
   } else if (*keysize < 32) {
     ^~~~~~~~
libtomcrypt/src/mac/hmac/hmac_test.c:617:7: warning: do not use 'else' after 'return' [readability-else-after-return]
    } else if (tested == 0) {
      ^~~~~~~~
libtomcrypt/src/misc/base64/base64_decode.c:109:11: warning: do not use 'else' after 'return' [readability-else-after-return]
          else
          ^~~~
libtomcrypt/src/misc/base64/base64_decode.c:115:11: warning: do not use 'else' after 'continue' [readability-else-after-return]
          else
          ^~~~
libtomcrypt/src/misc/hkdf/hkdf.c:33:6: warning: do not use 'else' after 'return' [readability-else-after-return]
   } else {
     ^~~~~~
libtomcrypt/src/misc/hkdf/hkdf_test.c:281:7: warning: do not use 'else' after 'return' [readability-else-after-return]
    } else if (tested == 0) {
      ^~~~~~~~
libtomcrypt/src/modes/cbc/cbc_decrypt.c:61:6: warning: do not use 'else' after 'return' [readability-else-after-return]
   } else {
     ^~~~~~
libtomcrypt/src/modes/cbc/cbc_encrypt.c:55:6: warning: do not use 'else' after 'return' [readability-else-after-return]
   } else {
     ^~~~~~
libtomcrypt/src/modes/ecb/ecb_decrypt.c:42:6: warning: do not use 'else' after 'return' [readability-else-after-return]
   } else {
     ^~~~~~
libtomcrypt/src/modes/ecb/ecb_encrypt.c:42:6: warning: do not use 'else' after 'return' [readability-else-after-return]
   } else {
     ^~~~~~
libtomcrypt/src/pk/dh/dh_generate_key.c:22:4: warning: do not use 'else' after 'return' [readability-else-after-return]
   else if (groupsize <= 192) {
   ^~~~~~~~
libtomcrypt/src/pk/dsa/dsa_export.c:58:7: warning: do not use 'else' after 'return' [readability-else-after-return]
      else {
      ^~~~~~
libtomcrypt/src/pk/dsa/dsa_export.c:97:7: warning: do not use 'else' after 'return' [readability-else-after-return]
      else {
      ^~~~~~
libtomcrypt/src/pk/ecc/ecc_get_curve.c:213:4: warning: do not use 'else' after 'return' [readability-else-after-return]
   else
   ^~~~
libtomcrypt/src/pk/rsa/rsa_export.c:55:6: warning: do not use 'else' after 'return' [readability-else-after-return]
   } else {
     ^~~~~~
libtomcrypt/src/stream/rabbit/rabbit.c:300:8: warning: do not use 'else' after 'return' [readability-else-after-return]
     } else {
       ^~~~~~
libtomcrypt/src/pk/asn1/der/general/der_decode_asn1_length.c:44:9: warning: do not use 'else' after 'return' [readability-else-after-return]
      } else if (real_len > sizeof(decoded_len)) {
        ^~~~~~~~
libtomcrypt/src/pk/asn1/der/general/der_encode_asn1_identifier.c:44:6: warning: do not use 'else' after 'return' [readability-else-after-return]
   } else {
     ^~~~~~
libtomcrypt/src/pk/asn1/der/generalizedtime/der_decode_generalizedtime.c:115:7: warning: do not use 'else' after 'return' [readability-else-after-return]
    } else if (buf[x] == '.') {
      ^~~~~~~~
libtomcrypt/src/pk/asn1/der/generalizedtime/der_decode_generalizedtime.c:130:7: warning: do not use 'else' after 'return' [readability-else-after-return]
    } else if (buf[x] == '+' || buf[x] == '-') {
      ^~~~~~~~
libtomcrypt/src/pk/asn1/der/set/der_encode_set.c:36:6: warning: do not use 'else' after 'return' [readability-else-after-return]
   } else {
     ^~~~~~
libtomcrypt/src/pk/asn1/der/utctime/der_decode_utctime.c:98:7: warning: do not use 'else' after 'return' [readability-else-after-return]
    } else if (buf[x] == '+' || buf[x] == '-') {
      ^~~~~~~~
libtomcrypt/src/pk/asn1/der/utctime/der_decode_utctime.c:111:7: warning: do not use 'else' after 'return' [readability-else-after-return]
    } else if (buf[x] == '+' || buf[x] == '-') {
      ^~~~~~~~
libtomcrypt/src/pk/asn1/der/utf8/der_length_utf8_string.c:26:6: warning: do not use 'else' after 'return' [readability-else-after-return]
   } else if (c <= 0x7FF) {
     ^~~~~~~~
```