### PR TITLE
fix clang-tidy warning: readability-non-const-parameter

### DIFF
--- a/src/prngs/sprng.c
+++ b/src/prngs/sprng.c
@@ -102,6 +102,7 @@ int sprng_done(prng_state *prng)
   @param prng      The PRNG to export
   @return CRYPT_OK if successful
 */
+/* NOLINTNEXTLINE(readability-non-const-parameter) - silence clang-tidy warning */
 int sprng_export(unsigned char *out, unsigned long *outlen, prng_state *prng)
 {
    LTC_ARGCHK(outlen != NULL);


### PR DESCRIPTION
The warning:
```
libtomcrypt/src/prngs/sprng.c:105:33: warning: pointer parameter 'out' can be pointer to const [readability-non-const-parameter]
int sprng_export(unsigned char *out, unsigned long *outlen, prng_state *prng)
                 ~~~~~~~~       ^
                 const
```