### PR TITLE
fix clang-tidy warning: inconsistent-declaration-parameter-name

### DIFF
--- a/src/ciphers/safer/safer.c
+++ b/src/ciphers/safer/safer.c
@@ -176,12 +176,12 @@ static void Safer_Expand_Userkey(const unsigned char *userkey_1,
 }
 #endif
 
-int safer_k64_setup(const unsigned char *key, int keylen, int numrounds, symmetric_key *skey)
+int safer_k64_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey)
 {
    LTC_ARGCHK(key != NULL);
    LTC_ARGCHK(skey != NULL);
 
-   if (numrounds != 0 && (numrounds < 6 || numrounds > LTC_SAFER_MAX_NOF_ROUNDS)) {
+   if (num_rounds != 0 && (num_rounds < 6 || num_rounds > LTC_SAFER_MAX_NOF_ROUNDS)) {
       return CRYPT_INVALID_ROUNDS;
    }
 
@@ -189,16 +189,16 @@ int safer_k64_setup(const unsigned char *key, int keylen, int numrounds, symmetr
       return CRYPT_INVALID_KEYSIZE;
    }
 
-   Safer_Expand_Userkey(key, key, (unsigned int)(numrounds != 0 ?numrounds:LTC_SAFER_K64_DEFAULT_NOF_ROUNDS), 0, skey->safer.key);
+   Safer_Expand_Userkey(key, key, (unsigned int)(num_rounds != 0 ?num_rounds:LTC_SAFER_K64_DEFAULT_NOF_ROUNDS), 0, skey->safer.key);
    return CRYPT_OK;
 }
 
-int safer_sk64_setup(const unsigned char *key, int keylen, int numrounds, symmetric_key *skey)
+int safer_sk64_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey)
 {
    LTC_ARGCHK(key != NULL);
    LTC_ARGCHK(skey != NULL);
 
-   if (numrounds != 0 && (numrounds < 6 || numrounds > LTC_SAFER_MAX_NOF_ROUNDS)) {
+   if (num_rounds != 0 && (num_rounds < 6 || num_rounds > LTC_SAFER_MAX_NOF_ROUNDS)) {
       return CRYPT_INVALID_ROUNDS;
    }
 
@@ -206,16 +206,16 @@ int safer_sk64_setup(const unsigned char *key, int keylen, int numrounds, symmet
       return CRYPT_INVALID_KEYSIZE;
    }
 
-   Safer_Expand_Userkey(key, key, (unsigned int)(numrounds != 0 ?numrounds:LTC_SAFER_SK64_DEFAULT_NOF_ROUNDS), 1, skey->safer.key);
+   Safer_Expand_Userkey(key, key, (unsigned int)(num_rounds != 0 ?num_rounds:LTC_SAFER_SK64_DEFAULT_NOF_ROUNDS), 1, skey->safer.key);
    return CRYPT_OK;
 }
 
-int safer_k128_setup(const unsigned char *key, int keylen, int numrounds, symmetric_key *skey)
+int safer_k128_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey)
 {
    LTC_ARGCHK(key != NULL);
    LTC_ARGCHK(skey != NULL);
 
-   if (numrounds != 0 && (numrounds < 6 || numrounds > LTC_SAFER_MAX_NOF_ROUNDS)) {
+   if (num_rounds != 0 && (num_rounds < 6 || num_rounds > LTC_SAFER_MAX_NOF_ROUNDS)) {
       return CRYPT_INVALID_ROUNDS;
    }
 
@@ -223,16 +223,16 @@ int safer_k128_setup(const unsigned char *key, int keylen, int numrounds, symmet
       return CRYPT_INVALID_KEYSIZE;
    }
 
-   Safer_Expand_Userkey(key, key+8, (unsigned int)(numrounds != 0 ?numrounds:LTC_SAFER_K128_DEFAULT_NOF_ROUNDS), 0, skey->safer.key);
+   Safer_Expand_Userkey(key, key+8, (unsigned int)(num_rounds != 0 ?num_rounds:LTC_SAFER_K128_DEFAULT_NOF_ROUNDS), 0, skey->safer.key);
    return CRYPT_OK;
 }
 
-int safer_sk128_setup(const unsigned char *key, int keylen, int numrounds, symmetric_key *skey)
+int safer_sk128_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey)
 {
    LTC_ARGCHK(key != NULL);
    LTC_ARGCHK(skey != NULL);
 
-   if (numrounds != 0 && (numrounds < 6 || numrounds > LTC_SAFER_MAX_NOF_ROUNDS)) {
+   if (num_rounds != 0 && (num_rounds < 6 || num_rounds > LTC_SAFER_MAX_NOF_ROUNDS)) {
       return CRYPT_INVALID_ROUNDS;
    }
 
@@ -240,30 +240,30 @@ int safer_sk128_setup(const unsigned char *key, int keylen, int numrounds, symme
       return CRYPT_INVALID_KEYSIZE;
    }
 
-   Safer_Expand_Userkey(key, key+8, (unsigned int)(numrounds != 0?numrounds:LTC_SAFER_SK128_DEFAULT_NOF_ROUNDS), 1, skey->safer.key);
+   Safer_Expand_Userkey(key, key+8, (unsigned int)(num_rounds != 0?num_rounds:LTC_SAFER_SK128_DEFAULT_NOF_ROUNDS), 1, skey->safer.key);
    return CRYPT_OK;
 }
 
 #ifdef LTC_CLEAN_STACK
-static int _safer_ecb_encrypt(const unsigned char *block_in,
-                             unsigned char *block_out,
+static int _safer_ecb_encrypt(const unsigned char *pt,
+                             unsigned char *ct,
                              const symmetric_key *skey)
 #else
-int safer_ecb_encrypt(const unsigned char *block_in,
-                             unsigned char *block_out,
+int safer_ecb_encrypt(const unsigned char *pt,
+                             unsigned char *ct,
                              const symmetric_key *skey)
 #endif
 {   unsigned char a, b, c, d, e, f, g, h, t;
     unsigned int round;
     const unsigned char *key;
 
-    LTC_ARGCHK(block_in != NULL);
-    LTC_ARGCHK(block_out != NULL);
+    LTC_ARGCHK(pt != NULL);
+    LTC_ARGCHK(ct != NULL);
     LTC_ARGCHK(skey != NULL);
 
     key = skey->safer.key;
-    a = block_in[0]; b = block_in[1]; c = block_in[2]; d = block_in[3];
-    e = block_in[4]; f = block_in[5]; g = block_in[6]; h = block_in[7];
+    a = pt[0]; b = pt[1]; c = pt[2]; d = pt[3];
+    e = pt[4]; f = pt[5]; g = pt[6]; h = pt[7];
     if (LTC_SAFER_MAX_NOF_ROUNDS < (round = *key)) round = LTC_SAFER_MAX_NOF_ROUNDS;
     while(round-- > 0)
     {
@@ -280,44 +280,44 @@ int safer_ecb_encrypt(const unsigned char *block_in,
     }
     a ^= *++key; b += *++key; c += *++key; d ^= *++key;
     e ^= *++key; f += *++key; g += *++key; h ^= *++key;
-    block_out[0] = a & 0xFF; block_out[1] = b & 0xFF;
-    block_out[2] = c & 0xFF; block_out[3] = d & 0xFF;
-    block_out[4] = e & 0xFF; block_out[5] = f & 0xFF;
-    block_out[6] = g & 0xFF; block_out[7] = h & 0xFF;
+    ct[0] = a & 0xFF; ct[1] = b & 0xFF;
+    ct[2] = c & 0xFF; ct[3] = d & 0xFF;
+    ct[4] = e & 0xFF; ct[5] = f & 0xFF;
+    ct[6] = g & 0xFF; ct[7] = h & 0xFF;
     return CRYPT_OK;
 }
 
 #ifdef LTC_CLEAN_STACK
-int safer_ecb_encrypt(const unsigned char *block_in,
-                             unsigned char *block_out,
+int safer_ecb_encrypt(const unsigned char *pt,
+                             unsigned char *ct,
                              const symmetric_key *skey)
 {
-    int err = _safer_ecb_encrypt(block_in, block_out, skey);
+    int err = _safer_ecb_encrypt(pt, ct, skey);
     burn_stack(sizeof(unsigned char) * 9 + sizeof(unsigned int) + sizeof(unsigned char *));
     return err;
 }
 #endif
 
 #ifdef LTC_CLEAN_STACK
-static int _safer_ecb_decrypt(const unsigned char *block_in,
-                             unsigned char *block_out,
+static int _safer_ecb_decrypt(const unsigned char *ct,
+                             unsigned char *pt,
                              const symmetric_key *skey)
 #else
-int safer_ecb_decrypt(const unsigned char *block_in,
-                             unsigned char *block_out,
+int safer_ecb_decrypt(const unsigned char *ct,
+                             unsigned char *pt,
                              const symmetric_key *skey)
 #endif
 {   unsigned char a, b, c, d, e, f, g, h, t;
     unsigned int round;
     const unsigned char *key;
 
-    LTC_ARGCHK(block_in != NULL);
-    LTC_ARGCHK(block_out != NULL);
+    LTC_ARGCHK(ct != NULL);
+    LTC_ARGCHK(pt != NULL);
     LTC_ARGCHK(skey != NULL);
 
     key = skey->safer.key;
-    a = block_in[0]; b = block_in[1]; c = block_in[2]; d = block_in[3];
-    e = block_in[4]; f = block_in[5]; g = block_in[6]; h = block_in[7];
+    a = ct[0]; b = ct[1]; c = ct[2]; d = ct[3];
+    e = ct[4]; f = ct[5]; g = ct[6]; h = ct[7];
     if (LTC_SAFER_MAX_NOF_ROUNDS < (round = *key)) round = LTC_SAFER_MAX_NOF_ROUNDS;
     key += LTC_SAFER_BLOCK_LEN * (1 + 2 * round);
     h ^= *key; g -= *--key; f -= *--key; e ^= *--key;
@@ -335,19 +335,19 @@ int safer_ecb_decrypt(const unsigned char *block_in,
         d = LOG(d) ^ *--key; c = EXP(c) - *--key;
         b = EXP(b) - *--key; a = LOG(a) ^ *--key;
     }
-    block_out[0] = a & 0xFF; block_out[1] = b & 0xFF;
-    block_out[2] = c & 0xFF; block_out[3] = d & 0xFF;
-    block_out[4] = e & 0xFF; block_out[5] = f & 0xFF;
-    block_out[6] = g & 0xFF; block_out[7] = h & 0xFF;
+    pt[0] = a & 0xFF; pt[1] = b & 0xFF;
+    pt[2] = c & 0xFF; pt[3] = d & 0xFF;
+    pt[4] = e & 0xFF; pt[5] = f & 0xFF;
+    pt[6] = g & 0xFF; pt[7] = h & 0xFF;
     return CRYPT_OK;
 }
 
 #ifdef LTC_CLEAN_STACK
-int safer_ecb_decrypt(const unsigned char *block_in,
-                             unsigned char *block_out,
+int safer_ecb_decrypt(const unsigned char *ct,
+                             unsigned char *pt,
                              const symmetric_key *skey)
 {
-    int err = _safer_ecb_decrypt(block_in, block_out, skey);
+    int err = _safer_ecb_decrypt(ct, pt, skey);
     burn_stack(sizeof(unsigned char) * 9 + sizeof(unsigned int) + sizeof(unsigned char *));
     return err;
 }

--- a/src/hashes/chc/chc.c
+++ b/src/hashes/chc/chc.c
@@ -160,7 +160,7 @@ static int chc_compress(hash_state *md, const unsigned char *buf)
    @param len  The length of the data (octets)
    @return CRYPT_OK if successful
 */
-static int _chc_process(hash_state * md, const unsigned char *buf, unsigned long len);
+static int _chc_process(hash_state * md, const unsigned char *in, unsigned long inlen);
 static HASH_PROCESS(_chc_process, chc_compress, chc, (unsigned long)cipher_blocksize)
 
 /**

--- a/src/hashes/sha3.c
+++ b/src/hashes/sha3.c
@@ -313,16 +313,16 @@ int sha3_process(hash_state *md, const unsigned char *in, unsigned long inlen)
 }
 
 #ifdef LTC_SHA3
-int sha3_done(hash_state *md, unsigned char *hash)
+int sha3_done(hash_state *md, unsigned char *out)
 {
-   return _done(md, hash, CONST64(0x06));
+   return _done(md, out, CONST64(0x06));
 }
 #endif
 
 #ifdef LTC_KECCAK
-int keccak_done(hash_state *md, unsigned char *hash)
+int keccak_done(hash_state *md, unsigned char *out)
 {
-   return _done(md, hash, CONST64(0x01));
+   return _done(md, out, CONST64(0x01));
 }
 #endif
 

--- a/src/headers/tomcrypt_cipher.h
+++ b/src/headers/tomcrypt_cipher.h
@@ -673,8 +673,8 @@ int safer_k64_setup(const unsigned char *key, int keylen, int num_rounds, symmet
 int safer_sk64_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey);
 int safer_k128_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey);
 int safer_sk128_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey);
-int safer_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *key);
-int safer_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *key);
+int safer_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey);
+int safer_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const symmetric_key *skey);
 int safer_k64_test(void);
 int safer_sk64_test(void);
 int safer_sk128_test(void);
@@ -1057,7 +1057,7 @@ typedef struct {
 
 int sosemanuk_setup(sosemanuk_state *ss, const unsigned char *key, unsigned long keylen);
 int sosemanuk_setiv(sosemanuk_state *ss, const unsigned char *iv, unsigned long ivlen);
-int sosemanuk_crypt(sosemanuk_state *ss, const unsigned char *in, unsigned long datalen, unsigned char *out);
+int sosemanuk_crypt(sosemanuk_state *ss, const unsigned char *in, unsigned long inlen, unsigned char *out);
 int sosemanuk_keystream(sosemanuk_state *ss, unsigned char *out, unsigned long outlen);
 int sosemanuk_done(sosemanuk_state *ss);
 int sosemanuk_test(void);

--- a/src/headers/tomcrypt_hash.h
+++ b/src/headers/tomcrypt_hash.h
@@ -250,7 +250,7 @@ extern  struct ltc_hash_descriptor {
 int chc_register(int cipher);
 int chc_init(hash_state * md);
 int chc_process(hash_state * md, const unsigned char *in, unsigned long inlen);
-int chc_done(hash_state * md, unsigned char *hash);
+int chc_done(hash_state * md, unsigned char *out);
 int chc_test(void);
 extern const struct ltc_hash_descriptor chc_desc;
 #endif
@@ -258,7 +258,7 @@ extern const struct ltc_hash_descriptor chc_desc;
 #ifdef LTC_WHIRLPOOL
 int whirlpool_init(hash_state * md);
 int whirlpool_process(hash_state * md, const unsigned char *in, unsigned long inlen);
-int whirlpool_done(hash_state * md, unsigned char *hash);
+int whirlpool_done(hash_state * md, unsigned char *out);
 int whirlpool_test(void);
 extern const struct ltc_hash_descriptor whirlpool_desc;
 #endif
@@ -282,7 +282,7 @@ int sha3_256_test(void);
 extern const struct ltc_hash_descriptor sha3_256_desc;
 int sha3_224_test(void);
 extern const struct ltc_hash_descriptor sha3_224_desc;
-int sha3_done(hash_state *md, unsigned char *hash);
+int sha3_done(hash_state *md, unsigned char *out);
 /* SHAKE128 + SHAKE256 */
 int sha3_shake_init(hash_state *md, int num);
 #define sha3_shake_process(a,b,c) sha3_process(a,b,c)
@@ -305,13 +305,13 @@ extern const struct ltc_hash_descriptor keccak_256_desc;
 int keccak_256_test(void);
 extern const struct ltc_hash_descriptor keccak_224_desc;
 int keccak_224_test(void);
-int keccak_done(hash_state *md, unsigned char *hash);
+int keccak_done(hash_state *md, unsigned char *out);
 #endif
 
 #ifdef LTC_SHA512
 int sha512_init(hash_state * md);
 int sha512_process(hash_state * md, const unsigned char *in, unsigned long inlen);
-int sha512_done(hash_state * md, unsigned char *hash);
+int sha512_done(hash_state * md, unsigned char *out);
 int sha512_test(void);
 extern const struct ltc_hash_descriptor sha512_desc;
 #endif
@@ -322,7 +322,7 @@ extern const struct ltc_hash_descriptor sha512_desc;
 #endif
 int sha384_init(hash_state * md);
 #define sha384_process sha512_process
-int sha384_done(hash_state * md, unsigned char *hash);
+int sha384_done(hash_state * md, unsigned char *out);
 int sha384_test(void);
 extern const struct ltc_hash_descriptor sha384_desc;
 #endif
@@ -333,7 +333,7 @@ extern const struct ltc_hash_descriptor sha384_desc;
 #endif
 int sha512_256_init(hash_state * md);
 #define sha512_256_process sha512_process
-int sha512_256_done(hash_state * md, unsigned char *hash);
+int sha512_256_done(hash_state * md, unsigned char *out);
 int sha512_256_test(void);
 extern const struct ltc_hash_descriptor sha512_256_desc;
 #endif
@@ -344,7 +344,7 @@ extern const struct ltc_hash_descriptor sha512_256_desc;
 #endif
 int sha512_224_init(hash_state * md);
 #define sha512_224_process sha512_process
-int sha512_224_done(hash_state * md, unsigned char *hash);
+int sha512_224_done(hash_state * md, unsigned char *out);
 int sha512_224_test(void);
 extern const struct ltc_hash_descriptor sha512_224_desc;
 #endif
@@ -352,7 +352,7 @@ extern const struct ltc_hash_descriptor sha512_224_desc;
 #ifdef LTC_SHA256
 int sha256_init(hash_state * md);
 int sha256_process(hash_state * md, const unsigned char *in, unsigned long inlen);
-int sha256_done(hash_state * md, unsigned char *hash);
+int sha256_done(hash_state * md, unsigned char *out);
 int sha256_test(void);
 extern const struct ltc_hash_descriptor sha256_desc;
 
@@ -362,7 +362,7 @@ extern const struct ltc_hash_descriptor sha256_desc;
 #endif
 int sha224_init(hash_state * md);
 #define sha224_process sha256_process
-int sha224_done(hash_state * md, unsigned char *hash);
+int sha224_done(hash_state * md, unsigned char *out);
 int sha224_test(void);
 extern const struct ltc_hash_descriptor sha224_desc;
 #endif
@@ -371,7 +371,7 @@ extern const struct ltc_hash_descriptor sha224_desc;
 #ifdef LTC_SHA1
 int sha1_init(hash_state * md);
 int sha1_process(hash_state * md, const unsigned char *in, unsigned long inlen);
-int sha1_done(hash_state * md, unsigned char *hash);
+int sha1_done(hash_state * md, unsigned char *out);
 int sha1_test(void);
 extern const struct ltc_hash_descriptor sha1_desc;
 #endif
@@ -395,7 +395,7 @@ int blake2s_128_test(void);
 
 int blake2s_init(hash_state * md, unsigned long outlen, const unsigned char *key, unsigned long keylen);
 int blake2s_process(hash_state * md, const unsigned char *in, unsigned long inlen);
-int blake2s_done(hash_state * md, unsigned char *hash);
+int blake2s_done(hash_state * md, unsigned char *out);
 #endif
 
 #ifdef LTC_BLAKE2B
@@ -417,13 +417,13 @@ int blake2b_160_test(void);
 
 int blake2b_init(hash_state * md, unsigned long outlen, const unsigned char *key, unsigned long keylen);
 int blake2b_process(hash_state * md, const unsigned char *in, unsigned long inlen);
-int blake2b_done(hash_state * md, unsigned char *hash);
+int blake2b_done(hash_state * md, unsigned char *out);
 #endif
 
 #ifdef LTC_MD5
 int md5_init(hash_state * md);
 int md5_process(hash_state * md, const unsigned char *in, unsigned long inlen);
-int md5_done(hash_state * md, unsigned char *hash);
+int md5_done(hash_state * md, unsigned char *out);
 int md5_test(void);
 extern const struct ltc_hash_descriptor md5_desc;
 #endif
@@ -431,7 +431,7 @@ extern const struct ltc_hash_descriptor md5_desc;
 #ifdef LTC_MD4
 int md4_init(hash_state * md);
 int md4_process(hash_state * md, const unsigned char *in, unsigned long inlen);
-int md4_done(hash_state * md, unsigned char *hash);
+int md4_done(hash_state * md, unsigned char *out);
 int md4_test(void);
 extern const struct ltc_hash_descriptor md4_desc;
 #endif
@@ -439,7 +439,7 @@ extern const struct ltc_hash_descriptor md4_desc;
 #ifdef LTC_MD2
 int md2_init(hash_state * md);
 int md2_process(hash_state * md, const unsigned char *in, unsigned long inlen);
-int md2_done(hash_state * md, unsigned char *hash);
+int md2_done(hash_state * md, unsigned char *out);
 int md2_test(void);
 extern const struct ltc_hash_descriptor md2_desc;
 #endif
@@ -447,7 +447,7 @@ extern const struct ltc_hash_descriptor md2_desc;
 #ifdef LTC_TIGER
 int tiger_init(hash_state * md);
 int tiger_process(hash_state * md, const unsigned char *in, unsigned long inlen);
-int tiger_done(hash_state * md, unsigned char *hash);
+int tiger_done(hash_state * md, unsigned char *out);
 int tiger_test(void);
 extern const struct ltc_hash_descriptor tiger_desc;
 #endif
@@ -455,7 +455,7 @@ extern const struct ltc_hash_descriptor tiger_desc;
 #ifdef LTC_RIPEMD128
 int rmd128_init(hash_state * md);
 int rmd128_process(hash_state * md, const unsigned char *in, unsigned long inlen);
-int rmd128_done(hash_state * md, unsigned char *hash);
+int rmd128_done(hash_state * md, unsigned char *out);
 int rmd128_test(void);
 extern const struct ltc_hash_descriptor rmd128_desc;
 #endif
@@ -463,7 +463,7 @@ extern const struct ltc_hash_descriptor rmd128_desc;
 #ifdef LTC_RIPEMD160
 int rmd160_init(hash_state * md);
 int rmd160_process(hash_state * md, const unsigned char *in, unsigned long inlen);
-int rmd160_done(hash_state * md, unsigned char *hash);
+int rmd160_done(hash_state * md, unsigned char *out);
 int rmd160_test(void);
 extern const struct ltc_hash_descriptor rmd160_desc;
 #endif
@@ -471,7 +471,7 @@ extern const struct ltc_hash_descriptor rmd160_desc;
 #ifdef LTC_RIPEMD256
 int rmd256_init(hash_state * md);
 int rmd256_process(hash_state * md, const unsigned char *in, unsigned long inlen);
-int rmd256_done(hash_state * md, unsigned char *hash);
+int rmd256_done(hash_state * md, unsigned char *out);
 int rmd256_test(void);
 extern const struct ltc_hash_descriptor rmd256_desc;
 #endif
@@ -479,7 +479,7 @@ extern const struct ltc_hash_descriptor rmd256_desc;
 #ifdef LTC_RIPEMD320
 int rmd320_init(hash_state * md);
 int rmd320_process(hash_state * md, const unsigned char *in, unsigned long inlen);
-int rmd320_done(hash_state * md, unsigned char *hash);
+int rmd320_done(hash_state * md, unsigned char *out);
 int rmd320_test(void);
 extern const struct ltc_hash_descriptor rmd320_desc;
 #endif

--- a/src/headers/tomcrypt_mac.h
+++ b/src/headers/tomcrypt_mac.h
@@ -29,7 +29,7 @@ int hmac_memory_multi(int hash,
                 const unsigned char *in,   unsigned long inlen, ...);
 int hmac_file(int hash, const char *fname, const unsigned char *key,
               unsigned long keylen,
-              unsigned char *dst, unsigned long *dstlen);
+              unsigned char *out, unsigned long *outlen);
 #endif
 
 #ifdef LTC_OMAC
@@ -84,7 +84,7 @@ int pmac_done(pmac_state *pmac, unsigned char *out, unsigned long *outlen);
 
 int pmac_memory(int cipher,
                const unsigned char *key, unsigned long keylen,
-               const unsigned char *msg, unsigned long msglen,
+               const unsigned char *in, unsigned long inlen,
                      unsigned char *out, unsigned long *outlen);
 
 int pmac_memory_multi(int cipher,
@@ -230,7 +230,7 @@ int f9_memory_multi(int cipher,
                 const unsigned char *in,  unsigned long inlen, ...);
 int f9_file(int cipher,
               const unsigned char *key, unsigned long keylen,
-              const          char *filename,
+              const          char *fname,
                     unsigned char *out, unsigned long *outlen);
 int f9_test(void);
 
@@ -419,7 +419,7 @@ typedef struct {
 } ccm_state;
 
 int ccm_init(ccm_state *ccm, int cipher,
-             const unsigned char *key, int keylen, int ptlen, int taglen, int aad_len);
+             const unsigned char *key, int keylen, int ptlen, int taglen, int aadlen);
 
 int ccm_reset(ccm_state *ccm);
 

--- a/src/headers/tomcrypt_misc.h
+++ b/src/headers/tomcrypt_misc.h
@@ -9,26 +9,26 @@
 
 /* ---- LTC_BASE64 Routines ---- */
 #ifdef LTC_BASE64
-int base64_encode(const unsigned char *in,  unsigned long len,
+int base64_encode(const unsigned char *in,  unsigned long inlen,
                                  char *out, unsigned long *outlen);
 
-int base64_decode(const char *in,  unsigned long len,
+int base64_decode(const char *in,  unsigned long inlen,
                         unsigned char *out, unsigned long *outlen);
-int base64_strict_decode(const char *in,  unsigned long len,
+int base64_strict_decode(const char *in,  unsigned long inlen,
                         unsigned char *out, unsigned long *outlen);
 int base64_sane_decode(const char *in,  unsigned long inlen,
                         unsigned char *out, unsigned long *outlen);
 #endif
 
 #ifdef LTC_BASE64_URL
-int base64url_encode(const unsigned char *in,  unsigned long len,
+int base64url_encode(const unsigned char *in,  unsigned long inlen,
                                     char *out, unsigned long *outlen);
 int base64url_strict_encode(const unsigned char *in,  unsigned long inlen,
                                            char *out, unsigned long *outlen);
 
-int base64url_decode(const char *in,  unsigned long len,
+int base64url_decode(const char *in,  unsigned long inlen,
                         unsigned char *out, unsigned long *outlen);
-int base64url_strict_decode(const char *in,  unsigned long len,
+int base64url_strict_decode(const char *in,  unsigned long inlen,
                         unsigned char *out, unsigned long *outlen);
 int base64url_sane_decode(const char *in,  unsigned long inlen,
                         unsigned char *out, unsigned long *outlen);
@@ -84,7 +84,7 @@ int hkdf(int hash_idx,
 
 /* ---- MEM routines ---- */
 int mem_neq(const void *a, const void *b, size_t len);
-void zeromem(volatile void *dst, size_t len);
+void zeromem(volatile void *out, size_t outlen);
 void burn_stack(unsigned long len);
 
 const char *error_to_string(int err);

--- a/src/headers/tomcrypt_pk.h
+++ b/src/headers/tomcrypt_pk.h
@@ -572,7 +572,7 @@ int der_decode_boolean(const unsigned char *in, unsigned long inlen,
 /* INTEGER */
 int der_encode_integer(void *num, unsigned char *out, unsigned long *outlen);
 int der_decode_integer(const unsigned char *in, unsigned long inlen, void *num);
-int der_length_integer(void *num, unsigned long *len);
+int der_length_integer(void *num, unsigned long *outlen);
 
 /* INTEGER -- handy for 0..2^32-1 values */
 int der_decode_short_integer(const unsigned char *in, unsigned long inlen, unsigned long *num);

--- a/src/headers/tomcrypt_private.h
+++ b/src/headers/tomcrypt_private.h
@@ -275,7 +275,7 @@ int der_decode_asn1_identifier(const unsigned char *in, unsigned long *inlen, lt
 int der_length_asn1_identifier(const ltc_asn1_list *id, unsigned long *idlen);
 
 int der_encode_asn1_length(unsigned long len, unsigned char* out, unsigned long* outlen);
-int der_decode_asn1_length(const unsigned char* len, unsigned long* lenlen, unsigned long* outlen);
+int der_decode_asn1_length(const unsigned char *in, unsigned long *inlen, unsigned long *outlen);
 int der_length_asn1_length(unsigned long len, unsigned long *outlen);
 
 int der_length_sequence_ex(const ltc_asn1_list *list, unsigned long inlen,

--- a/src/mac/pmac/pmac_done.c
+++ b/src/mac/pmac/pmac_done.c
@@ -15,51 +15,51 @@
 
 #ifdef LTC_PMAC
 
-int pmac_done(pmac_state *state, unsigned char *out, unsigned long *outlen)
+int pmac_done(pmac_state *pmac, unsigned char *out, unsigned long *outlen)
 {
    int err, x;
 
-   LTC_ARGCHK(state != NULL);
-   LTC_ARGCHK(out   != NULL);
-   if ((err = cipher_is_valid(state->cipher_idx)) != CRYPT_OK) {
+   LTC_ARGCHK(pmac != NULL);
+   LTC_ARGCHK(out  != NULL);
+   if ((err = cipher_is_valid(pmac->cipher_idx)) != CRYPT_OK) {
       return err;
    }
 
-   if ((state->buflen > (int)sizeof(state->block)) || (state->buflen < 0) ||
-       (state->block_len > (int)sizeof(state->block)) || (state->buflen > state->block_len)) {
+   if ((pmac->buflen > (int)sizeof(pmac->block)) || (pmac->buflen < 0) ||
+       (pmac->block_len > (int)sizeof(pmac->block)) || (pmac->buflen > pmac->block_len)) {
       return CRYPT_INVALID_ARG;
    }
 
 
    /* handle padding.  If multiple xor in L/x */
 
-   if (state->buflen == state->block_len) {
+   if (pmac->buflen == pmac->block_len) {
       /* xor Lr against the checksum */
-      for (x = 0; x < state->block_len; x++) {
-          state->checksum[x] ^= state->block[x] ^ state->Lr[x];
+      for (x = 0; x < pmac->block_len; x++) {
+          pmac->checksum[x] ^= pmac->block[x] ^ pmac->Lr[x];
       }
    } else {
       /* otherwise xor message bytes then the 0x80 byte */
-      for (x = 0; x < state->buflen; x++) {
-          state->checksum[x] ^= state->block[x];
+      for (x = 0; x < pmac->buflen; x++) {
+          pmac->checksum[x] ^= pmac->block[x];
       }
-      state->checksum[x] ^= 0x80;
+      pmac->checksum[x] ^= 0x80;
    }
 
    /* encrypt it */
-   if ((err = cipher_descriptor[state->cipher_idx].ecb_encrypt(state->checksum, state->checksum, &state->key)) != CRYPT_OK) {
+   if ((err = cipher_descriptor[pmac->cipher_idx].ecb_encrypt(pmac->checksum, pmac->checksum, &pmac->key)) != CRYPT_OK) {
       return err;
    }
-   cipher_descriptor[state->cipher_idx].done(&state->key);
+   cipher_descriptor[pmac->cipher_idx].done(&pmac->key);
 
    /* store it */
-   for (x = 0; x < state->block_len && x < (int)*outlen; x++) {
-       out[x] = state->checksum[x];
+   for (x = 0; x < pmac->block_len && x < (int)*outlen; x++) {
+       out[x] = pmac->checksum[x];
    }
    *outlen = x;
 
 #ifdef LTC_CLEAN_STACK
-   zeromem(state, sizeof(*state));
+   zeromem(pmac, sizeof(*pmac));
 #endif
    return CRYPT_OK;
 }

--- a/src/pk/ecc/ecc_set_dp.c
+++ b/src/pk/ecc/ecc_set_dp.c
@@ -11,12 +11,12 @@
 
 #ifdef LTC_MECC
 
-int ecc_set_dp(const ltc_ecc_curve *curve, ecc_key *key)
+int ecc_set_dp(const ltc_ecc_curve *cu, ecc_key *key)
 {
    int err;
 
    LTC_ARGCHK(key != NULL);
-   LTC_ARGCHK(curve != NULL);
+   LTC_ARGCHK(cu != NULL);
 
    if ((err = mp_init_multi(&key->dp.prime, &key->dp.order, &key->dp.A, &key->dp.B,
                             &key->dp.base.x, &key->dp.base.y, &key->dp.base.z,
@@ -26,19 +26,19 @@ int ecc_set_dp(const ltc_ecc_curve *curve, ecc_key *key)
    }
 
    /* A, B, order, prime, Gx, Gy */
-   if ((err = mp_read_radix(key->dp.prime, curve->prime, 16)) != CRYPT_OK) { goto error; }
-   if ((err = mp_read_radix(key->dp.order, curve->order, 16)) != CRYPT_OK) { goto error; }
-   if ((err = mp_read_radix(key->dp.A, curve->A, 16)) != CRYPT_OK)         { goto error; }
-   if ((err = mp_read_radix(key->dp.B, curve->B, 16)) != CRYPT_OK)         { goto error; }
-   if ((err = mp_read_radix(key->dp.base.x, curve->Gx, 16)) != CRYPT_OK)   { goto error; }
-   if ((err = mp_read_radix(key->dp.base.y, curve->Gy, 16)) != CRYPT_OK)   { goto error; }
-   if ((err = mp_set(key->dp.base.z, 1)) != CRYPT_OK)                      { goto error; }
+   if ((err = mp_read_radix(key->dp.prime, cu->prime, 16)) != CRYPT_OK) { goto error; }
+   if ((err = mp_read_radix(key->dp.order, cu->order, 16)) != CRYPT_OK) { goto error; }
+   if ((err = mp_read_radix(key->dp.A, cu->A, 16)) != CRYPT_OK)         { goto error; }
+   if ((err = mp_read_radix(key->dp.B, cu->B, 16)) != CRYPT_OK)         { goto error; }
+   if ((err = mp_read_radix(key->dp.base.x, cu->Gx, 16)) != CRYPT_OK)   { goto error; }
+   if ((err = mp_read_radix(key->dp.base.y, cu->Gy, 16)) != CRYPT_OK)   { goto error; }
+   if ((err = mp_set(key->dp.base.z, 1)) != CRYPT_OK)                   { goto error; }
    /* cofactor & size */
-   key->dp.cofactor = curve->cofactor;
+   key->dp.cofactor = cu->cofactor;
    key->dp.size = mp_unsigned_bin_size(key->dp.prime);
    /* OID string >> unsigned long oid[16] + oidlen */
    key->dp.oidlen = 16;
-   if ((err = pk_oid_str_to_num(curve->OID, key->dp.oid, &key->dp.oidlen)) != CRYPT_OK) { goto error; }
+   if ((err = pk_oid_str_to_num(cu->OID, key->dp.oid, &key->dp.oidlen)) != CRYPT_OK) { goto error; }
    /* success */
    return CRYPT_OK;
 


### PR DESCRIPTION
see #376