### PR TITLE
stream cipher refinements

### DIFF
--- a/doc/crypt.tex
+++ b/doc/crypt.tex
@@ -1250,13 +1250,17 @@ Stream ciphers are symmetric key ciphers which operate on a stream of bytes (in 
 however LibTomCrypt's implementation works with bytes).
 
 The API for all stream ciphers operates in mode: \textit{setup} -- \textit{crypt} -- \textit{crypt} -- ... -- \textit{done}.
+The proper order of progression through these modes is enforced with a \textit{status} flag in the cipher's state.
+(An empty state has a \textit{status} of 0, a state after \textit{setup} has a \textit{status} of 1 or 3,
+and a state after \textit{setiv} has a \textit{status} of 2.)
+
 Please note that both encryption and decryption are implemented via \textit{crypt}.
 
 Another useful feature of the stream ciphers API is generation of a random stream of bytes which works like:
 \textit{setup} -- \textit{keystream} -- \textit{keystream} -- ... -- \textit{done}. The random stream generation is
 implemented like encryption of a stream of \textit{0x00} bytes.
 
-Note: You shouldn't use the keystream interface as a PRNG, as it doesn't allow to re-seed the internal state.
+Note: You shouldn't use the keystream interface as a PRNG, as it doesn't allow re-seeding the internal state.
 
 \mysection{ChaCha}
 
@@ -1336,7 +1340,7 @@ err = salsa20_ivctr64(&st, nonce, 8, counter);
 \end{verbatim}
 
 To initialize \textit{XSalsa20} for the recommended 20 rounds with a 256-bit
-key (32 bytes) and a 192-bit nonce (24 bytes), use: 
+key (32 bytes) and a 192-bit nonce (24 bytes), use:
 
 \begin{verbatim}
 salsa20_state st;
@@ -1359,6 +1363,21 @@ err = salsa20_keystream(&st, out_buffer, out_len);
 Finally, when finished you should wipe the state.
 \begin{verbatim}
 err = salsa20_done(&st);
+\end{verbatim}
+
+Many encryptions/decryptions are performed on small data.  To make this process easier,
+Salsa20 has a helper function \textit{salsa20\_onecall()} that with one function call,
+will instantiate a state, call \textit{salsa20\_setup()}, \textit{salsa20\_ivctr64()},
+\textit{salsa20\_crypt()}, and \textit{salsa20\_done()}, returning the crypted data.
+\begin{verbatim}
+int salsa20_onecall(key, keylen, iv ivlen, datain, datalen, rounds, dataout);
+\end{verbatim}
+
+XSalsa20 likewise has a helper function \textit{xsalsa20\_onecall()} that with one
+function call, will instantiate a state, call \textit{xsalsa20\_setup()},
+\textit{salsa20\_crypt()}, and \textit{salsa20\_done()}, returning the crypted data.
+\begin{verbatim}
+int xsalsa20_onecall(key, keylen, nonce, noncelen, datain, datalen, rounds, dataout);
 \end{verbatim}
 
 For both \textit{Salsa20} and \textit{XSalsa20} rounds must be an even number
@@ -1387,10 +1406,9 @@ the EU eSTREAM competition.  Sosemanuk is a stream cipher that borrows heavily f
 another stream cipher, and the block cipher Serpent.  (Sosemanuk means "snow snake" in the
 Cree Indian language.)
 
-Sosemanuk will accept a key between 1 and 256 bits, but Sosemanuk's security level of 128
-bits is achieved only if the key is between 128 and 256 bits.  Keys longer than 128 bits
-are not guaranteed to provided higher security.  The initialization vector is 128 bits.
-(All length arguments are expressed in bytes.)
+Sosemanuk will accept a key between 16 and 32 bytes (128 and 256 bits).  The initialization
+vector is 16 bytes (128 bits).  Keys longer than 128 bits are not guaranteed to increase
+Sosemanuk's security level of 128 bits.  All length arguments are expressed in bytes.
 
 See \url{http://www.ecrypt.eu.org/stream/p3ciphers/sosemanuk/sosemanuk_p3.pdf} for more
 information.
@@ -1426,6 +1444,14 @@ err = sosemanuk_done(&ss);
 To do multiple encryptions and decryptions with the same key, you will want to set the iv but
 you do not need to re-run \textit{sosemanuk\_setup()} again, unless of course, you called
 \textit{sosemanuk\_done()}.
+
+Many encryptions/decryptions are performed on small data.  To make this process easier,
+Sosemanuk has a helper function \textit{sosemanuk\_onecall()} that with one function call,
+will instantiate a state, call \textit{sosemanuk\_setup()}, \textit{sosemanuk\_setiv()},
+\textit{sosemanuk\_crypt()}, and \textit{sosemanuk\_done()}, returning the crypted data.
+\begin{verbatim}
+int sosemanuk_onecall(key, keylen, iv ivlen, datain, datalen, dataout);
+\end{verbatim}
 
 \mysection{Rabbit}
 
@@ -7057,6 +7083,43 @@ LIB.crypt_list_all_sizes(names_list, byref(list_size))
 
 print(names_list.value)
 \end{verbatim}
+
+For stream ciphers, currently only Salsa20/XSalsa20 and Sosemanuk,
+LTC now supports an alternate and arguably a preferred way to get
+state sizes.
+\begin{verbatim}
+size = salsa20_state_size();
+size = sosemanuk_state_size();
+\end{verbatim}
+
+These new functions greatly simplify the supporting code needed
+in the calling programs.  Using Python as an example, this new
+function instantiates \textit{sosemanuk\_state} with one line.
+\begin{verbatim}
+import ctypes
+...
+LTC = ctypes.CDLL('libtomcrypt.dylib')
+...
+state = ctypes.c_buffer(LTC.sosemanuk_state_size())
+\end{verbatim}
+replaces
+\begin{verbatim}
+import ctypes
+...
+LTC = ctypes.CDLL('libtomcrypt.dylib')
+...
+def _get_size(name):
+    size = ctypes.c_int(0)
+    rc = LTC.crypt_get_size(bytes(name), byref(size))
+    if rc != 0:
+        raise Exception('LTC.crypt_get_size(%s) rc = %d' % (name, rc))
+    return size.value
+...
+state = ctypes.c_buffer(_get_size(b'sosemanuk_state'))
+\end{verbatim}
+
+Over time this new alternate method will applied to all cipher and
+hash function state sizes.
 
 
 \chapter{Programming Guidelines}

--- a/libtomcrypt_VS2008.vcproj
+++ b/libtomcrypt_VS2008.vcproj
@@ -1487,6 +1487,10 @@
 					>
 				</File>
 				<File
+					RelativePath="src\misc\crypt\crypt_helper_functions.c"
+					>
+				</File>
+				<File
 					RelativePath="src\misc\crypt\crypt_inits.c"
 					>
 				</File>

--- a/makefile.mingw
+++ b/makefile.mingw
@@ -101,12 +101,12 @@ src/misc/crypt/crypt_find_cipher_id.o src/misc/crypt/crypt_find_hash.o \
 src/misc/crypt/crypt_find_hash_any.o src/misc/crypt/crypt_find_hash_id.o \
 src/misc/crypt/crypt_find_hash_oid.o src/misc/crypt/crypt_find_prng.o src/misc/crypt/crypt_fsa.o \
 src/misc/crypt/crypt_hash_descriptor.o src/misc/crypt/crypt_hash_is_valid.o \
-src/misc/crypt/crypt_inits.o src/misc/crypt/crypt_ltc_mp_descriptor.o \
-src/misc/crypt/crypt_prng_descriptor.o src/misc/crypt/crypt_prng_is_valid.o \
-src/misc/crypt/crypt_prng_rng_descriptor.o src/misc/crypt/crypt_register_all_ciphers.o \
-src/misc/crypt/crypt_register_all_hashes.o src/misc/crypt/crypt_register_all_prngs.o \
-src/misc/crypt/crypt_register_cipher.o src/misc/crypt/crypt_register_hash.o \
-src/misc/crypt/crypt_register_prng.o src/misc/crypt/crypt_sizes.o \
+src/misc/crypt/crypt_helper_functions.o src/misc/crypt/crypt_inits.o \
+src/misc/crypt/crypt_ltc_mp_descriptor.o src/misc/crypt/crypt_prng_descriptor.o \
+src/misc/crypt/crypt_prng_is_valid.o src/misc/crypt/crypt_prng_rng_descriptor.o \
+src/misc/crypt/crypt_register_all_ciphers.o src/misc/crypt/crypt_register_all_hashes.o \
+src/misc/crypt/crypt_register_all_prngs.o src/misc/crypt/crypt_register_cipher.o \
+src/misc/crypt/crypt_register_hash.o src/misc/crypt/crypt_register_prng.o src/misc/crypt/crypt_sizes.o \
 src/misc/crypt/crypt_unregister_cipher.o src/misc/crypt/crypt_unregister_hash.o \
 src/misc/crypt/crypt_unregister_prng.o src/misc/error_to_string.o src/misc/hkdf/hkdf.o \
 src/misc/hkdf/hkdf_test.o src/misc/mem_neq.o src/misc/padding/padding_depad.o \

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -94,12 +94,12 @@ src/misc/crypt/crypt_find_cipher_id.obj src/misc/crypt/crypt_find_hash.obj \
 src/misc/crypt/crypt_find_hash_any.obj src/misc/crypt/crypt_find_hash_id.obj \
 src/misc/crypt/crypt_find_hash_oid.obj src/misc/crypt/crypt_find_prng.obj src/misc/crypt/crypt_fsa.obj \
 src/misc/crypt/crypt_hash_descriptor.obj src/misc/crypt/crypt_hash_is_valid.obj \
-src/misc/crypt/crypt_inits.obj src/misc/crypt/crypt_ltc_mp_descriptor.obj \
-src/misc/crypt/crypt_prng_descriptor.obj src/misc/crypt/crypt_prng_is_valid.obj \
-src/misc/crypt/crypt_prng_rng_descriptor.obj src/misc/crypt/crypt_register_all_ciphers.obj \
-src/misc/crypt/crypt_register_all_hashes.obj src/misc/crypt/crypt_register_all_prngs.obj \
-src/misc/crypt/crypt_register_cipher.obj src/misc/crypt/crypt_register_hash.obj \
-src/misc/crypt/crypt_register_prng.obj src/misc/crypt/crypt_sizes.obj \
+src/misc/crypt/crypt_helper_functions.obj src/misc/crypt/crypt_inits.obj \
+src/misc/crypt/crypt_ltc_mp_descriptor.obj src/misc/crypt/crypt_prng_descriptor.obj \
+src/misc/crypt/crypt_prng_is_valid.obj src/misc/crypt/crypt_prng_rng_descriptor.obj \
+src/misc/crypt/crypt_register_all_ciphers.obj src/misc/crypt/crypt_register_all_hashes.obj \
+src/misc/crypt/crypt_register_all_prngs.obj src/misc/crypt/crypt_register_cipher.obj \
+src/misc/crypt/crypt_register_hash.obj src/misc/crypt/crypt_register_prng.obj src/misc/crypt/crypt_sizes.obj \
 src/misc/crypt/crypt_unregister_cipher.obj src/misc/crypt/crypt_unregister_hash.obj \
 src/misc/crypt/crypt_unregister_prng.obj src/misc/error_to_string.obj src/misc/hkdf/hkdf.obj \
 src/misc/hkdf/hkdf_test.obj src/misc/mem_neq.obj src/misc/padding/padding_depad.obj \

--- a/makefile.unix
+++ b/makefile.unix
@@ -111,12 +111,12 @@ src/misc/crypt/crypt_find_cipher_id.o src/misc/crypt/crypt_find_hash.o \
 src/misc/crypt/crypt_find_hash_any.o src/misc/crypt/crypt_find_hash_id.o \
 src/misc/crypt/crypt_find_hash_oid.o src/misc/crypt/crypt_find_prng.o src/misc/crypt/crypt_fsa.o \
 src/misc/crypt/crypt_hash_descriptor.o src/misc/crypt/crypt_hash_is_valid.o \
-src/misc/crypt/crypt_inits.o src/misc/crypt/crypt_ltc_mp_descriptor.o \
-src/misc/crypt/crypt_prng_descriptor.o src/misc/crypt/crypt_prng_is_valid.o \
-src/misc/crypt/crypt_prng_rng_descriptor.o src/misc/crypt/crypt_register_all_ciphers.o \
-src/misc/crypt/crypt_register_all_hashes.o src/misc/crypt/crypt_register_all_prngs.o \
-src/misc/crypt/crypt_register_cipher.o src/misc/crypt/crypt_register_hash.o \
-src/misc/crypt/crypt_register_prng.o src/misc/crypt/crypt_sizes.o \
+src/misc/crypt/crypt_helper_functions.o src/misc/crypt/crypt_inits.o \
+src/misc/crypt/crypt_ltc_mp_descriptor.o src/misc/crypt/crypt_prng_descriptor.o \
+src/misc/crypt/crypt_prng_is_valid.o src/misc/crypt/crypt_prng_rng_descriptor.o \
+src/misc/crypt/crypt_register_all_ciphers.o src/misc/crypt/crypt_register_all_hashes.o \
+src/misc/crypt/crypt_register_all_prngs.o src/misc/crypt/crypt_register_cipher.o \
+src/misc/crypt/crypt_register_hash.o src/misc/crypt/crypt_register_prng.o src/misc/crypt/crypt_sizes.o \
 src/misc/crypt/crypt_unregister_cipher.o src/misc/crypt/crypt_unregister_hash.o \
 src/misc/crypt/crypt_unregister_prng.o src/misc/error_to_string.o src/misc/hkdf/hkdf.o \
 src/misc/hkdf/hkdf_test.o src/misc/mem_neq.o src/misc/padding/padding_depad.o \

--- a/makefile_include.mk
+++ b/makefile_include.mk
@@ -271,12 +271,12 @@ src/misc/crypt/crypt_find_cipher_id.o src/misc/crypt/crypt_find_hash.o \
 src/misc/crypt/crypt_find_hash_any.o src/misc/crypt/crypt_find_hash_id.o \
 src/misc/crypt/crypt_find_hash_oid.o src/misc/crypt/crypt_find_prng.o src/misc/crypt/crypt_fsa.o \
 src/misc/crypt/crypt_hash_descriptor.o src/misc/crypt/crypt_hash_is_valid.o \
-src/misc/crypt/crypt_inits.o src/misc/crypt/crypt_ltc_mp_descriptor.o \
-src/misc/crypt/crypt_prng_descriptor.o src/misc/crypt/crypt_prng_is_valid.o \
-src/misc/crypt/crypt_prng_rng_descriptor.o src/misc/crypt/crypt_register_all_ciphers.o \
-src/misc/crypt/crypt_register_all_hashes.o src/misc/crypt/crypt_register_all_prngs.o \
-src/misc/crypt/crypt_register_cipher.o src/misc/crypt/crypt_register_hash.o \
-src/misc/crypt/crypt_register_prng.o src/misc/crypt/crypt_sizes.o \
+src/misc/crypt/crypt_helper_functions.o src/misc/crypt/crypt_inits.o \
+src/misc/crypt/crypt_ltc_mp_descriptor.o src/misc/crypt/crypt_prng_descriptor.o \
+src/misc/crypt/crypt_prng_is_valid.o src/misc/crypt/crypt_prng_rng_descriptor.o \
+src/misc/crypt/crypt_register_all_ciphers.o src/misc/crypt/crypt_register_all_hashes.o \
+src/misc/crypt/crypt_register_all_prngs.o src/misc/crypt/crypt_register_cipher.o \
+src/misc/crypt/crypt_register_hash.o src/misc/crypt/crypt_register_prng.o src/misc/crypt/crypt_sizes.o \
 src/misc/crypt/crypt_unregister_cipher.o src/misc/crypt/crypt_unregister_hash.o \
 src/misc/crypt/crypt_unregister_prng.o src/misc/error_to_string.o src/misc/hkdf/hkdf.o \
 src/misc/hkdf/hkdf_test.o src/misc/mem_neq.o src/misc/padding/padding_depad.o \

--- a/src/encauth/chachapoly/chacha20poly1305_setiv.c
+++ b/src/encauth/chachapoly/chacha20poly1305_setiv.c
@@ -41,6 +41,7 @@ int chacha20poly1305_setiv(chacha20poly1305_state *st, const unsigned char *iv, 
    /* copy chacha20 key to temporary state */
    for(i = 0; i < 12; i++) tmp_st.input[i] = st->chacha.input[i];
    tmp_st.rounds = 20;
+   tmp_st.status = st->chacha.status;
    /* set IV */
    if (ivlen == 12) {
       /* IV 32bit */

--- a/src/headers/tomcrypt_cipher.h
+++ b/src/headers/tomcrypt_cipher.h
@@ -1022,6 +1022,8 @@ typedef struct {
    int           status;  /* 0=uninitialized, 1,3=finished setup(), 2=finished setiv() */
 } salsa20_state;
 
+int salsa20_state_size(void);
+
 int salsa20_onecall(const unsigned char *key,    unsigned long keylen,
                     const unsigned char *iv,     unsigned long ivlen,
                     const unsigned char *datain, unsigned long datalen,
@@ -1068,6 +1070,8 @@ typedef struct {
    int           ivlen;
    int           status;  /* 0=uninitialized, 1,3=finished setup(), 2=finished setiv() */
 } sosemanuk_state;
+
+int sosemanuk_state_size(void);
 
 int sosemanuk_onecall(const unsigned char *key,    unsigned long keylen,
                       const unsigned char *iv,     unsigned long ivlen,

--- a/src/headers/tomcrypt_cipher.h
+++ b/src/headers/tomcrypt_cipher.h
@@ -1043,23 +1043,25 @@ int xsalsa20_test(void);
 #ifdef LTC_SOSEMANUK
 
 typedef struct {
-    ulong32 kc[100];    /* key_context */
-    ulong32 s00, s01, s02, s03, s04, s05, s06, s07, s08, s09;
-    ulong32 r1, r2;
-    /*
-     * Buffering: the stream cipher produces output data by
-     * blocks of 640 bits. buf[] contains such a block, and
-     * "ptr" is the index of the next output byte.
-     */
-    unsigned char buf[80];
-    unsigned ptr;
+   ulong32 kc[100];    /* key_context */
+   ulong32 s00, s01, s02, s03, s04, s05, s06, s07, s08, s09;
+   ulong32 r1, r2;
+   /*
+    * Buffering: the stream cipher produces output data by
+    * blocks of 640 bits. buf[] contains such a block, and
+    * "ptr" is the index of the next output byte.
+    */
+   unsigned char buf[80];
+   unsigned      ptr;
+   int           ivlen;
+   int           status;  /* 0=uninitialized, 1=finished setup(), 2=finished setiv() */
 } sosemanuk_state;
 
-int sosemanuk_setup(sosemanuk_state *ss, const unsigned char *key, unsigned long keylen);
-int sosemanuk_setiv(sosemanuk_state *ss, const unsigned char *iv, unsigned long ivlen);
-int sosemanuk_crypt(sosemanuk_state *ss, const unsigned char *in, unsigned long datalen, unsigned char *out);
-int sosemanuk_keystream(sosemanuk_state *ss, unsigned char *out, unsigned long outlen);
-int sosemanuk_done(sosemanuk_state *ss);
+int sosemanuk_setup(sosemanuk_state *st, const unsigned char *key, unsigned long keylen);
+int sosemanuk_setiv(sosemanuk_state *st, const unsigned char *iv, unsigned long ivlen);
+int sosemanuk_crypt(sosemanuk_state *st, const unsigned char *in, unsigned long datalen, unsigned char *out);
+int sosemanuk_keystream(sosemanuk_state *st, unsigned char *out, unsigned long outlen);
+int sosemanuk_done(sosemanuk_state *st);
 int sosemanuk_test(void);
 
 #endif /* LTC_SOSEMANUK */

--- a/src/headers/tomcrypt_cipher.h
+++ b/src/headers/tomcrypt_cipher.h
@@ -995,11 +995,12 @@ LTC_MUTEX_PROTO(ltc_cipher_mutex)
 #ifdef LTC_CHACHA
 
 typedef struct {
-   ulong32 input[16];
+   ulong32       input[16];
    unsigned char kstream[64];
    unsigned long ksleft;
+   unsigned long rounds;
    unsigned long ivlen;
-   int rounds;
+   unsigned long status;  /* 0=uninitialized, 1=finished setup(), 2=finished ivctrXX() */
 } chacha_state;
 
 int chacha_setup(chacha_state *st, const unsigned char *key, unsigned long keylen, int rounds);
@@ -1024,11 +1025,11 @@ typedef struct {
 
 int salsa20_state_size(void);
 
-int salsa20_onecall(const unsigned char *key,    unsigned long keylen,
-                    const unsigned char *iv,     unsigned long ivlen,
-                    const unsigned char *datain, unsigned long datalen,
-                    unsigned long rounds,
-                    unsigned char *dataout);
+int salsa20_memory(const unsigned char *key,    unsigned long keylen,
+                   const unsigned char *iv,     unsigned long ivlen,
+                   const unsigned char *datain, unsigned long datalen,
+                   unsigned long rounds,
+                   unsigned char *dataout);
 
 int salsa20_setup(salsa20_state *st, const unsigned char *key, unsigned long keylen, unsigned long rounds);
 int salsa20_ivctr64(salsa20_state *st, const unsigned char *iv, unsigned long ivlen, ulong64 counter);
@@ -1043,11 +1044,11 @@ int salsa20_test(void);
 
 int xsalsa20_state_size(void);
 
-int xsalsa20_onecall(const unsigned char *key,    unsigned long keylen,
-                     const unsigned char *nonce,  unsigned long noncelen,
-                     const unsigned char *datain, unsigned long datalen,
-                     unsigned long rounds,
-                     unsigned char *dataout);
+int xsalsa20_memory(const unsigned char *key,    unsigned long keylen,
+                    const unsigned char *nonce,  unsigned long noncelen,
+                    const unsigned char *datain, unsigned long datalen,
+                    unsigned long rounds,
+                    unsigned char *dataout);
 
 int xsalsa20_setup(salsa20_state *st, const unsigned char *key,   unsigned long keylen,
                                       const unsigned char *nonce, unsigned long noncelen,
@@ -1070,15 +1071,15 @@ typedef struct {
    unsigned char buf[80];
    unsigned      ptr;
    unsigned long ivlen;
-   unsigned long status;  /* 0=uninitialized, 1,3=finished setup(), 2=finished setiv() */
+   unsigned long status;  /* 0=uninitialized, 1=finished setup(), 2=finished setiv() */
 } sosemanuk_state;
 
 int sosemanuk_state_size(void);
 
-int sosemanuk_onecall(const unsigned char *key,    unsigned long keylen,
-                      const unsigned char *iv,     unsigned long ivlen,
-                      const unsigned char *datain, unsigned long datalen,
-                      unsigned char *dataout);
+int sosemanuk_memory(const unsigned char *key,    unsigned long keylen,
+                     const unsigned char *iv,     unsigned long ivlen,
+                     const unsigned char *datain, unsigned long datalen,
+                     unsigned char *dataout);
 
 int sosemanuk_setup(sosemanuk_state *st, const unsigned char *key, unsigned long keylen);
 int sosemanuk_setiv(sosemanuk_state *st, const unsigned char *iv, unsigned long ivlen);
@@ -1100,8 +1101,9 @@ typedef struct {
 typedef struct {
    rabbit_ctx master_ctx;
    rabbit_ctx work_ctx;
-   unsigned char block[16];     /* last keystream block containing unused bytes */
-   ulong32       unused;        /* count fm right */
+   unsigned char block[16]; /* last keystream block containing unused bytes */
+   ulong32       unused;    /* count fm right */
+   ulong32       status;    /* 0=uninitialized, 1=finished setup(), 2=finished setiv() */
 } rabbit_state;
 
 int rabbit_setup(rabbit_state* st, const unsigned char *key, unsigned long keylen);
@@ -1118,6 +1120,7 @@ int rabbit_test(void);
 typedef struct {
    unsigned int x, y;
    unsigned char buf[256];
+   unsigned long status;  /* 0=uninitialized, 1=finished setup() */
 } rc4_state;
 
 int rc4_stream_setup(rc4_state *st, const unsigned char *key, unsigned long keylen);
@@ -1135,7 +1138,8 @@ typedef struct {
            initR[17],   /* saved register contents */
            konst,       /* key dependent constant */
            sbuf;        /* partial word encryption buffer */
-   int     nbuf;        /* number of part-word stream bits buffered */
+   ulong32 nbuf;        /* number of part-word stream bits buffered */
+   ulong32 status;      /* 0=uninitialized, 1=finished setup(), 2=finished setiv() */
 } sober128_state;
 
 int sober128_stream_setup(sober128_state *st, const unsigned char *key, unsigned long keylen);

--- a/src/headers/tomcrypt_cipher.h
+++ b/src/headers/tomcrypt_cipher.h
@@ -1005,6 +1005,12 @@ typedef struct {
 
 int chacha_state_size(void);
 
+int chacha_memory(const unsigned char *key,    unsigned long keylen,
+                  const unsigned char *iv,     unsigned long ivlen,
+                  const unsigned char *datain, unsigned long datalen,
+                  unsigned long rounds,
+                  unsigned char *dataout);
+
 int chacha_setup(chacha_state *st, const unsigned char *key, unsigned long keylen, int rounds);
 int chacha_ivctr32(chacha_state *st, const unsigned char *iv, unsigned long ivlen, ulong32 counter);
 int chacha_ivctr64(chacha_state *st, const unsigned char *iv, unsigned long ivlen, ulong64 counter);
@@ -1110,6 +1116,11 @@ typedef struct {
 
 int rabbit_state_size(void);
 
+int rabbit_memory(const unsigned char *key,    unsigned long keylen,
+                  const unsigned char *iv,     unsigned long ivlen,
+                  const unsigned char *datain, unsigned long datalen,
+                  unsigned char *dataout);
+
 int rabbit_setup(rabbit_state* st, const unsigned char *key, unsigned long keylen);
 int rabbit_setiv(rabbit_state* st, const unsigned char *iv, unsigned long ivlen);
 int rabbit_crypt(rabbit_state* st, const unsigned char *in, unsigned long inlen, unsigned char *out);
@@ -1128,6 +1139,10 @@ typedef struct {
 } rc4_state;
 
 int rc4_state_size(void);
+
+int rc4_memory(const unsigned char *key,    unsigned long keylen,
+               const unsigned char *datain, unsigned long datalen,
+               unsigned char *dataout);
 
 int rc4_stream_setup(rc4_state *st, const unsigned char *key, unsigned long keylen);
 int rc4_stream_crypt(rc4_state *st, const unsigned char *in, unsigned long inlen, unsigned char *out);
@@ -1149,6 +1164,11 @@ typedef struct {
 } sober128_state;
 
 int sober128_state_size(void);
+
+int sober128_memory(const unsigned char *key,    unsigned long keylen,
+                    const unsigned char *iv,     unsigned long ivlen,
+                    const unsigned char *datain, unsigned long datalen,
+                    unsigned char *dataout);
 
 int sober128_stream_setup(sober128_state *st, const unsigned char *key, unsigned long keylen);
 int sober128_stream_setiv(sober128_state *st, const unsigned char *iv, unsigned long ivlen);

--- a/src/headers/tomcrypt_cipher.h
+++ b/src/headers/tomcrypt_cipher.h
@@ -1015,14 +1015,20 @@ int chacha_test(void);
 #ifdef LTC_SALSA20
 
 typedef struct {
-   ulong32 input[16];
+   ulong32       input[16];
    unsigned char kstream[64];
    unsigned long ksleft;
    int           rounds;
    int           status;  /* 0=uninitialized, 1,3=finished setup(), 2=finished setiv() */
 } salsa20_state;
 
-int salsa20_setup(salsa20_state *st, const unsigned char *key, unsigned long keylen, int rounds);
+int salsa20_onecall(const unsigned char *key,    unsigned long keylen,
+                    const unsigned char *iv,     unsigned long ivlen,
+                    const unsigned char *datain, unsigned long datalen,
+                    unsigned long rounds,
+                    unsigned char *dataout);
+
+int salsa20_setup(salsa20_state *st, const unsigned char *key, unsigned long keylen, unsigned long rounds);
 int salsa20_ivctr64(salsa20_state *st, const unsigned char *iv, unsigned long ivlen, ulong64 counter);
 int salsa20_crypt(salsa20_state *st, const unsigned char *in, unsigned long inlen, unsigned char *out);
 int salsa20_keystream(salsa20_state *st, unsigned char *out, unsigned long outlen);
@@ -1033,9 +1039,15 @@ int salsa20_test(void);
 
 #ifdef LTC_XSALSA20
 
+int xsalsa20_onecall(const unsigned char *key,    unsigned long keylen,
+                     const unsigned char *nonce,  unsigned long noncelen,
+                     const unsigned char *datain, unsigned long datalen,
+                     unsigned long rounds,
+                     unsigned char *dataout);
+
 int xsalsa20_setup(salsa20_state *st, const unsigned char *key,   unsigned long keylen,
                                       const unsigned char *nonce, unsigned long noncelen,
-                                      int rounds);
+                                      unsigned long rounds);
 int xsalsa20_test(void);
 
 #endif /* LTC_XSALSA20 */
@@ -1054,8 +1066,13 @@ typedef struct {
    unsigned char buf[80];
    unsigned      ptr;
    int           ivlen;
-   int           status;  /* 0=uninitialized, 1=finished setup(), 2=finished setiv() */
+   int           status;  /* 0=uninitialized, 1,3=finished setup(), 2=finished setiv() */
 } sosemanuk_state;
+
+int sosemanuk_onecall(const unsigned char *key,    unsigned long keylen,
+                      const unsigned char *iv,     unsigned long ivlen,
+                      const unsigned char *datain, unsigned long datalen,
+                      unsigned char *dataout);
 
 int sosemanuk_setup(sosemanuk_state *st, const unsigned char *key, unsigned long keylen);
 int sosemanuk_setiv(sosemanuk_state *st, const unsigned char *iv, unsigned long ivlen);

--- a/src/headers/tomcrypt_cipher.h
+++ b/src/headers/tomcrypt_cipher.h
@@ -1041,6 +1041,8 @@ int salsa20_test(void);
 
 #ifdef LTC_XSALSA20
 
+int xsalsa20_state_size(void);
+
 int xsalsa20_onecall(const unsigned char *key,    unsigned long keylen,
                      const unsigned char *nonce,  unsigned long noncelen,
                      const unsigned char *datain, unsigned long datalen,

--- a/src/headers/tomcrypt_cipher.h
+++ b/src/headers/tomcrypt_cipher.h
@@ -1018,8 +1018,8 @@ typedef struct {
    ulong32       input[16];
    unsigned char kstream[64];
    unsigned long ksleft;
-   int           rounds;
-   int           status;  /* 0=uninitialized, 1,3=finished setup(), 2=finished setiv() */
+   unsigned long rounds;
+   unsigned long status;  /* 0=uninitialized, 1,3=finished setup(), 2=finished setiv() */
 } salsa20_state;
 
 int salsa20_state_size(void);
@@ -1067,8 +1067,8 @@ typedef struct {
     */
    unsigned char buf[80];
    unsigned      ptr;
-   int           ivlen;
-   int           status;  /* 0=uninitialized, 1,3=finished setup(), 2=finished setiv() */
+   unsigned long ivlen;
+   unsigned long status;  /* 0=uninitialized, 1,3=finished setup(), 2=finished setiv() */
 } sosemanuk_state;
 
 int sosemanuk_state_size(void);

--- a/src/headers/tomcrypt_cipher.h
+++ b/src/headers/tomcrypt_cipher.h
@@ -1003,6 +1003,8 @@ typedef struct {
    unsigned long status;  /* 0=uninitialized, 1=finished setup(), 2=finished ivctrXX() */
 } chacha_state;
 
+int chacha_state_size(void);
+
 int chacha_setup(chacha_state *st, const unsigned char *key, unsigned long keylen, int rounds);
 int chacha_ivctr32(chacha_state *st, const unsigned char *iv, unsigned long ivlen, ulong32 counter);
 int chacha_ivctr64(chacha_state *st, const unsigned char *iv, unsigned long ivlen, ulong64 counter);
@@ -1106,6 +1108,8 @@ typedef struct {
    ulong32       status;    /* 0=uninitialized, 1=finished setup(), 2=finished setiv() */
 } rabbit_state;
 
+int rabbit_state_size(void);
+
 int rabbit_setup(rabbit_state* st, const unsigned char *key, unsigned long keylen);
 int rabbit_setiv(rabbit_state* st, const unsigned char *iv, unsigned long ivlen);
 int rabbit_crypt(rabbit_state* st, const unsigned char *in, unsigned long inlen, unsigned char *out);
@@ -1122,6 +1126,8 @@ typedef struct {
    unsigned char buf[256];
    unsigned long status;  /* 0=uninitialized, 1=finished setup() */
 } rc4_state;
+
+int rc4_state_size(void);
 
 int rc4_stream_setup(rc4_state *st, const unsigned char *key, unsigned long keylen);
 int rc4_stream_crypt(rc4_state *st, const unsigned char *in, unsigned long inlen, unsigned char *out);
@@ -1141,6 +1147,8 @@ typedef struct {
    ulong32 nbuf;        /* number of part-word stream bits buffered */
    ulong32 status;      /* 0=uninitialized, 1=finished setup(), 2=finished setiv() */
 } sober128_state;
+
+int sober128_state_size(void);
 
 int sober128_stream_setup(sober128_state *st, const unsigned char *key, unsigned long keylen);
 int sober128_stream_setiv(sober128_state *st, const unsigned char *iv, unsigned long ivlen);

--- a/src/headers/tomcrypt_cipher.h
+++ b/src/headers/tomcrypt_cipher.h
@@ -1018,8 +1018,8 @@ typedef struct {
    ulong32 input[16];
    unsigned char kstream[64];
    unsigned long ksleft;
-   unsigned long ivlen;
-   int rounds;
+   int           rounds;
+   int           status;  /* 0=uninitialized, 1,3=finished setup(), 2=finished setiv() */
 } salsa20_state;
 
 int salsa20_setup(salsa20_state *st, const unsigned char *key, unsigned long keylen, int rounds);

--- a/src/headers/tomcrypt_custom.h
+++ b/src/headers/tomcrypt_custom.h
@@ -641,6 +641,9 @@
 
 #endif
 
+/* helper functions for stream ciphers (disable to prevent building them) */
+#define LTC_HELPER_FUNCTIONS
+
 /* Debuggers */
 
 /* define this if you use Valgrind, note: it CHANGES the way SOBER-128 and RC4 work (see the code) */

--- a/src/misc/crypt/crypt_helper_functions.c
+++ b/src/misc/crypt/crypt_helper_functions.c
@@ -8,6 +8,8 @@
  */
 #include "tomcrypt_private.h"
 
+#ifdef LTC_HELPER_FUNCTIONS
+
 /**
   @file crypt_helper_functions.c
 
@@ -33,10 +35,10 @@ int chacha_memory(const unsigned char *key,    unsigned long keylen,
         if ((err = chacha_ivctr32(&state, iv, ivlen, 0)) != CRYPT_OK) goto WIPE_KEY;
    } else {
         if ((err = chacha_ivctr64(&state, iv, ivlen, 0)) != CRYPT_OK) goto WIPE_KEY;
-   )
+   }
    err = chacha_crypt(&state, datain, datalen, dataout);
 WIPE_KEY:
-   err = chacha_done(&state);
+   chacha_done(&state);
    return err;
 }
 
@@ -59,7 +61,7 @@ int salsa20_onecall(const unsigned char *key,    unsigned long keylen,
    if ((err = salsa20_ivctr64(&state, iv, ivlen, 0))      != CRYPT_OK) goto WIPE_KEY;
    err = salsa20_crypt(&state, datain, datalen, dataout);
 WIPE_KEY:
-   err = salsa20_done(&state);
+   salsa20_done(&state);
    return err;
 }
 
@@ -81,7 +83,7 @@ int xsalsa20_onecall(const unsigned char *key,    unsigned long keylen,
    if ((err = xsalsa20_setup(&state, key, keylen, nonce, noncelen, rounds)) != CRYPT_OK) goto WIPE_KEY;
    err = salsa20_crypt(&state, datain, datalen, dataout);
 WIPE_KEY:
-   err = salsa20_done(&state);
+   salsa20_done(&state);
    return err;
 }
 
@@ -104,7 +106,7 @@ int sosemanuk_onecall(const unsigned char *key,    unsigned long keylen,
    if ((err = sosemanuk_setiv(&state, iv, ivlen))   != CRYPT_OK) goto WIPE_KEY;
    err = sosemanuk_crypt(&state, datain, datalen, dataout);
 WIPE_KEY:
-   err = sosemanuk_done(&state);
+   sosemanuk_done(&state);
    return err;
 }
 
@@ -126,7 +128,7 @@ int rabbit_onecall(const unsigned char *key,    unsigned long keylen,
    if ((err = rabbit_setiv(&state, iv, ivlen))   != CRYPT_OK) goto WIPE_KEY;
    err = rabbit_crypt(&state, datain, datalen, dataout);
 WIPE_KEY:
-   err = rabbit_done(&state);
+   rabbit_done(&state);
    return err;
 }
 
@@ -146,7 +148,7 @@ int rc4_stream_onecall(const unsigned char *key,    unsigned long keylen,
    if ((err = rc4_stream_setup(&state, key, keylen)) != CRYPT_OK) goto WIPE_KEY;
    err = rc4_stream_crypt(&state, datain, datalen, dataout);
 WIPE_KEY:
-   err = rc4_stream_done(&state);
+   rc4_stream_done(&state);
    return err;
 }
 
@@ -168,13 +170,15 @@ int sober128_stream_onecall(const unsigned char *key,    unsigned long keylen,
    if ((err = sober128_stream_setiv(&state, iv, ivlen))   != CRYPT_OK) goto WIPE_KEY;
    err = sober128_stream_crypt(&state, datain, datalen, dataout);
 WIPE_KEY:
-   err = sober128_stream_done(&state);
+   sober128_stream_done(&state);
    return err;
 }
 
 #endif /* LTC_SOBER128_STREAM */
 
 /* ======================================================================== */
+
+#endif /* LTC_HELPER_FUNCTIONS */
 
 /* ref:         $Format:%D$ */
 /* git commit:  $Format:%H$ */

--- a/src/misc/crypt/crypt_helper_functions.c
+++ b/src/misc/crypt/crypt_helper_functions.c
@@ -29,9 +29,11 @@ int chacha_memory(const unsigned char *key,    unsigned long keylen,
    int err;
 
    if ((err = chacha_setup(&state, key, keylen, rounds)) != CRYPT_OK) goto WIPE_KEY;
-   if (ivlen == 12)
+   if (ivlen == 12) {
         if ((err = chacha_ivctr32(&state, iv, ivlen, 0)) != CRYPT_OK) goto WIPE_KEY;
-   else if ((err = chacha_ivctr64(&state, iv, ivlen, 0)) != CRYPT_OK) goto WIPE_KEY;
+   } else {
+        if ((err = chacha_ivctr64(&state, iv, ivlen, 0)) != CRYPT_OK) goto WIPE_KEY;
+   )
    err = chacha_crypt(&state, datain, datalen, dataout);
 WIPE_KEY:
    err = chacha_done(&state);

--- a/src/misc/crypt/crypt_helper_functions.c
+++ b/src/misc/crypt/crypt_helper_functions.c
@@ -1,0 +1,85 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ */
+#include "tomcrypt_private.h"
+
+/**
+  @file crypt_helper_functions.c
+
+  A home for the "one call" and other helper functions.
+  Larry Bugbee - June 2018
+*/
+
+/* ======================================================================== */
+
+#ifdef LTC_SALSA20
+
+int salsa20_onecall(const unsigned char *key,    unsigned long keylen,
+                    const unsigned char *iv,     unsigned long ivlen,
+                    const unsigned char *datain, unsigned long datalen,
+                    unsigned long rounds,
+                    unsigned char *dataout)
+{
+   salsa20_state state;
+   int err;
+
+   if ((err = salsa20_setup(&state, key, keylen, rounds))      != CRYPT_OK) return err;
+   if ((err = salsa20_ivctr64(&state, iv, ivlen, 0))           != CRYPT_OK) return err;
+   if ((err = salsa20_crypt(&state, datain, datalen, dataout)) != CRYPT_OK) return err;
+   if ((err = salsa20_done(&state))                            != CRYPT_OK) return err;
+
+   return CRYPT_OK;
+}
+
+#endif
+
+#ifdef LTC_XSALSA20
+
+int xsalsa20_onecall(const unsigned char *key,    unsigned long keylen,
+                     const unsigned char *nonce,  unsigned long noncelen,
+                     const unsigned char *datain, unsigned long datalen,
+                     unsigned long rounds,
+                     unsigned char *dataout)
+{
+   salsa20_state state;
+   int err;
+
+   if ((err = xsalsa20_setup(&state, key, keylen, nonce, noncelen, rounds)) != CRYPT_OK) return err;
+   if ((err = salsa20_crypt(&state, datain, datalen, dataout))              != CRYPT_OK) return err;
+   if ((err = salsa20_done(&state))                                         != CRYPT_OK) return err;
+
+   return CRYPT_OK;
+}
+
+#endif
+
+#ifdef LTC_SOSEMANUK
+
+int sosemanuk_onecall(const unsigned char *key,    unsigned long keylen,
+                      const unsigned char *iv,     unsigned long ivlen,
+                      const unsigned char *datain, unsigned long datalen,
+                      unsigned char *dataout)
+{
+   sosemanuk_state state;
+   int err;
+
+   if ((err = sosemanuk_setup(&state, key, keylen))              != CRYPT_OK) return err;
+   if ((err = sosemanuk_setiv(&state, iv, ivlen))                != CRYPT_OK) return err;
+   if ((err = sosemanuk_crypt(&state, datain, datalen, dataout)) != CRYPT_OK) return err;
+   if ((err = sosemanuk_done(&state))                            != CRYPT_OK) return err;
+
+   return CRYPT_OK;
+}
+
+#endif
+
+/* ======================================================================== */
+
+/* ref:         $Format:%D$ */
+/* git commit:  $Format:%H$ */
+/* commit time: $Format:%ai$ */

--- a/src/misc/crypt/crypt_helper_functions.c
+++ b/src/misc/crypt/crypt_helper_functions.c
@@ -17,6 +17,31 @@
 
 /* ======================================================================== */
 
+#ifdef LTC_CHACHA
+
+int chacha_memory(const unsigned char *key,    unsigned long keylen,
+                  const unsigned char *iv,     unsigned long ivlen,
+                  const unsigned char *datain, unsigned long datalen,
+                  unsigned long rounds,
+                  unsigned char *dataout)
+{
+   chacha_state state;
+   int err;
+
+   if ((err = chacha_setup(&state, key, keylen, rounds)) != CRYPT_OK) goto WIPE_KEY;
+   if (ivlen == 12)
+        if ((err = chacha_ivctr32(&state, iv, ivlen, 0)) != CRYPT_OK) goto WIPE_KEY;
+   else if ((err = chacha_ivctr64(&state, iv, ivlen, 0)) != CRYPT_OK) goto WIPE_KEY;
+   err = chacha_crypt(&state, datain, datalen, dataout);
+WIPE_KEY:
+   err = chacha_done(&state);
+   return err;
+}
+
+#endif /* LTC_CHACHA */
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
 #ifdef LTC_SALSA20
 
 int salsa20_onecall(const unsigned char *key,    unsigned long keylen,
@@ -28,15 +53,17 @@ int salsa20_onecall(const unsigned char *key,    unsigned long keylen,
    salsa20_state state;
    int err;
 
-   if ((err = salsa20_setup(&state, key, keylen, rounds))      != CRYPT_OK) return err;
-   if ((err = salsa20_ivctr64(&state, iv, ivlen, 0))           != CRYPT_OK) return err;
-   if ((err = salsa20_crypt(&state, datain, datalen, dataout)) != CRYPT_OK) return err;
-   if ((err = salsa20_done(&state))                            != CRYPT_OK) return err;
-
-   return CRYPT_OK;
+   if ((err = salsa20_setup(&state, key, keylen, rounds)) != CRYPT_OK) goto WIPE_KEY;
+   if ((err = salsa20_ivctr64(&state, iv, ivlen, 0))      != CRYPT_OK) goto WIPE_KEY;
+   err = salsa20_crypt(&state, datain, datalen, dataout);
+WIPE_KEY:
+   err = salsa20_done(&state);
+   return err;
 }
 
-#endif
+#endif /* LTC_SALSA20 */
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 #ifdef LTC_XSALSA20
 
@@ -49,14 +76,17 @@ int xsalsa20_onecall(const unsigned char *key,    unsigned long keylen,
    salsa20_state state;
    int err;
 
-   if ((err = xsalsa20_setup(&state, key, keylen, nonce, noncelen, rounds)) != CRYPT_OK) return err;
-   if ((err = salsa20_crypt(&state, datain, datalen, dataout))              != CRYPT_OK) return err;
-   if ((err = salsa20_done(&state))                                         != CRYPT_OK) return err;
-
-   return CRYPT_OK;
+   if ((err = xsalsa20_setup(&state, key, keylen, nonce, noncelen, rounds)) != CRYPT_OK) goto WIPE_KEY;
+   err = salsa20_crypt(&state, datain, datalen, dataout);
+WIPE_KEY:
+   err = salsa20_done(&state);
+   return err;
 }
 
-#endif
+#endif /* LTC_XSALSA20 */
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
 
 #ifdef LTC_SOSEMANUK
 
@@ -68,15 +98,79 @@ int sosemanuk_onecall(const unsigned char *key,    unsigned long keylen,
    sosemanuk_state state;
    int err;
 
-   if ((err = sosemanuk_setup(&state, key, keylen))              != CRYPT_OK) return err;
-   if ((err = sosemanuk_setiv(&state, iv, ivlen))                != CRYPT_OK) return err;
-   if ((err = sosemanuk_crypt(&state, datain, datalen, dataout)) != CRYPT_OK) return err;
-   if ((err = sosemanuk_done(&state))                            != CRYPT_OK) return err;
-
-   return CRYPT_OK;
+   if ((err = sosemanuk_setup(&state, key, keylen)) != CRYPT_OK) goto WIPE_KEY;
+   if ((err = sosemanuk_setiv(&state, iv, ivlen))   != CRYPT_OK) goto WIPE_KEY;
+   err = sosemanuk_crypt(&state, datain, datalen, dataout);
+WIPE_KEY:
+   err = sosemanuk_done(&state);
+   return err;
 }
 
-#endif
+#endif /* LTC_SOSEMANUK */
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+#ifdef LTC_RABBIT
+
+int rabbit_onecall(const unsigned char *key,    unsigned long keylen,
+                   const unsigned char *iv,     unsigned long ivlen,
+                   const unsigned char *datain, unsigned long datalen,
+                   unsigned char *dataout)
+{
+   rabbit_state state;
+   int err;
+
+   if ((err = rabbit_setup(&state, key, keylen)) != CRYPT_OK) goto WIPE_KEY;
+   if ((err = rabbit_setiv(&state, iv, ivlen))   != CRYPT_OK) goto WIPE_KEY;
+   err = rabbit_crypt(&state, datain, datalen, dataout);
+WIPE_KEY:
+   err = rabbit_done(&state);
+   return err;
+}
+
+#endif /* LTC_RABBIT */
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+#ifdef LTC_RC4_STREAM
+
+int rc4_stream_onecall(const unsigned char *key,    unsigned long keylen,
+                       const unsigned char *datain, unsigned long datalen,
+                       unsigned char *dataout)
+{
+   rc4_state state;
+   int err;
+
+   if ((err = rc4_stream_setup(&state, key, keylen)) != CRYPT_OK) goto WIPE_KEY;
+   err = rc4_stream_crypt(&state, datain, datalen, dataout);
+WIPE_KEY:
+   err = rc4_stream_done(&state);
+   return err;
+}
+
+#endif /* LTC_RC4_STREAM */
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+#ifdef LTC_SOBER128_STREAM
+
+int sober128_stream_onecall(const unsigned char *key,    unsigned long keylen,
+                   const unsigned char *iv,     unsigned long ivlen,
+                   const unsigned char *datain, unsigned long datalen,
+                   unsigned char *dataout)
+{
+   sober128_state state;
+   int err;
+
+   if ((err = sober128_stream_setup(&state, key, keylen)) != CRYPT_OK) goto WIPE_KEY;
+   if ((err = sober128_stream_setiv(&state, iv, ivlen))   != CRYPT_OK) goto WIPE_KEY;
+   err = sober128_stream_crypt(&state, datain, datalen, dataout);
+WIPE_KEY:
+   err = sober128_stream_done(&state);
+   return err;
+}
+
+#endif /* LTC_SOBER128_STREAM */
 
 /* ======================================================================== */
 

--- a/src/misc/crypt/crypt_sizes.c
+++ b/src/misc/crypt/crypt_sizes.c
@@ -290,19 +290,28 @@ static const crypt_size _crypt_sizes[] = {
 
 };
 
-
-
-
 /* ======================================================================== */
 
+#ifdef LTC_CHACHA
+int chacha_state_size(void)    { return sizeof(chacha_state); }
+#endif
 #ifdef LTC_SALSA20
-int salsa20_state_size(void) { return sizeof(salsa20_state); }
+int salsa20_state_size(void)   { return sizeof(salsa20_state); }
 #endif
 #ifdef LTC_XSALSA20
-int xsalsa20_state_size(void) { return sizeof(salsa20_state); }
+int xsalsa20_state_size(void)  { return sizeof(salsa20_state); }
 #endif
 #ifdef LTC_SOSEMANUK
 int sosemanuk_state_size(void) { return sizeof(sosemanuk_state); }
+#endif
+#ifdef LTC_RABBIT
+int rabbit_state_size(void)    { return sizeof(rabbit_state); }
+#endif
+#ifdef LTC_RC4_STREAM
+int rc4_state_size(void)       { return sizeof(rc4_state); }
+#endif
+#ifdef LTC_SOBER128_STREAM
+int sober128_state_size(void)  { return sizeof(sober128_state); }
 #endif
 
 /* ======================================================================== */

--- a/src/misc/crypt/crypt_sizes.c
+++ b/src/misc/crypt/crypt_sizes.c
@@ -290,6 +290,22 @@ static const crypt_size _crypt_sizes[] = {
 
 };
 
+
+
+
+/* ======================================================================== */
+
+#ifdef LTC_SALSA20
+int salsa20_state_size(void) { return sizeof(salsa20_state); }
+#endif
+#ifdef LTC_XSALSA20
+int xsalsa20_state_size(void) { return sizeof(salsa20_state); }
+#endif
+#ifdef LTC_SOSEMANUK
+int sosemanuk_state_size(void) { return sizeof(sosemanuk_state); }
+#endif
+
+/* ======================================================================== */
 /* crypt_get_size()
  * sizeout will be the size (bytes) of the named struct or union
  * return -1 if named item not found
@@ -306,6 +322,7 @@ int crypt_get_size(const char* namein, unsigned int *sizeout) {
     return -1;
 }
 
+/* ======================================================================== */
 /* crypt_list_all_sizes()
  * if names_list is NULL, names_list_size will be the minimum
  *     size needed to receive the complete names_list

--- a/src/stream/chacha/chacha_crypt.c
+++ b/src/stream/chacha/chacha_crypt.c
@@ -58,10 +58,10 @@ int chacha_crypt(chacha_state *st, const unsigned char *in, unsigned long inlen,
 
    if (inlen == 0) return CRYPT_OK; /* nothing to do */
 
-   LTC_ARGCHK(st        != NULL);
-   LTC_ARGCHK(in        != NULL);
-   LTC_ARGCHK(out       != NULL);
-   LTC_ARGCHK(st->ivlen != 0);
+   LTC_ARGCHK(st         != NULL);
+   LTC_ARGCHK(in         != NULL);
+   LTC_ARGCHK(out        != NULL);
+   LTC_ARGCHK(st->status != -1);
 
    if (st->ksleft > 0) {
       j = MIN(st->ksleft, inlen);

--- a/src/stream/chacha/chacha_crypt.c
+++ b/src/stream/chacha/chacha_crypt.c
@@ -61,7 +61,7 @@ int chacha_crypt(chacha_state *st, const unsigned char *in, unsigned long inlen,
    LTC_ARGCHK(st         != NULL);
    LTC_ARGCHK(in         != NULL);
    LTC_ARGCHK(out        != NULL);
-   LTC_ARGCHK(st->status != -1);
+   LTC_ARGCHK(st->status == 2);
 
    if (st->ksleft > 0) {
       j = MIN(st->ksleft, inlen);

--- a/src/stream/chacha/chacha_done.c
+++ b/src/stream/chacha/chacha_done.c
@@ -20,6 +20,7 @@ int chacha_done(chacha_state *st)
 {
    LTC_ARGCHK(st != NULL);
    XMEMSET(st, 0, sizeof(chacha_state));
+   st->ivlen = -1;
    return CRYPT_OK;
 }
 

--- a/src/stream/chacha/chacha_done.c
+++ b/src/stream/chacha/chacha_done.c
@@ -20,7 +20,6 @@ int chacha_done(chacha_state *st)
 {
    LTC_ARGCHK(st != NULL);
    XMEMSET(st, 0, sizeof(chacha_state));
-   st->ivlen = -1;
    return CRYPT_OK;
 }
 

--- a/src/stream/chacha/chacha_ivctr32.c
+++ b/src/stream/chacha/chacha_ivctr32.c
@@ -37,6 +37,7 @@ int chacha_ivctr32(chacha_state *st, const unsigned char *iv, unsigned long ivle
    LOAD32L(st->input[15], iv + 8);
    st->ksleft = 0;
    st->status = 2;
+   st->ivlen  = ivlen;
    return CRYPT_OK;
 }
 

--- a/src/stream/chacha/chacha_ivctr32.c
+++ b/src/stream/chacha/chacha_ivctr32.c
@@ -28,15 +28,15 @@ int chacha_ivctr32(chacha_state *st, const unsigned char *iv, unsigned long ivle
 {
    LTC_ARGCHK(st != NULL);
    LTC_ARGCHK(iv != NULL);
-   /* 96bit IV + 32bit counter */
-   LTC_ARGCHK(ivlen == 12);
+   LTC_ARGCHK(ivlen == 12);             /* 96bit IV + 32bit counter */
+   LTC_ARGCHK(st->status == 1 || st->status == 2);
 
    st->input[12] = counter;
    LOAD32L(st->input[13], iv + 0);
    LOAD32L(st->input[14], iv + 4);
    LOAD32L(st->input[15], iv + 8);
    st->ksleft = 0;
-   st->ivlen = ivlen;
+   st->status = 2;
    return CRYPT_OK;
 }
 

--- a/src/stream/chacha/chacha_ivctr64.c
+++ b/src/stream/chacha/chacha_ivctr64.c
@@ -36,6 +36,7 @@ int chacha_ivctr64(chacha_state *st, const unsigned char *iv, unsigned long ivle
    LOAD32L(st->input[14], iv + 0);
    LOAD32L(st->input[15], iv + 4);
    st->ksleft = 0;
+   st->ivlen  = ivlen;
    st->status = 2;
    return CRYPT_OK;
 }

--- a/src/stream/chacha/chacha_ivctr64.c
+++ b/src/stream/chacha/chacha_ivctr64.c
@@ -28,15 +28,15 @@ int chacha_ivctr64(chacha_state *st, const unsigned char *iv, unsigned long ivle
 {
    LTC_ARGCHK(st != NULL);
    LTC_ARGCHK(iv != NULL);
-   /* 64bit IV + 64bit counter */
-   LTC_ARGCHK(ivlen == 8);
+   LTC_ARGCHK(ivlen == 8);              /* 64bit IV + 64bit counter */
+   LTC_ARGCHK(st->status == 1 || st->status == 2);
 
    st->input[12] = (ulong32)(counter & 0xFFFFFFFF);
    st->input[13] = (ulong32)(counter >> 32);
    LOAD32L(st->input[14], iv + 0);
    LOAD32L(st->input[15], iv + 4);
    st->ksleft = 0;
-   st->ivlen = ivlen;
+   st->status = 2;
    return CRYPT_OK;
 }
 

--- a/src/stream/chacha/chacha_setup.c
+++ b/src/stream/chacha/chacha_setup.c
@@ -19,6 +19,7 @@
 static const char * const sigma = "expand 32-byte k";
 static const char * const tau   = "expand 16-byte k";
 
+/* ======================================================================== */
 /**
    Initialize an ChaCha context (only the key)
    @param st        [out] The destination of the ChaCha state
@@ -56,7 +57,7 @@ int chacha_setup(chacha_state *st, const unsigned char *key, unsigned long keyle
    LOAD32L(st->input[2],  constants + 8);
    LOAD32L(st->input[3],  constants + 12);
    st->rounds = rounds; /* e.g. 20 for chacha20 */
-   st->ivlen = 0; /* will be set later by chacha_ivctr(32|64) */
+   st->ivlen = -1;      /* will be set later by chacha_ivctr(32|64) */
    return CRYPT_OK;
 }
 

--- a/src/stream/chacha/chacha_setup.c
+++ b/src/stream/chacha/chacha_setup.c
@@ -57,7 +57,7 @@ int chacha_setup(chacha_state *st, const unsigned char *key, unsigned long keyle
    LOAD32L(st->input[2],  constants + 8);
    LOAD32L(st->input[3],  constants + 12);
    st->rounds = rounds; /* e.g. 20 for chacha20 */
-   st->ivlen = -1;      /* will be set later by chacha_ivctr(32|64) */
+   st->status = 1;
    return CRYPT_OK;
 }
 

--- a/src/stream/rc4/rc4_stream.c
+++ b/src/stream/rc4/rc4_stream.c
@@ -42,6 +42,7 @@ int rc4_stream_setup(rc4_state *st, const unsigned char *key, unsigned long keyl
    }
    st->x = 0;
    st->y = 0;
+   st->status = 1;
 
    return CRYPT_OK;
 }
@@ -61,6 +62,7 @@ int rc4_stream_crypt(rc4_state *st, const unsigned char *in, unsigned long inlen
    LTC_ARGCHK(st  != NULL);
    LTC_ARGCHK(in  != NULL);
    LTC_ARGCHK(out != NULL);
+   LTC_ARGCHK(st->status == 1);
 
    x = st->x;
    y = st->y;

--- a/src/stream/salsa20/salsa20_crypt.c
+++ b/src/stream/salsa20/salsa20_crypt.c
@@ -59,10 +59,10 @@ int salsa20_crypt(salsa20_state *st, const unsigned char *in, unsigned long inle
 
    if (inlen == 0) return CRYPT_OK; /* nothing to do */
 
-   LTC_ARGCHK(st        != NULL);
-   LTC_ARGCHK(in        != NULL);
-   LTC_ARGCHK(out       != NULL);
-   LTC_ARGCHK(st->ivlen == 8 || st->ivlen == 24);
+   LTC_ARGCHK(st  != NULL);
+   LTC_ARGCHK(in  != NULL);
+   LTC_ARGCHK(out != NULL);
+   LTC_ARGCHK(st->status == 2 || st->status == 3);
 
    if (st->ksleft > 0) {
       j = MIN(st->ksleft, inlen);

--- a/src/stream/salsa20/salsa20_ivctr64.c
+++ b/src/stream/salsa20/salsa20_ivctr64.c
@@ -29,8 +29,8 @@ int salsa20_ivctr64(salsa20_state *st, const unsigned char *iv, unsigned long iv
 {
    LTC_ARGCHK(st != NULL);
    LTC_ARGCHK(iv != NULL);
-   LTC_ARGCHK(st->status == 1 || st->status == 2);
    LTC_ARGCHK(ivlen == 8);
+   LTC_ARGCHK(st->status == 1 || st->status == 2);
 
    LOAD32L(st->input[6], iv + 0);
    LOAD32L(st->input[7], iv + 4);

--- a/src/stream/salsa20/salsa20_ivctr64.c
+++ b/src/stream/salsa20/salsa20_ivctr64.c
@@ -29,7 +29,7 @@ int salsa20_ivctr64(salsa20_state *st, const unsigned char *iv, unsigned long iv
 {
    LTC_ARGCHK(st != NULL);
    LTC_ARGCHK(iv != NULL);
-   /* Salsa20: 64-bit IV (nonce) + 64-bit counter */
+   LTC_ARGCHK(st->status == 1 || st->status == 2);
    LTC_ARGCHK(ivlen == 8);
 
    LOAD32L(st->input[6], iv + 0);
@@ -37,7 +37,7 @@ int salsa20_ivctr64(salsa20_state *st, const unsigned char *iv, unsigned long iv
    st->input[8] = (ulong32)(counter & 0xFFFFFFFF);
    st->input[9] = (ulong32)(counter >> 32);
    st->ksleft = 0;
-   st->ivlen = ivlen;
+   st->status = 2;
    return CRYPT_OK;
 }
 

--- a/src/stream/salsa20/salsa20_setup.c
+++ b/src/stream/salsa20/salsa20_setup.c
@@ -37,7 +37,7 @@ int salsa20_setup(salsa20_state *st, const unsigned char *key, unsigned long key
    LTC_ARGCHK(keylen == 32 || keylen == 16);
 
    if (rounds == 0) rounds = 20;
-   LTC_ARGCHK(rounds % 2 == 0); /* number of rounds must be evenly divisible by 2 */
+   LTC_ARGCHK(rounds % 2 == 0);       /* rounds must be evenly divisible by 2 */
 
    LOAD32L(st->input[1],  key + 0);
    LOAD32L(st->input[2],  key + 4);
@@ -58,7 +58,7 @@ int salsa20_setup(salsa20_state *st, const unsigned char *key, unsigned long key
    LOAD32L(st->input[10],  constants + 8);
    LOAD32L(st->input[15],  constants + 12);
    st->rounds = rounds;     /* default is 20 for salsa20 */
-   st->ivlen = 0;           /* will be set later by salsa20_ivctr(32|64) */
+   st->status = 1;
    return CRYPT_OK;
 }
 

--- a/src/stream/salsa20/salsa20_setup.c
+++ b/src/stream/salsa20/salsa20_setup.c
@@ -20,6 +20,26 @@
 static const char * const sigma = "expand 32-byte k";
 static const char * const tau   = "expand 16-byte k";
 
+/* ======================================================================== */
+
+int salsa20_onecall(const unsigned char *key,    unsigned long keylen,
+                    const unsigned char *iv,     unsigned long ivlen,
+                    const unsigned char *datain, unsigned long datalen,
+                    unsigned long rounds,
+                    unsigned char *dataout)
+{
+   salsa20_state state;
+   int err;
+
+   if ((err = salsa20_setup(&state, key, keylen, rounds))      != CRYPT_OK) return err;
+   if ((err = salsa20_ivctr64(&state, iv, ivlen, 0))           != CRYPT_OK) return err;
+   if ((err = salsa20_crypt(&state, datain, datalen, dataout)) != CRYPT_OK) return err;
+   if ((err = salsa20_done(&state))                            != CRYPT_OK) return err;
+
+   return CRYPT_OK;
+}
+
+/* ======================================================================== */
 /**
    Initialize an Salsa20 context (only the key)
    @param st        [out] The destination of the Salsa20 state
@@ -28,7 +48,7 @@ static const char * const tau   = "expand 16-byte k";
    @param rounds    Number of rounds (e.g. 20 for Salsa20)
    @return CRYPT_OK if successful
 */
-int salsa20_setup(salsa20_state *st, const unsigned char *key, unsigned long keylen, int rounds)
+int salsa20_setup(salsa20_state *st, const unsigned char *key, unsigned long keylen, unsigned long rounds)
 {
    const char *constants;
 

--- a/src/stream/salsa20/salsa20_setup.c
+++ b/src/stream/salsa20/salsa20_setup.c
@@ -21,29 +21,6 @@ static const char * const sigma = "expand 32-byte k";
 static const char * const tau   = "expand 16-byte k";
 
 /* ======================================================================== */
-
-int salsa20_state_size(void) { return sizeof(salsa20_state); }
-
-/* ======================================================================== */
-
-int salsa20_onecall(const unsigned char *key,    unsigned long keylen,
-                    const unsigned char *iv,     unsigned long ivlen,
-                    const unsigned char *datain, unsigned long datalen,
-                    unsigned long rounds,
-                    unsigned char *dataout)
-{
-   salsa20_state state;
-   int err;
-
-   if ((err = salsa20_setup(&state, key, keylen, rounds))      != CRYPT_OK) return err;
-   if ((err = salsa20_ivctr64(&state, iv, ivlen, 0))           != CRYPT_OK) return err;
-   if ((err = salsa20_crypt(&state, datain, datalen, dataout)) != CRYPT_OK) return err;
-   if ((err = salsa20_done(&state))                            != CRYPT_OK) return err;
-
-   return CRYPT_OK;
-}
-
-/* ======================================================================== */
 /**
    Initialize an Salsa20 context (only the key)
    @param st        [out] The destination of the Salsa20 state

--- a/src/stream/salsa20/salsa20_setup.c
+++ b/src/stream/salsa20/salsa20_setup.c
@@ -22,6 +22,10 @@ static const char * const tau   = "expand 16-byte k";
 
 /* ======================================================================== */
 
+int salsa20_state_size(void) { return sizeof(salsa20_state); }
+
+/* ======================================================================== */
+
 int salsa20_onecall(const unsigned char *key,    unsigned long keylen,
                     const unsigned char *iv,     unsigned long ivlen,
                     const unsigned char *datain, unsigned long datalen,

--- a/src/stream/salsa20/xsalsa20_setup.c
+++ b/src/stream/salsa20/xsalsa20_setup.c
@@ -119,7 +119,7 @@ int xsalsa20_setup(salsa20_state *st, const unsigned char *key, unsigned long ke
    st->input[ 9] = 0;
    st->rounds = rounds;
    st->ksleft = 0;
-   st->ivlen  = 24;           /* set switch to say nonce/IV has been loaded */
+   st->status = 3;
 
 #ifdef LTC_CLEAN_STACK
    zeromem(x, sizeof(x));

--- a/src/stream/salsa20/xsalsa20_setup.c
+++ b/src/stream/salsa20/xsalsa20_setup.c
@@ -18,6 +18,26 @@
 
 #ifdef LTC_XSALSA20
 
+/* ======================================================================== */
+
+int xsalsa20_onecall(const unsigned char *key,    unsigned long keylen,
+                     const unsigned char *nonce,  unsigned long noncelen,
+                     const unsigned char *datain, unsigned long datalen,
+                     unsigned long rounds,
+                     unsigned char *dataout)
+{
+   salsa20_state state;
+   int err;
+
+   if ((err = xsalsa20_setup(&state, key, keylen, nonce, noncelen, rounds)) != CRYPT_OK) return err;
+   if ((err = salsa20_crypt(&state, datain, datalen, dataout))              != CRYPT_OK) return err;
+   if ((err = salsa20_done(&state))                                         != CRYPT_OK) return err;
+
+   return CRYPT_OK;
+}
+
+/* ======================================================================== */
+
 static const char * const constants = "expand 32-byte k";
 
 #define QUARTERROUND(a,b,c,d) \
@@ -59,7 +79,7 @@ static void _xsalsa20_doubleround(ulong32 *x, int rounds)
 */
 int xsalsa20_setup(salsa20_state *st, const unsigned char *key, unsigned long keylen,
                                       const unsigned char *nonce, unsigned long noncelen,
-                                      int rounds)
+                                      unsigned long rounds)
 {
    const int sti[] = {0, 5, 10, 15, 6, 7, 8, 9};  /* indices used to build subkey fm x */
    ulong32       x[64];                           /* input to & output fm doubleround */
@@ -72,7 +92,7 @@ int xsalsa20_setup(salsa20_state *st, const unsigned char *key, unsigned long ke
    LTC_ARGCHK(nonce     != NULL);
    LTC_ARGCHK(noncelen  == 24);
    if (rounds == 0) rounds = 20;
-   LTC_ARGCHK(rounds % 2 == 0);     /* number of rounds must be evenly divisible by 2 */
+   LTC_ARGCHK(rounds % 2 == 0);       /* rounds must be evenly divisible by 2 */
 
    /* load the state to "hash" the key */
    LOAD32L(x[ 0], constants +  0);

--- a/src/stream/salsa20/xsalsa20_setup.c
+++ b/src/stream/salsa20/xsalsa20_setup.c
@@ -20,24 +20,6 @@
 
 /* ======================================================================== */
 
-int xsalsa20_onecall(const unsigned char *key,    unsigned long keylen,
-                     const unsigned char *nonce,  unsigned long noncelen,
-                     const unsigned char *datain, unsigned long datalen,
-                     unsigned long rounds,
-                     unsigned char *dataout)
-{
-   salsa20_state state;
-   int err;
-
-   if ((err = xsalsa20_setup(&state, key, keylen, nonce, noncelen, rounds)) != CRYPT_OK) return err;
-   if ((err = salsa20_crypt(&state, datain, datalen, dataout))              != CRYPT_OK) return err;
-   if ((err = salsa20_done(&state))                                         != CRYPT_OK) return err;
-
-   return CRYPT_OK;
-}
-
-/* ======================================================================== */
-
 static const char * const constants = "expand 32-byte k";
 
 #define QUARTERROUND(a,b,c,d) \

--- a/src/stream/sober128/sober128_stream.c
+++ b/src/stream/sober128/sober128_stream.c
@@ -152,6 +152,7 @@ static void s128_diffuse(sober128_state *c)
     DROUND(16);
 }
 
+/* ======================================================================== */
 /**
    Initialize an Sober128 context (only the key)
    @param c         [out] The destination of the Sober128 state
@@ -195,6 +196,7 @@ int sober128_stream_setup(sober128_state *c, const unsigned char *key, unsigned 
    s128_genkonst(c);
    s128_savestate(c);
    c->nbuf = 0;
+   c->status = 1;
 
    return CRYPT_OK;
 }
@@ -213,6 +215,7 @@ int sober128_stream_setiv(sober128_state *c, const unsigned char *iv, unsigned l
    LTC_ARGCHK(c  != NULL);
    LTC_ARGCHK(iv != NULL);
    LTC_ARGCHK(ivlen > 0);
+   LTC_ARGCHK(c->status != 0);
 
    /* ok we are adding an IV then... */
    s128_reloadstate(c);
@@ -235,6 +238,7 @@ int sober128_stream_setiv(sober128_state *c, const unsigned char *iv, unsigned l
    /* now diffuse */
    s128_diffuse(c);
    c->nbuf = 0;
+   c->status = 2;
 
    return CRYPT_OK;
 }
@@ -258,6 +262,7 @@ int sober128_stream_crypt(sober128_state *c, const unsigned char *in, unsigned l
    if (inlen == 0) return CRYPT_OK; /* nothing to do */
    LTC_ARGCHK(out != NULL);
    LTC_ARGCHK(c   != NULL);
+   LTC_ARGCHK(c->status == 2);
 
    /* handle any previously buffered bytes */
    while (c->nbuf != 0 && inlen != 0) {

--- a/src/stream/sosemanuk/sosemanuk.c
+++ b/src/stream/sosemanuk/sosemanuk.c
@@ -347,6 +347,7 @@ int sosemanuk_setup(sosemanuk_state *st, const unsigned char *key, unsigned long
 #undef WUP1
 
     st->status = 1;  /* 0=uninitialized, 1=finished setup(), 2=finished setiv() */
+
     return CRYPT_OK;
 }
 

--- a/src/stream/sosemanuk/sosemanuk.c
+++ b/src/stream/sosemanuk/sosemanuk.c
@@ -199,24 +199,6 @@
 
 /* ======================================================================== */
 
- int sosemanuk_onecall(const unsigned char *key,    unsigned long keylen,
-                       const unsigned char *iv,     unsigned long ivlen,
-                       const unsigned char *datain, unsigned long datalen,
-                       unsigned char *dataout)
-{
-   sosemanuk_state state;
-   int err;
-
-   if ((err = sosemanuk_setup(&state, key, keylen))              != CRYPT_OK) return err;
-   if ((err = sosemanuk_setiv(&state, iv, ivlen))                != CRYPT_OK) return err;
-   if ((err = sosemanuk_crypt(&state, datain, datalen, dataout)) != CRYPT_OK) return err;
-   if ((err = sosemanuk_done(&state))                            != CRYPT_OK) return err;
-
-   return CRYPT_OK;
-}
-
-/* ======================================================================== */
-
 /*
  * Initialize Sosemanuk's state by providing a key. The key is an array of
  * 16 to 32 bytes.

--- a/src/stream/sosemanuk/sosemanuk.c
+++ b/src/stream/sosemanuk/sosemanuk.c
@@ -10,6 +10,12 @@
 /*
  * This LTC implementation was adapted from:
  *    http://www.ecrypt.eu.org/stream/e2-sosemanuk.html
+ *
+ * Sosemanuk specifications require:
+ *    1- a key of at least 128 bits (16 bytes), not exceeding 256 bits (32 bytes).
+ *    2- keys < 32 bytes are terminated with 0x01 followed by NULLs as needed.
+ *    3- an iv of 128 bits (16 bytes).
+ * See http://www.ecrypt.eu.org/stream/p3ciphers/sosemanuk/sosemanuk_p3.pdf
  */
 
 /*
@@ -193,15 +199,30 @@
 
 /* ======================================================================== */
 
+ int sosemanuk_onecall(const unsigned char *key,    unsigned long keylen, 
+                       const unsigned char *iv,     unsigned long ivlen, 
+                       const unsigned char *datain, unsigned long datalen, 
+                       unsigned char *dataout)
+{
+   sosemanuk_state state;
+   
+   sosemanuk_setup(&state, key, keylen);
+   sosemanuk_setiv(&state, iv, ivlen);
+   sosemanuk_crypt(&state, datain, datalen, dataout);
+   sosemanuk_done(&state);
+}
+
+/* ======================================================================== */
+
 /*
  * Initialize Sosemanuk's state by providing a key. The key is an array of
- * 1 to 32 bytes.
+ * 16 to 32 bytes.
  * @param ss       The Sosemanuk state
  * @param key      Key
  * @param keylen   Length of key in bytes
  * @return CRYPT_OK on success
  */
-int sosemanuk_setup(sosemanuk_state *ss, const unsigned char *key, unsigned long keylen)
+int sosemanuk_setup(sosemanuk_state *st, const unsigned char *key, unsigned long keylen)
 {
     /*
      * This key schedule is actually a truncated Serpent key schedule.
@@ -216,10 +237,10 @@ int sosemanuk_setup(sosemanuk_state *ss, const unsigned char *key, unsigned long
         r2 = w ## o2; \
         r3 = w ## o3; \
         S(r0, r1, r2, r3, r4); \
-        ss->kc[i ++] = r ## d0; \
-        ss->kc[i ++] = r ## d1; \
-        ss->kc[i ++] = r ## d2; \
-        ss->kc[i ++] = r ## d3; \
+        st->kc[i ++] = r ## d0; \
+        st->kc[i ++] = r ## d1; \
+        st->kc[i ++] = r ## d2; \
+        st->kc[i ++] = r ## d3; \
     } while (0)
 
 #define SKS0    SKS(S0, 4, 5, 6, 7, 1, 4, 2, 0)
@@ -255,9 +276,9 @@ int sosemanuk_setup(sosemanuk_state *ss, const unsigned char *key, unsigned long
     ulong32 w0, w1, w2, w3, w4, w5, w6, w7;
     int i = 0;
 
-   LTC_ARGCHK(ss  != NULL);
+   LTC_ARGCHK(st  != NULL);
    LTC_ARGCHK(key != NULL);
-   LTC_ARGCHK(keylen > 0 && keylen <= 32);
+   LTC_ARGCHK(keylen >= 16 && keylen <= 32);
 
     /*
      * The key is copied into the wbuf[] buffer and padded to 256 bits
@@ -318,36 +339,31 @@ int sosemanuk_setup(sosemanuk_state *ss, const unsigned char *key, unsigned long
 #undef WUP0
 #undef WUP1
 
-    /*
-     * Initialize with a zero-value iv to ensure state is correct in the
-     * event user fails to call setiv().
-     */
-    return sosemanuk_setiv(ss, NULL, 0);
+    st->status = 1;  /* 0=uninitialized, 1=finished setup(), 2=finished setiv() */
+    return CRYPT_OK;
 }
 
 
 /*
- * Initialization continues by setting the IV. The IV length is up to 16 bytes.
- * If "ivlen" is 0 (no IV), then the "iv" parameter can be NULL.  If multiple
- * encryptions/decryptions are to be performed with the same key and
+ * Initialization continues by setting the IV.  The IV length is 16 bytes.  If
+ * multiple encryptions/decryptions are to be performed with the same key and
  * sosemanuk_done() has not been called, only sosemanuk_setiv() need be called
  * to set the state.
- * @param ss       The Sosemanuk state
+ * @param st       The Sosemanuk state
  * @param iv       Initialization vector
- * @param ivlen    Length of iv in bytes
  * @return CRYPT_OK on success
  */
-int sosemanuk_setiv(sosemanuk_state *ss, const unsigned char *iv, unsigned long ivlen)
+int sosemanuk_setiv(sosemanuk_state *st, const unsigned char *iv, unsigned long ivlen)
 {
 
     /*
      * The Serpent key addition step.
      */
 #define KA(zc, x0, x1, x2, x3)  do { \
-        x0 ^= ss->kc[(zc)]; \
-        x1 ^= ss->kc[(zc) + 1]; \
-        x2 ^= ss->kc[(zc) + 2]; \
-        x3 ^= ss->kc[(zc) + 3]; \
+        x0 ^= st->kc[(zc)]; \
+        x1 ^= st->kc[(zc) + 1]; \
+        x2 ^= st->kc[(zc) + 2]; \
+        x3 ^= st->kc[(zc) + 3]; \
     } while (0)
 
     /*
@@ -377,11 +393,12 @@ int sosemanuk_setiv(sosemanuk_state *ss, const unsigned char *iv, unsigned long 
     ulong32 r0, r1, r2, r3, r4;
     unsigned char ivtmp[16] = {0};
 
-    LTC_ARGCHK(ss != NULL);
-    LTC_ARGCHK(ivlen <= 16);
-    LTC_ARGCHK(iv != NULL || ivlen == 0);
+    LTC_ARGCHK(st != NULL);
+    LTC_ARGCHK(iv != NULL);
+    LTC_ARGCHK(ivlen == 16);
+    LTC_ARGCHK(st->status != 0);
 
-    if (ivlen > 0) XMEMCPY(ivtmp, iv, ivlen);
+    XMEMCPY(ivtmp, iv, ivlen);
 
     /*
      * Decode IV into four 32-bit words (little-endian).
@@ -407,10 +424,10 @@ int sosemanuk_setiv(sosemanuk_state *ss, const unsigned char *iv, unsigned long 
     FSS(36, S1, 1, 3, 2, 4, 0, 2, 1, 4, 3);
     FSS(40, S2, 2, 1, 4, 3, 0, 4, 3, 1, 0);
     FSS(44, S3, 4, 3, 1, 0, 2, 3, 1, 0, 2);
-    ss->s09 = r3;
-    ss->s08 = r1;
-    ss->s07 = r0;
-    ss->s06 = r2;
+    st->s09 = r3;
+    st->s08 = r1;
+    st->s07 = r0;
+    st->s06 = r2;
 
     FSS(48, S4, 3, 1, 0, 2, 4, 1, 4, 3, 2);
     FSS(52, S5, 1, 4, 3, 2, 0, 4, 2, 1, 3);
@@ -418,10 +435,10 @@ int sosemanuk_setiv(sosemanuk_state *ss, const unsigned char *iv, unsigned long 
     FSS(60, S7, 4, 2, 0, 1, 3, 3, 1, 2, 4);
     FSS(64, S0, 3, 1, 2, 4, 0, 1, 0, 2, 3);
     FSS(68, S1, 1, 0, 2, 3, 4, 2, 1, 3, 0);
-    ss->r1  = r2;
-    ss->s04 = r1;
-    ss->r2  = r3;
-    ss->s05 = r0;
+    st->r1  = r2;
+    st->s04 = r1;
+    st->r2  = r3;
+    st->s05 = r0;
 
     FSS(72, S2, 2, 1, 3, 0, 4, 3, 0, 1, 4);
     FSS(76, S3, 3, 0, 1, 4, 2, 0, 1, 4, 2);
@@ -429,17 +446,18 @@ int sosemanuk_setiv(sosemanuk_state *ss, const unsigned char *iv, unsigned long 
     FSS(84, S5, 1, 3, 0, 2, 4, 3, 2, 1, 0);
     FSS(88, S6, 3, 2, 1, 0, 4, 3, 2, 4, 1);
     FSF(92, S7, 3, 2, 4, 1, 0, 0, 1, 2, 3);
-    ss->s03 = r0;
-    ss->s02 = r1;
-    ss->s01 = r2;
-    ss->s00 = r3;
+    st->s03 = r0;
+    st->s02 = r1;
+    st->s01 = r2;
+    st->s00 = r3;
 
-    ss->ptr = sizeof(ss->buf);
+    st->ptr = sizeof(st->buf);
 
 #undef KA
 #undef FSS
 #undef FSF
 
+    st->status = 2;  /* 0=uninitialized, 1=finished setup(), 2=finished setiv() */
     return CRYPT_OK;
 }
 
@@ -588,7 +606,7 @@ static const ulong32 mul_ia[] = {
  * Compute the next block of bits of output stream. This is equivalent
  * to one full rotation of the shift register.
  */
-static LTC_INLINE void _sosemanuk_internal(sosemanuk_state *ss)
+static LTC_INLINE void _sosemanuk_internal(sosemanuk_state *st)
 {
     /*
      * MUL_A(x) computes alpha * x (in F_{2^32}).
@@ -659,24 +677,24 @@ static LTC_INLINE void _sosemanuk_internal(sosemanuk_state *ss)
      */
 #define SRD(S, x0, x1, x2, x3, ooff)   do { \
         S(u0, u1, u2, u3, u4); \
-        STORE32L(u ## x0 ^ v0, ss->buf + ooff); \
-        STORE32L(u ## x1 ^ v1, ss->buf + ooff +  4); \
-        STORE32L(u ## x2 ^ v2, ss->buf + ooff +  8); \
-        STORE32L(u ## x3 ^ v3, ss->buf + ooff + 12); \
+        STORE32L(u ## x0 ^ v0, st->buf + ooff); \
+        STORE32L(u ## x1 ^ v1, st->buf + ooff +  4); \
+        STORE32L(u ## x2 ^ v2, st->buf + ooff +  8); \
+        STORE32L(u ## x3 ^ v3, st->buf + ooff + 12); \
     } while (0)
 
-    ulong32 s00 = ss->s00;
-    ulong32 s01 = ss->s01;
-    ulong32 s02 = ss->s02;
-    ulong32 s03 = ss->s03;
-    ulong32 s04 = ss->s04;
-    ulong32 s05 = ss->s05;
-    ulong32 s06 = ss->s06;
-    ulong32 s07 = ss->s07;
-    ulong32 s08 = ss->s08;
-    ulong32 s09 = ss->s09;
-    ulong32 r1 = ss->r1;
-    ulong32 r2 = ss->r2;
+    ulong32 s00 = st->s00;
+    ulong32 s01 = st->s01;
+    ulong32 s02 = st->s02;
+    ulong32 s03 = st->s03;
+    ulong32 s04 = st->s04;
+    ulong32 s05 = st->s05;
+    ulong32 s06 = st->s06;
+    ulong32 s07 = st->s07;
+    ulong32 s08 = st->s08;
+    ulong32 s09 = st->s09;
+    ulong32 r1 = st->r1;
+    ulong32 r2 = st->r2;
     ulong32 u0, u1, u2, u3, u4;
     ulong32 v0, v1, v2, v3;
 
@@ -706,18 +724,18 @@ static LTC_INLINE void _sosemanuk_internal(sosemanuk_state *ss)
     STEP(09, 00, 01, 02, 03, 04, 05, 06, 07, 08, v3, u3);
     SRD(S2, 2, 3, 1, 4, 64);
 
-    ss->s00 = s00;
-    ss->s01 = s01;
-    ss->s02 = s02;
-    ss->s03 = s03;
-    ss->s04 = s04;
-    ss->s05 = s05;
-    ss->s06 = s06;
-    ss->s07 = s07;
-    ss->s08 = s08;
-    ss->s09 = s09;
-    ss->r1 = r1;
-    ss->r2 = r2;
+    st->s00 = s00;
+    st->s01 = s01;
+    st->s02 = s02;
+    st->s03 = s03;
+    st->s04 = s04;
+    st->s05 = s05;
+    st->s06 = s06;
+    st->s07 = s07;
+    st->s08 = s08;
+    st->s09 = s09;
+    st->r1 = r1;
+    st->r2 = r2;
 }
 
 /*
@@ -739,40 +757,41 @@ static LTC_INLINE void _xorbuf(const unsigned char *in1, const unsigned char *in
  * buffer, combined by XOR with the stream, and the result is written
  * in the "out" buffer. "in" and "out" must be either equal, or
  * reference distinct buffers (no partial overlap is allowed).
- * @param ss       The Sosemanuk state
+ * @param st       The Sosemanuk state
  * @param in       Data in
  * @param inlen    Length of data in bytes
  * @param out      Data out
  * @return CRYPT_OK on success
  */
-int sosemanuk_crypt(sosemanuk_state *ss,
+int sosemanuk_crypt(sosemanuk_state *st,
                         const unsigned char *in, unsigned long inlen, unsigned char *out)
 {
-    LTC_ARGCHK(ss  != NULL);
+    LTC_ARGCHK(st  != NULL);
     LTC_ARGCHK(in  != NULL);
     LTC_ARGCHK(out != NULL);
+    LTC_ARGCHK(st->status == 2);
 
-    if (ss->ptr < (sizeof(ss->buf))) {
-        unsigned long rlen = (sizeof(ss->buf)) - ss->ptr;
+    if (st->ptr < (sizeof(st->buf))) {
+        unsigned long rlen = (sizeof(st->buf)) - st->ptr;
 
         if (rlen > inlen)
             rlen = inlen;
-        _xorbuf(ss->buf + ss->ptr, in, out, rlen);
+        _xorbuf(st->buf + st->ptr, in, out, rlen);
         in += rlen;
         out += rlen;
         inlen -= rlen;
-        ss->ptr += rlen;
+        st->ptr += rlen;
     }
     while (inlen > 0) {
-        _sosemanuk_internal(ss);
-        if (inlen >= sizeof(ss->buf)) {
-            _xorbuf(ss->buf, in, out, sizeof(ss->buf));
-            in += sizeof(ss->buf);
-            out += sizeof(ss->buf);
-            inlen -= sizeof(ss->buf);
+        _sosemanuk_internal(st);
+        if (inlen >= sizeof(st->buf)) {
+            _xorbuf(st->buf, in, out, sizeof(st->buf));
+            in += sizeof(st->buf);
+            out += sizeof(st->buf);
+            inlen -= sizeof(st->buf);
         } else {
-            _xorbuf(ss->buf, in, out, inlen);
-            ss->ptr = inlen;
+            _xorbuf(st->buf, in, out, inlen);
+            st->ptr = inlen;
             inlen = 0;
         }
     }
@@ -784,29 +803,29 @@ int sosemanuk_crypt(sosemanuk_state *ss,
 /*
  * Cipher operation, as a PRNG: the provided output buffer is filled with
  * pseudo-random bytes as output from the stream cipher.
- * @param ss       The Sosemanuk state
+ * @param st       The Sosemanuk state
  * @param out      Data out
  * @param outlen   Length of output in bytes
  * @return CRYPT_OK on success
  */
-int sosemanuk_keystream(sosemanuk_state *ss, unsigned char *out, unsigned long outlen)
+int sosemanuk_keystream(sosemanuk_state *st, unsigned char *out, unsigned long outlen)
 {
    if (outlen == 0) return CRYPT_OK; /* nothing to do */
    LTC_ARGCHK(out != NULL);
    XMEMSET(out, 0, outlen);
-   return sosemanuk_crypt(ss, out, outlen, out);
+   return sosemanuk_crypt(st, out, outlen, out);
 }
 
 
 /*
  * Terminate and clear Sosemanuk key context
- * @param ss      The Sosemanuk state
+ * @param st      The Sosemanuk state
  * @return CRYPT_OK on success
  */
-int sosemanuk_done(sosemanuk_state *ss)
+int sosemanuk_done(sosemanuk_state *st)
 {
-   LTC_ARGCHK(ss != NULL);
-   XMEMSET(ss, 0, sizeof(sosemanuk_state));
+   LTC_ARGCHK(st != NULL);
+   XMEMSET(st, 0, sizeof(sosemanuk_state));
    return CRYPT_OK;
 }
 

--- a/src/stream/sosemanuk/sosemanuk.c
+++ b/src/stream/sosemanuk/sosemanuk.c
@@ -199,9 +199,10 @@
 
 /* ======================================================================== */
 
- int sosemanuk_onecall(const unsigned char *key,    unsigned long keylen, 
-                       const unsigned char *iv,     unsigned long ivlen, 
-                       const unsigned char *datain, unsigned long datalen, 
+int sosemanuk_state_size(void) { return sizeof(sosemanuk_state); }
+
+/* ======================================================================== */
+
  int sosemanuk_onecall(const unsigned char *key,    unsigned long keylen,
                        const unsigned char *iv,     unsigned long ivlen,
                        const unsigned char *datain, unsigned long datalen,

--- a/src/stream/sosemanuk/sosemanuk.c
+++ b/src/stream/sosemanuk/sosemanuk.c
@@ -199,10 +199,6 @@
 
 /* ======================================================================== */
 
-int sosemanuk_state_size(void) { return sizeof(sosemanuk_state); }
-
-/* ======================================================================== */
-
  int sosemanuk_onecall(const unsigned char *key,    unsigned long keylen,
                        const unsigned char *iv,     unsigned long ivlen,
                        const unsigned char *datain, unsigned long datalen,

--- a/src/stream/sosemanuk/sosemanuk.c
+++ b/src/stream/sosemanuk/sosemanuk.c
@@ -202,14 +202,20 @@
  int sosemanuk_onecall(const unsigned char *key,    unsigned long keylen, 
                        const unsigned char *iv,     unsigned long ivlen, 
                        const unsigned char *datain, unsigned long datalen, 
+ int sosemanuk_onecall(const unsigned char *key,    unsigned long keylen,
+                       const unsigned char *iv,     unsigned long ivlen,
+                       const unsigned char *datain, unsigned long datalen,
                        unsigned char *dataout)
 {
    sosemanuk_state state;
-   
-   sosemanuk_setup(&state, key, keylen);
-   sosemanuk_setiv(&state, iv, ivlen);
-   sosemanuk_crypt(&state, datain, datalen, dataout);
-   sosemanuk_done(&state);
+   int err;
+
+   if ((err = sosemanuk_setup(&state, key, keylen))              != CRYPT_OK) return err;
+   if ((err = sosemanuk_setiv(&state, iv, ivlen))                != CRYPT_OK) return err;
+   if ((err = sosemanuk_crypt(&state, datain, datalen, dataout)) != CRYPT_OK) return err;
+   if ((err = sosemanuk_done(&state))                            != CRYPT_OK) return err;
+
+   return CRYPT_OK;
 }
 
 /* ======================================================================== */

--- a/src/stream/sosemanuk/sosemanuk_test.c
+++ b/src/stream/sosemanuk/sosemanuk_test.c
@@ -38,7 +38,7 @@ int sosemanuk_test(void)
        if ((err = sosemanuk_crypt(&ss, (unsigned char*)pt + 40, len - 40, out + 40)) != CRYPT_OK) return err;
        if (compare_testvector(out, len, ct, sizeof(ct), "SOSEMANUK-TV1", 1))                      return CRYPT_FAIL_TESTVECTOR;
 
-       /* crypt in one go - using sosemanuk_ivctr64() */
+       /* crypt in one go - using sosemanuk_setiv() */
        if ((err = sosemanuk_setup(&ss, k, sizeof(k)))                 != CRYPT_OK) return err;
        if ((err = sosemanuk_setiv(&ss, n, sizeof(n)))                 != CRYPT_OK) return err;
        if ((err = sosemanuk_crypt(&ss, (unsigned char*)pt, len, out)) != CRYPT_OK) return err;


### PR DESCRIPTION
This PR addresses several issues found while reviewing the stream ciphers.  The current focus is on Salsa20/XSalsa20 and Sosemanuk, but the intent is, if in agreement, to extend the following to all stream ciphers.  ...and perhaps block ciphers and hash functions.

  1- flow control between the cipher's functions: enforce the calling of setiv() before calling crypt(), enforce the calling of setup() before calling setiv(), etc.  The proper sequences vary for Salsa20, XSalsa20, and RC4 for example.
 ![state diagram - chacha salsa sosemanuk rabbit](https://user-images.githubusercontent.com/845950/41827551-e49dd14c-77e4-11e8-9375-c2efc9e294fa.jpg)
![state diagram - xsalsa](https://user-images.githubusercontent.com/845950/41827559-ed98cc16-77e4-11e8-988c-cc3e072c4d26.jpg)

  2- "one call" helper functions to support the [frequent] needs to crypt small, in-memory data with a single call.  See Salsa20 and Sosemanuk in doc/crypt.tex.

  3- an alternate and preferred way to get a cipher's state size.  See bottom of Dynamic Language section in doc/crypt.tex.

  4- miscellaneous small "corrections"


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

* [ x ] documentation is added or updated
* [ ] tests will be added or updated
