### PR TITLE
fix "make test" built with no math provider or multiple providers

### DIFF
--- a/src/headers/tomcrypt_custom.h
+++ b/src/headers/tomcrypt_custom.h
@@ -417,7 +417,7 @@
 #define LTC_DH1536
 #define LTC_DH2048
 
-#ifndef TFM_DESC
+#if defined(LTM_DESC) || defined(GMP_DESC)
 /* tfm has a problem in fp_isprime for larger key sizes */
 #define LTC_DH3072
 #define LTC_DH4096

--- a/tests/dh_test.c
+++ b/tests/dh_test.c
@@ -10,12 +10,6 @@
 
 #if defined(LTC_MDH)
 
-#ifdef LTC_DH4096
-#define KEYSIZE 4096
-#else
-#define KEYSIZE 2048
-#endif
-
 static int _prime_test(void)
 {
    void *p, *g, *tmp;
@@ -24,6 +18,9 @@ static int _prime_test(void)
    if ((err = mp_init_multi(&p, &g, &tmp, NULL)) != CRYPT_OK)               { goto error; }
 
    for (x = 0; ltc_dh_sets[x].size != 0; x++) {
+      /* tfm has a problem with larger sizes */
+      if ((strcmp(ltc_mp.name, "TomsFastMath") == 0) && (ltc_dh_sets[x].size > 256)) break;
+
       if ((err = mp_read_radix(g, ltc_dh_sets[x].base, 16)) != CRYPT_OK)    { goto error; }
       if ((err = mp_read_radix(p, ltc_dh_sets[x].prime, 16)) != CRYPT_OK)   { goto error; }
 
@@ -321,8 +318,11 @@ static int _basic_test(void)
 {
    unsigned char buf[3][4096];
    unsigned long x, y, z;
-   int           size;
+   int           size, KEYSIZE;
    dh_key        usera, userb;
+
+   /* tfm has a problem with larger sizes */
+   KEYSIZE = (strcmp(ltc_mp.name, "TomsFastMath") == 0) ? 2048 : 4096;
 
    /* make up two keys */
    DO(dh_set_pg_groupsize(KEYSIZE/8, &usera));
@@ -372,6 +372,9 @@ static int _basic_test(void)
    }
 
    for (x = 0; ltc_dh_sets[x].size != 0; x++) {
+      /* tfm has a problem with larger sizes */
+      if ((strcmp(ltc_mp.name, "TomsFastMath") == 0) && (ltc_dh_sets[x].size > 256)) break;
+
       DO(dh_set_pg_groupsize(ltc_dh_sets[x].size, &usera));
       DO(dh_generate_key(&yarrow_prng, find_prng ("yarrow"), &usera));
       size = dh_get_groupsize(&usera);

--- a/tests/ecc_test.c
+++ b/tests/ecc_test.c
@@ -445,8 +445,6 @@ int _ecc_new_api(void)
    unsigned char data16[16] = { 0xd1, 0xd1, 0xd1, 0xd1, 0xd1, 0xd1, 0xd1, 0xd1, 0xd1, 0xd1, 0xd1, 0xd1, 0xd1, 0xd1, 0xd1, 0xd1 };
    unsigned long len16;
 
-   if (ltc_mp.name == NULL) return CRYPT_NOP;
-
    for (i = 0; i < (int)(sizeof(names)/sizeof(names[0])); i++) {
       DO(ecc_get_curve(names[i], &dp));
       /* make new key */
@@ -900,6 +898,8 @@ int _ecc_import_export(void) {
 
 int ecc_tests(void)
 {
+   if (ltc_mp.name == NULL) return CRYPT_NOP;
+
    DO(_ecc_old_api()); /* up to 1.18 */
    DO(_ecc_new_api());
    DO(_ecc_import_export());


### PR DESCRIPTION
This PR fixes:
* a crash when building tests linked with ltc without any math provider
* a failure when building tests linked with ltc with multiple math providers (tfm is the trouble maker, any combination containing tfm fails)