### PR TITLE
fix clang-tidy warning: google-readability-braces-around-statements

### DIFF
--- a/src/ciphers/des.c
+++ b/src/ciphers/des.c
@@ -2068,8 +2068,9 @@ int des_keysize(int *keysize)
 int des3_keysize(int *keysize)
 {
     LTC_ARGCHK(keysize != NULL);
-    if (*keysize < 16)
+    if (*keysize < 16) {
        return CRYPT_INVALID_KEYSIZE;
+    }
     if (*keysize < 24) {
        *keysize = 16;
        return CRYPT_OK;

--- a/src/ciphers/safer/safer.c
+++ b/src/ciphers/safer/safer.c
@@ -113,8 +113,9 @@ static void Safer_Expand_Userkey(const unsigned char *userkey_1,
     unsigned char ka[LTC_SAFER_BLOCK_LEN + 1];
     unsigned char kb[LTC_SAFER_BLOCK_LEN + 1];
 
-    if (LTC_SAFER_MAX_NOF_ROUNDS < nof_rounds)
+    if (LTC_SAFER_MAX_NOF_ROUNDS < nof_rounds) {
         nof_rounds = LTC_SAFER_MAX_NOF_ROUNDS;
+    }
     *key++ = (unsigned char)nof_rounds;
     ka[LTC_SAFER_BLOCK_LEN] = (unsigned char)0;
     kb[LTC_SAFER_BLOCK_LEN] = (unsigned char)0;

--- a/src/ciphers/safer/saferp.c
+++ b/src/ciphers/safer/saferp.c
@@ -547,8 +547,9 @@ int saferp_keysize(int *keysize)
 {
    LTC_ARGCHK(keysize != NULL);
 
-   if (*keysize < 16)
+   if (*keysize < 16) {
       return CRYPT_INVALID_KEYSIZE;
+   }
    if (*keysize < 24) {
       *keysize = 16;
    } else if (*keysize < 32) {

--- a/src/encauth/ocb3/ocb3_decrypt_last.c
+++ b/src/encauth/ocb3/ocb3_decrypt_last.c
@@ -66,10 +66,11 @@ int ocb3_decrypt_last(ocb3_state *ocb, const unsigned char *ct, unsigned long ct
      /* Checksum_* = Checksum_m xor (P_* || 1 || zeros(127-bitlen(P_*))) */
      ocb3_int_xor_blocks(ocb->checksum, ocb->checksum, pt+full_blocks_len, last_block_len);
      for(x=last_block_len; x<ocb->block_len; x++) {
-       if (x == last_block_len)
+       if (x == last_block_len) {
          ocb->checksum[x] ^= 0x80;
-       else
+       } else {
          ocb->checksum[x] ^= 0x00;
+       }
      }
 
      /* Tag = ENCIPHER(K, Checksum_* xor Offset_* xor L_$) xor HASH(K,A) */

--- a/src/encauth/ocb3/ocb3_encrypt_last.c
+++ b/src/encauth/ocb3/ocb3_encrypt_last.c
@@ -68,10 +68,11 @@ int ocb3_encrypt_last(ocb3_state *ocb, const unsigned char *pt, unsigned long pt
      /* Checksum_* = Checksum_m xor (P_* || 1 || zeros(127-bitlen(P_*))) */
      ocb3_int_xor_blocks(ocb->checksum, ocb->checksum, pt+full_blocks_len, last_block_len);
      for(x=last_block_len; x<ocb->block_len; x++) {
-       if (x == last_block_len)
+       if (x == last_block_len) {
          ocb->checksum[x] ^= 0x80;
-       else
+       } else {
          ocb->checksum[x] ^= 0x00;
+       }
      }
 
      /* Tag = ENCIPHER(K, Checksum_* xor Offset_* xor L_$) xor HASH(K,A) */
@@ -82,8 +83,7 @@ int ocb3_encrypt_last(ocb3_state *ocb, const unsigned char *pt, unsigned long pt
      if ((err = cipher_descriptor[ocb->cipher].ecb_encrypt(ocb->tag_part, ocb->tag_part, &ocb->key)) != CRYPT_OK) {
        goto LBL_ERR;
      }
-   }
-   else {
+   } else {
      /* Tag = ENCIPHER(K, Checksum_m xor Offset_m xor L_$) xor HASH(K,A) */
      /* at this point we calculate only: Tag_part = ENCIPHER(K, Checksum_m xor Offset_m xor L_$) */
      for(x=0; x<ocb->block_len; x++) {

--- a/src/hashes/blake2b.c
+++ b/src/hashes/blake2b.c
@@ -160,9 +160,9 @@ static int blake2b_is_lastblock(const hash_state *md) { return md->blake2b.f[0] 
 
 static void blake2b_set_lastblock(hash_state *md)
 {
-   if (md->blake2b.last_node)
+   if (md->blake2b.last_node) {
       blake2b_set_lastnode(md);
-
+   }
    md->blake2b.f[0] = CONST64(0xffffffffffffffff);
 }
 
@@ -177,8 +177,9 @@ static void blake2b_init0(hash_state *md)
    unsigned long i;
    XMEMSET(&md->blake2b, 0, sizeof(md->blake2b));
 
-   for (i = 0; i < 8; ++i)
+   for (i = 0; i < 8; ++i) {
       md->blake2b.h[i] = blake2b_IV[i];
+   }
 }
 
 /* init xors IV with input parameter block */
@@ -219,11 +220,12 @@ int blake2b_init(hash_state *md, unsigned long outlen, const unsigned char *key,
 
    LTC_ARGCHK(md != NULL);
 
-   if ((!outlen) || (outlen > BLAKE2B_OUTBYTES))
+   if ((!outlen) || (outlen > BLAKE2B_OUTBYTES)) {
       return CRYPT_INVALID_ARG;
-
-   if ((key && !keylen) || (keylen && !key) || (keylen > BLAKE2B_KEYBYTES))
+   }
+   if ((key && !keylen) || (keylen && !key) || (keylen > BLAKE2B_KEYBYTES)) {
       return CRYPT_INVALID_ARG;
+   }
 
    XMEMSET(P, 0, sizeof(P));
 
@@ -416,16 +418,18 @@ int blake2b_done(hash_state *md, unsigned char *out)
 
    /* if(md->blakebs.outlen != outlen) return CRYPT_INVALID_ARG; */
 
-   if (blake2b_is_lastblock(md))
+   if (blake2b_is_lastblock(md)) {
       return CRYPT_ERROR;
+   }
 
    blake2b_increment_counter(md, md->blake2b.curlen);
    blake2b_set_lastblock(md);
    XMEMSET(md->blake2b.buf + md->blake2b.curlen, 0, BLAKE2B_BLOCKBYTES - md->blake2b.curlen); /* Padding */
    blake2b_compress(md, md->blake2b.buf);
 
-   for (i = 0; i < 8; ++i) /* Output full hash to temp buffer */
+   for (i = 0; i < 8; ++i) { /* Output full hash to temp buffer */
       STORE64L(md->blake2b.h[i], buffer + i * 8);
+   }
 
    XMEMCPY(out, buffer, md->blake2b.outlen);
    zeromem(md, sizeof(hash_state));

--- a/src/hashes/blake2s.c
+++ b/src/hashes/blake2s.c
@@ -152,9 +152,9 @@ static int blake2s_is_lastblock(const hash_state *md) { return md->blake2s.f[0] 
 
 static void blake2s_set_lastblock(hash_state *md)
 {
-   if (md->blake2s.last_node)
+   if (md->blake2s.last_node) {
       blake2s_set_lastnode(md);
-
+   }
    md->blake2s.f[0] = 0xffffffffUL;
 }
 
@@ -169,8 +169,9 @@ static int blake2s_init0(hash_state *md)
    int i;
    XMEMSET(&md->blake2s, 0, sizeof(struct blake2s_state));
 
-   for (i = 0; i < 8; ++i)
+   for (i = 0; i < 8; ++i) {
       md->blake2s.h[i] = blake2s_IV[i];
+   }
 
    return CRYPT_OK;
 }
@@ -213,11 +214,12 @@ int blake2s_init(hash_state *md, unsigned long outlen, const unsigned char *key,
 
    LTC_ARGCHK(md != NULL);
 
-   if ((!outlen) || (outlen > BLAKE2S_OUTBYTES))
+   if ((!outlen) || (outlen > BLAKE2S_OUTBYTES)) {
       return CRYPT_INVALID_ARG;
-
-   if ((key && !keylen) || (keylen && !key) || (keylen > BLAKE2S_KEYBYTES))
+   }
+   if ((key && !keylen) || (keylen && !key) || (keylen > BLAKE2S_KEYBYTES)) {
       return CRYPT_INVALID_ARG;
+   }
 
    XMEMSET(P, 0, sizeof(P));
 
@@ -308,8 +310,9 @@ static int blake2s_compress(hash_state *md, const unsigned char *buf)
       LOAD32L(m[i], buf + i * sizeof(m[i]));
    }
 
-   for (i = 0; i < 8; ++i)
+   for (i = 0; i < 8; ++i) {
       v[i] = md->blake2s.h[i];
+   }
 
    v[8] = blake2s_IV[0];
    v[9] = blake2s_IV[1];
@@ -331,9 +334,9 @@ static int blake2s_compress(hash_state *md, const unsigned char *buf)
    ROUND(8);
    ROUND(9);
 
-   for (i = 0; i < 8; ++i)
+   for (i = 0; i < 8; ++i) {
       md->blake2s.h[i] = md->blake2s.h[i] ^ v[i] ^ v[i + 8];
-
+   }
    return CRYPT_OK;
 }
 #undef G
@@ -404,16 +407,17 @@ int blake2s_done(hash_state *md, unsigned char *out)
 
    /* if(md->blake2s.outlen != outlen) return CRYPT_INVALID_ARG; */
 
-   if (blake2s_is_lastblock(md))
+   if (blake2s_is_lastblock(md)) {
       return CRYPT_ERROR;
-
+   }
    blake2s_increment_counter(md, md->blake2s.curlen);
    blake2s_set_lastblock(md);
    XMEMSET(md->blake2s.buf + md->blake2s.curlen, 0, BLAKE2S_BLOCKBYTES - md->blake2s.curlen); /* Padding */
    blake2s_compress(md, md->blake2s.buf);
 
-   for (i = 0; i < 8; ++i) /* Output full hash to temp buffer */
+   for (i = 0; i < 8; ++i) { /* Output full hash to temp buffer */
       STORE32L(md->blake2s.h[i], buffer + i * 4);
+   }
 
    XMEMCPY(out, buffer, md->blake2s.outlen);
    zeromem(md, sizeof(hash_state));

--- a/src/hashes/sha3.c
+++ b/src/hashes/sha3.c
@@ -167,13 +167,14 @@ static void keccakf(ulong64 s[25])
 
    for(round = 0; round < SHA3_KECCAK_ROUNDS; round++) {
       /* Theta */
-      for(i = 0; i < 5; i++)
+      for(i = 0; i < 5; i++) {
          bc[i] = s[i] ^ s[i + 5] ^ s[i + 10] ^ s[i + 15] ^ s[i + 20];
-
+      }
       for(i = 0; i < 5; i++) {
          t = bc[(i + 4) % 5] ^ ROL64(bc[(i + 1) % 5], 1);
-         for(j = 0; j < 25; j += 5)
+         for(j = 0; j < 25; j += 5) {
             s[j + i] ^= t;
+         }
       }
       /* Rho Pi */
       t = s[1];
@@ -185,10 +186,12 @@ static void keccakf(ulong64 s[25])
       }
       /* Chi */
       for(j = 0; j < 25; j += 5) {
-         for(i = 0; i < 5; i++)
+         for(i = 0; i < 5; i++) {
             bc[i] = s[j + i];
-         for(i = 0; i < 5; i++)
+         }
+         for(i = 0; i < 5; i++) {
             s[j + i] ^= (~bc[(i + 1) % 5]) & bc[(i + 2) % 5];
+         }
       }
       /* Iota */
       s[0] ^= keccakf_rndc[round];

--- a/src/misc/adler32.c
+++ b/src/misc/adler32.c
@@ -41,8 +41,9 @@ void adler32_update(adler32_state *ctx, const unsigned char *input, unsigned lon
          length--;
       } while (length % 8 != 0);
 
-      if (s1 >= _adler32_base)
+      if (s1 >= _adler32_base) {
          s1 -= _adler32_base;
+      }
       s2 %= _adler32_base;
    }
 
@@ -67,8 +68,9 @@ void adler32_update(adler32_state *ctx, const unsigned char *input, unsigned lon
       length -= 8;
       input += 8;
 
-      if (s1 >= _adler32_base)
+      if (s1 >= _adler32_base) {
          s1 -= _adler32_base;
+      }
       s2 %= _adler32_base;
    }
 

--- a/src/misc/base16/base16_encode.c
+++ b/src/misc/base16/base16_encode.c
@@ -52,8 +52,11 @@ int base16_encode(const unsigned char *in,  unsigned long  inlen,
    x--;
    *outlen = x; /* returning the length without terminating NUL */
 
-   if (options == 0) alphabet = alphabets[0];
-   else alphabet = alphabets[1];
+   if (options == 0) {
+      alphabet = alphabets[0];
+   } else {
+      alphabet = alphabets[1];
+   }
 
    for (i = 0; i < x; i += 2) {
       out[i]   = alphabet[(in[i/2] >> 4) & 0x0f];

--- a/src/misc/burn_stack.c
+++ b/src/misc/burn_stack.c
@@ -21,8 +21,9 @@ void burn_stack(unsigned long len)
 {
    unsigned char buf[32];
    zeromem(buf, sizeof(buf));
-   if (len > (unsigned long)sizeof(buf))
+   if (len > (unsigned long)sizeof(buf)) {
       burn_stack(len - sizeof(buf));
+   }
 }
 
 

--- a/src/misc/compare_testvector.c
+++ b/src/misc/compare_testvector.c
@@ -63,11 +63,11 @@ static void _print_hex(const char* what, const void* v, const unsigned long l)
 int compare_testvector(const void* is, const unsigned long is_len, const void* should, const unsigned long should_len, const char* what, int which)
 {
    int res = 0;
-   if(is_len != should_len)
+   if(is_len != should_len) {
       res = is_len > should_len ? -1 : 1;
-   else
+   } else {
       res = XMEMCMP(is, should, is_len);
-
+   }
 #if defined(LTC_TEST) && defined(LTC_TEST_DBG)
    if (res != 0) {
       fprintf(stderr, "Testvector #%i of %s failed:\n", which, what);

--- a/src/misc/crc32.c
+++ b/src/misc/crc32.c
@@ -153,8 +153,9 @@ void crc32_update(crc32_state *ctx, const unsigned char *input, unsigned long le
    LTC_ARGCHKVD(input != NULL);
    crc = ctx->crc;
 
-   while (length--)
+   while (length--) {
       crc = crc32_m_tab[CRC32_INDEX(crc) ^ *input++] ^ CRC32_SHIFTED(crc);
+   }
 
    ctx->crc = crc;
 }

--- a/src/misc/crypt/crypt_constants.c
+++ b/src/misc/crypt/crypt_constants.c
@@ -265,8 +265,9 @@ int crypt_list_all_constants(char *names_list, unsigned int *names_list_size) {
     /* calculate amount of memory required for the list */
     for (i=0; i<count; i++) {
         number_len = snprintf(NULL, 0, "%s,%d\n", _crypt_constants[i].name, _crypt_constants[i].value);
-        if (number_len < 0)
+        if (number_len < 0) {
           return -1;
+        }
         total_len += number_len;
     }
 

--- a/src/misc/crypt/crypt_sizes.c
+++ b/src/misc/crypt/crypt_sizes.c
@@ -326,8 +326,9 @@ int crypt_list_all_sizes(char *names_list, unsigned int *names_list_size) {
     /* calculate amount of memory required for the list */
     for (i=0; i<count; i++) {
         number_len = snprintf(NULL, 0, "%s,%u\n", _crypt_sizes[i].name, _crypt_sizes[i].size);
-        if (number_len < 0)
+        if (number_len < 0) {
           return -1;
+        }
         total_len += number_len;
         /* this last +1 is for newlines (and ending NULL) */
     }

--- a/src/misc/hkdf/hkdf.c
+++ b/src/misc/hkdf/hkdf.c
@@ -54,10 +54,12 @@ int hkdf_expand(int hash_idx, const unsigned char *info, unsigned long infolen,
    hashsize = hash_descriptor[hash_idx].hashsize;
 
    /* RFC5869 parameter restrictions */
-   if (inlen < hashsize || outlen > hashsize * 255)
+   if (inlen < hashsize || outlen > hashsize * 255) {
       return CRYPT_INVALID_ARG;
-   if (info == NULL && infolen != 0)
+   }
+   if (info == NULL && infolen != 0) {
       return CRYPT_INVALID_ARG;
+   }
    LTC_ARGCHK(out != NULL);
 
    Tlen = hashsize + infolen + 1;
@@ -86,8 +88,9 @@ int hkdf_expand(int hash_idx, const unsigned char *info, unsigned long infolen,
       }
       outoff += Noutlen;
 
-      if (outoff >= outlen) /* loop exit condition */
+      if (outoff >= outlen) { /* loop exit condition */
          break;
+      }
 
       /* All subsequent HMAC data T(N) DOES include the previous hash value */
       XMEMCPY(T, out + hashsize * (N-1), hashsize);

--- a/src/misc/padding/padding_pad.c
+++ b/src/misc/padding/padding_pad.c
@@ -99,8 +99,11 @@ int padding_pad(unsigned char *data, unsigned long length, unsigned long* padded
    type = mode & LTC_PAD_MASK;
 
    if (*padded_length < l) {
-      if (type != LTC_PAD_ISO_10126) *padded_length = l;
-      else *padded_length = length + 256;
+      if (type != LTC_PAD_ISO_10126) {
+         *padded_length = l;
+      } else {
+         *padded_length = length + 256;
+      }
       return CRYPT_BUFFER_OVERFLOW;
    }
 

--- a/src/misc/pkcs5/pkcs_5_1.c
+++ b/src/misc/pkcs5/pkcs_5_1.c
@@ -109,19 +109,23 @@ static int _pkcs_5_alg1_common(const unsigned char *password,
          the output buffer (and how many bytes we have to copy) */
       outidx = block*hash_descriptor[hash_idx].hashsize;
       nb = hash_descriptor[hash_idx].hashsize;
-      if(outidx+nb > *outlen)
+      if(outidx+nb > *outlen) {
           nb = *outlen - outidx;
-      if(nb > 0)
+      }
+      if(nb > 0) {
           XMEMCPY(out+outidx, buf, nb);
+      }
 
       block++;
-      if (!openssl_compat)
+      if (!openssl_compat) {
           break;
+      }
    }
    /* In strict mode, we always return the hashsize, in compat we filled it
       as much as was requested, so we leave it alone. */
-   if(!openssl_compat)
+   if(!openssl_compat) {
       *outlen = hash_descriptor[hash_idx].hashsize;
+   }
 
    err = CRYPT_OK;
 LBL_ERR:

--- a/src/modes/cfb/cfb_start.c
+++ b/src/modes/cfb/cfb_start.c
@@ -43,8 +43,9 @@ int cfb_start(int cipher, const unsigned char *IV, const unsigned char *key,
    /* copy data */
    cfb->cipher = cipher;
    cfb->blocklen = cipher_descriptor[cipher].block_length;
-   for (x = 0; x < cfb->blocklen; x++)
+   for (x = 0; x < cfb->blocklen; x++) {
        cfb->IV[x] = IV[x];
+   }
 
    /* init the cipher */
    if ((err = cipher_descriptor[cipher].setup(key, keylen, num_rounds, &cfb->key)) != CRYPT_OK) {

--- a/src/pk/ecc/ltc_ecc_is_point_at_infinity.c
+++ b/src/pk/ecc/ltc_ecc_is_point_at_infinity.c
@@ -44,10 +44,11 @@ int ltc_ecc_is_point_at_infinity(const ecc_point *P, void *modulus, int *retval)
 
    /* test y^2 == x^3 */
    err = CRYPT_OK;
-   if ((mp_cmp(x3, y2) == LTC_MP_EQ) && !mp_iszero(y2))
+   if ((mp_cmp(x3, y2) == LTC_MP_EQ) && !mp_iszero(y2)) {
       *retval = 1;
-   else
+   } else {
       *retval = 0;
+   }
 
 cleanup:
    mp_clear_multi(x3, y2, NULL);

--- a/src/pk/rsa/rsa_export.c
+++ b/src/pk/rsa/rsa_export.c
@@ -87,8 +87,7 @@ int rsa_export(unsigned char *out, unsigned long *outlen, int type, const rsa_ke
         PKA_RSA, tmp, tmplen, LTC_ASN1_NULL, NULL, 0);
 
 finish:
-      if (tmp != out)
-        XFREE(tmp);
+      if (tmp != out) XFREE(tmp);
       return err;
    }
 

--- a/src/pk/rsa/rsa_import.c
+++ b/src/pk/rsa/rsa_import.c
@@ -116,9 +116,9 @@ LBL_ERR:
    mp_clear_multi(key->d,  key->e, key->N, key->dQ, key->dP, key->qP, key->p, key->q, NULL);
 
 LBL_FREE:
-   if (tmpbuf != NULL)
-     XFREE(tmpbuf);
-
+   if (tmpbuf != NULL) {
+      XFREE(tmpbuf);
+   }
    return err;
 }
 

--- a/src/prngs/fortuna.c
+++ b/src/prngs/fortuna.c
@@ -108,11 +108,13 @@ static int _fortuna_reseed(prng_state *prng)
 
 #ifdef LTC_FORTUNA_RESEED_RATELIMIT_TIMED
    ulong64 now = _fortuna_current_time();
-   if (now == prng->u.fortuna.wd)
+   if (now == prng->u.fortuna.wd) {
       return CRYPT_OK;
+   }
 #else
-   if (++prng->u.fortuna.wd < LTC_FORTUNA_WD)
+   if (++prng->u.fortuna.wd < LTC_FORTUNA_WD) {
       return CRYPT_OK;
+   }
 #endif
 
    /* new K == LTC_SHA256(K || s) where s == LTC_SHA256(P0) || LTC_SHA256(P1) ... */

--- a/src/prngs/rng_get_bytes.c
+++ b/src/prngs/rng_get_bytes.c
@@ -30,9 +30,12 @@ static unsigned long _rng_nix(unsigned char *buf, unsigned long len,
     LTC_UNUSED_PARAM(callback);
 #ifdef LTC_TRY_URANDOM_FIRST
     f = fopen("/dev/urandom", "rb");
-    if (f == NULL)
-#endif /* LTC_TRY_URANDOM_FIRST */
+    if (f == NULL) {
        f = fopen("/dev/random", "rb");
+    }
+#else
+    f = fopen("/dev/random", "rb");
+#endif /* LTC_TRY_URANDOM_FIRST */
 
     if (f == NULL) {
        return 0;

--- a/src/stream/rabbit/rabbit.c
+++ b/src/stream/rabbit/rabbit.c
@@ -99,8 +99,9 @@ static LTC_INLINE void _rabbit_next_state(rabbit_ctx *p_instance)
    ulong32 g[8], c_old[8], i;
 
    /* Save old counter values */
-   for (i=0; i<8; i++)
+   for (i=0; i<8; i++) {
       c_old[i] = p_instance->c[i];
+   }
 
    /* Calculate new counter values */
    p_instance->c[0] = (ulong32)(p_instance->c[0] + 0x4D34D34D + p_instance->carry);
@@ -114,8 +115,9 @@ static LTC_INLINE void _rabbit_next_state(rabbit_ctx *p_instance)
    p_instance->carry = (p_instance->c[7] < c_old[7]);
 
    /* Calculate the g-values */
-   for (i=0;i<8;i++)
+   for (i=0;i<8;i++) {
       g[i] = _rabbit_g_func((ulong32)(p_instance->x[i] + p_instance->c[i]));
+   }
 
    /* Calculate new state values */
    p_instance->x[0] = (ulong32)(g[0] + ROLc(g[7],16) + ROLc(g[6], 16));
@@ -198,12 +200,14 @@ int rabbit_setup(rabbit_state* st, const unsigned char *key, unsigned long keyle
    st->master_ctx.carry = 0;
 
    /* Iterate the master context four times */
-   for (i=0; i<4; i++)
+   for (i=0; i<4; i++) {
       _rabbit_next_state(&(st->master_ctx));
+   }
 
    /* Modify the counters */
-   for (i=0; i<8; i++)
+   for (i=0; i<8; i++) {
       st->master_ctx.c[i] ^= st->master_ctx.x[(i+4)&0x7];
+   }
 
    /* Copy master instance to work instance */
    for (i=0; i<8; i++) {
@@ -250,13 +254,15 @@ int rabbit_setiv(rabbit_state* st, const unsigned char *iv, unsigned long ivlen)
    st->work_ctx.c[7] = st->master_ctx.c[7] ^ i3;
 
    /* Copy state variables */
-   for (i=0; i<8; i++)
+   for (i=0; i<8; i++) {
       st->work_ctx.x[i] = st->master_ctx.x[i];
+   }
    st->work_ctx.carry = st->master_ctx.carry;
 
    /* Iterate the work context four times */
-   for (i=0; i<4; i++)
+   for (i=0; i<4; i++) {
       _rabbit_next_state(&(st->work_ctx));
+   }
 
    /* reset keystream buffer and unused count */
    XMEMSET(&(st->block), 0, sizeof(st->block));

--- a/src/stream/sosemanuk/sosemanuk.c
+++ b/src/stream/sosemanuk/sosemanuk.c
@@ -266,8 +266,9 @@ int sosemanuk_setup(sosemanuk_state *ss, const unsigned char *key, unsigned long
     XMEMCPY(wbuf, key, keylen);
     if (keylen < 32) {
         wbuf[keylen] = 0x01;
-        if (keylen < 31)
+        if (keylen < 31) {
             XMEMSET(wbuf + keylen + 1, 0, 31 - keylen);
+        }
     }
 
     LOAD32L(w0, wbuf);
@@ -725,8 +726,9 @@ static LTC_INLINE void _sosemanuk_internal(sosemanuk_state *ss)
 static LTC_INLINE void _xorbuf(const unsigned char *in1, const unsigned char *in2,
     unsigned char *out, unsigned long datalen)
 {
-    while (datalen -- > 0)
+    while (datalen -- > 0) {
         *out ++ = *in1 ++ ^ *in2 ++;
+    }
 }
 
 
@@ -751,8 +753,9 @@ int sosemanuk_crypt(sosemanuk_state *ss,
     if (ss->ptr < (sizeof(ss->buf))) {
         unsigned long rlen = (sizeof(ss->buf)) - ss->ptr;
 
-        if (rlen > inlen)
+        if (rlen > inlen) {
             rlen = inlen;
+        }
         _xorbuf(ss->buf + ss->ptr, in, out, rlen);
         in += rlen;
         out += rlen;


### PR DESCRIPTION
This is the last patch related to my clang-tidy testing. After this patch the script `.ci/clang-tidy.sh` should not throw any warning (at least with clang-tidy 6.0.0).

It is related to `braces-around-statements` for which the clang-tidy has two plugins: `google-readability-braces-around-statements` and `readability-braces-around-statements`.

I have chosen less restrictive `google-readability-braces-around-statements`.

It allows one line statements without braces:

```C
if (something) some_func(1,2,3);
```

But does not allow:

```C
if (something)
   some_func(1,2,3);
```

Which should be rewritten as:

```C
if (something) {
   some_func(1,2,3);
}
```
