### PR TITLE
rename ecc_set_dp >> ecc_set_curve + ecc_get_curve >> ecc_find_curve

### DIFF
--- a/libtomcrypt_VS2008.vcproj
+++ b/libtomcrypt_VS2008.vcproj
@@ -2283,11 +2283,11 @@
 					>
 				</File>
 				<File
-					RelativePath="src\pk\ecc\ecc_free.c"
+					RelativePath="src\pk\ecc\ecc_find_curve.c"
 					>
 				</File>
 				<File
-					RelativePath="src\pk\ecc\ecc_get_curve.c"
+					RelativePath="src\pk\ecc\ecc_free.c"
 					>
 				</File>
 				<File
@@ -2319,11 +2319,11 @@
 					>
 				</File>
 				<File
-					RelativePath="src\pk\ecc\ecc_set_dp.c"
+					RelativePath="src\pk\ecc\ecc_set_curve.c"
 					>
 				</File>
 				<File
-					RelativePath="src\pk\ecc\ecc_set_dp_internal.c"
+					RelativePath="src\pk\ecc\ecc_set_curve_internal.c"
 					>
 				</File>
 				<File

--- a/makefile.mingw
+++ b/makefile.mingw
@@ -177,12 +177,12 @@ src/pk/dsa/dsa_make_key.o src/pk/dsa/dsa_set.o src/pk/dsa/dsa_set_pqg_dsaparam.o
 src/pk/dsa/dsa_shared_secret.o src/pk/dsa/dsa_sign_hash.o src/pk/dsa/dsa_verify_hash.o \
 src/pk/dsa/dsa_verify_key.o src/pk/ecc/ecc.o src/pk/ecc/ecc_ansi_x963_export.o \
 src/pk/ecc/ecc_ansi_x963_import.o src/pk/ecc/ecc_decrypt_key.o src/pk/ecc/ecc_encrypt_key.o \
-src/pk/ecc/ecc_export.o src/pk/ecc/ecc_export_openssl.o src/pk/ecc/ecc_free.o \
-src/pk/ecc/ecc_get_curve.o src/pk/ecc/ecc_get_key.o src/pk/ecc/ecc_get_oid_str.o \
-src/pk/ecc/ecc_get_size.o src/pk/ecc/ecc_import.o src/pk/ecc/ecc_import_openssl.o \
-src/pk/ecc/ecc_import_x509.o src/pk/ecc/ecc_make_key.o src/pk/ecc/ecc_set_dp.o \
-src/pk/ecc/ecc_set_dp_internal.o src/pk/ecc/ecc_set_key.o src/pk/ecc/ecc_shared_secret.o \
-src/pk/ecc/ecc_sign_hash.o src/pk/ecc/ecc_sizes.o src/pk/ecc/ecc_test.o src/pk/ecc/ecc_verify_hash.o \
+src/pk/ecc/ecc_export.o src/pk/ecc/ecc_export_openssl.o src/pk/ecc/ecc_find_curve.o \
+src/pk/ecc/ecc_free.o src/pk/ecc/ecc_get_key.o src/pk/ecc/ecc_get_oid_str.o src/pk/ecc/ecc_get_size.o \
+src/pk/ecc/ecc_import.o src/pk/ecc/ecc_import_openssl.o src/pk/ecc/ecc_import_x509.o \
+src/pk/ecc/ecc_make_key.o src/pk/ecc/ecc_set_curve.o src/pk/ecc/ecc_set_curve_internal.o \
+src/pk/ecc/ecc_set_key.o src/pk/ecc/ecc_shared_secret.o src/pk/ecc/ecc_sign_hash.o \
+src/pk/ecc/ecc_sizes.o src/pk/ecc/ecc_test.o src/pk/ecc/ecc_verify_hash.o \
 src/pk/ecc/ltc_ecc_export_point.o src/pk/ecc/ltc_ecc_import_point.o src/pk/ecc/ltc_ecc_is_point.o \
 src/pk/ecc/ltc_ecc_is_point_at_infinity.o src/pk/ecc/ltc_ecc_map.o src/pk/ecc/ltc_ecc_mul2add.o \
 src/pk/ecc/ltc_ecc_mulmod.o src/pk/ecc/ltc_ecc_mulmod_timing.o src/pk/ecc/ltc_ecc_points.o \

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -170,12 +170,12 @@ src/pk/dsa/dsa_make_key.obj src/pk/dsa/dsa_set.obj src/pk/dsa/dsa_set_pqg_dsapar
 src/pk/dsa/dsa_shared_secret.obj src/pk/dsa/dsa_sign_hash.obj src/pk/dsa/dsa_verify_hash.obj \
 src/pk/dsa/dsa_verify_key.obj src/pk/ecc/ecc.obj src/pk/ecc/ecc_ansi_x963_export.obj \
 src/pk/ecc/ecc_ansi_x963_import.obj src/pk/ecc/ecc_decrypt_key.obj src/pk/ecc/ecc_encrypt_key.obj \
-src/pk/ecc/ecc_export.obj src/pk/ecc/ecc_export_openssl.obj src/pk/ecc/ecc_free.obj \
-src/pk/ecc/ecc_get_curve.obj src/pk/ecc/ecc_get_key.obj src/pk/ecc/ecc_get_oid_str.obj \
-src/pk/ecc/ecc_get_size.obj src/pk/ecc/ecc_import.obj src/pk/ecc/ecc_import_openssl.obj \
-src/pk/ecc/ecc_import_x509.obj src/pk/ecc/ecc_make_key.obj src/pk/ecc/ecc_set_dp.obj \
-src/pk/ecc/ecc_set_dp_internal.obj src/pk/ecc/ecc_set_key.obj src/pk/ecc/ecc_shared_secret.obj \
-src/pk/ecc/ecc_sign_hash.obj src/pk/ecc/ecc_sizes.obj src/pk/ecc/ecc_test.obj src/pk/ecc/ecc_verify_hash.obj \
+src/pk/ecc/ecc_export.obj src/pk/ecc/ecc_export_openssl.obj src/pk/ecc/ecc_find_curve.obj \
+src/pk/ecc/ecc_free.obj src/pk/ecc/ecc_get_key.obj src/pk/ecc/ecc_get_oid_str.obj src/pk/ecc/ecc_get_size.obj \
+src/pk/ecc/ecc_import.obj src/pk/ecc/ecc_import_openssl.obj src/pk/ecc/ecc_import_x509.obj \
+src/pk/ecc/ecc_make_key.obj src/pk/ecc/ecc_set_curve.obj src/pk/ecc/ecc_set_curve_internal.obj \
+src/pk/ecc/ecc_set_key.obj src/pk/ecc/ecc_shared_secret.obj src/pk/ecc/ecc_sign_hash.obj \
+src/pk/ecc/ecc_sizes.obj src/pk/ecc/ecc_test.obj src/pk/ecc/ecc_verify_hash.obj \
 src/pk/ecc/ltc_ecc_export_point.obj src/pk/ecc/ltc_ecc_import_point.obj src/pk/ecc/ltc_ecc_is_point.obj \
 src/pk/ecc/ltc_ecc_is_point_at_infinity.obj src/pk/ecc/ltc_ecc_map.obj src/pk/ecc/ltc_ecc_mul2add.obj \
 src/pk/ecc/ltc_ecc_mulmod.obj src/pk/ecc/ltc_ecc_mulmod_timing.obj src/pk/ecc/ltc_ecc_points.obj \

--- a/makefile.unix
+++ b/makefile.unix
@@ -187,12 +187,12 @@ src/pk/dsa/dsa_make_key.o src/pk/dsa/dsa_set.o src/pk/dsa/dsa_set_pqg_dsaparam.o
 src/pk/dsa/dsa_shared_secret.o src/pk/dsa/dsa_sign_hash.o src/pk/dsa/dsa_verify_hash.o \
 src/pk/dsa/dsa_verify_key.o src/pk/ecc/ecc.o src/pk/ecc/ecc_ansi_x963_export.o \
 src/pk/ecc/ecc_ansi_x963_import.o src/pk/ecc/ecc_decrypt_key.o src/pk/ecc/ecc_encrypt_key.o \
-src/pk/ecc/ecc_export.o src/pk/ecc/ecc_export_openssl.o src/pk/ecc/ecc_free.o \
-src/pk/ecc/ecc_get_curve.o src/pk/ecc/ecc_get_key.o src/pk/ecc/ecc_get_oid_str.o \
-src/pk/ecc/ecc_get_size.o src/pk/ecc/ecc_import.o src/pk/ecc/ecc_import_openssl.o \
-src/pk/ecc/ecc_import_x509.o src/pk/ecc/ecc_make_key.o src/pk/ecc/ecc_set_dp.o \
-src/pk/ecc/ecc_set_dp_internal.o src/pk/ecc/ecc_set_key.o src/pk/ecc/ecc_shared_secret.o \
-src/pk/ecc/ecc_sign_hash.o src/pk/ecc/ecc_sizes.o src/pk/ecc/ecc_test.o src/pk/ecc/ecc_verify_hash.o \
+src/pk/ecc/ecc_export.o src/pk/ecc/ecc_export_openssl.o src/pk/ecc/ecc_find_curve.o \
+src/pk/ecc/ecc_free.o src/pk/ecc/ecc_get_key.o src/pk/ecc/ecc_get_oid_str.o src/pk/ecc/ecc_get_size.o \
+src/pk/ecc/ecc_import.o src/pk/ecc/ecc_import_openssl.o src/pk/ecc/ecc_import_x509.o \
+src/pk/ecc/ecc_make_key.o src/pk/ecc/ecc_set_curve.o src/pk/ecc/ecc_set_curve_internal.o \
+src/pk/ecc/ecc_set_key.o src/pk/ecc/ecc_shared_secret.o src/pk/ecc/ecc_sign_hash.o \
+src/pk/ecc/ecc_sizes.o src/pk/ecc/ecc_test.o src/pk/ecc/ecc_verify_hash.o \
 src/pk/ecc/ltc_ecc_export_point.o src/pk/ecc/ltc_ecc_import_point.o src/pk/ecc/ltc_ecc_is_point.o \
 src/pk/ecc/ltc_ecc_is_point_at_infinity.o src/pk/ecc/ltc_ecc_map.o src/pk/ecc/ltc_ecc_mul2add.o \
 src/pk/ecc/ltc_ecc_mulmod.o src/pk/ecc/ltc_ecc_mulmod_timing.o src/pk/ecc/ltc_ecc_points.o \

--- a/makefile_include.mk
+++ b/makefile_include.mk
@@ -347,12 +347,12 @@ src/pk/dsa/dsa_make_key.o src/pk/dsa/dsa_set.o src/pk/dsa/dsa_set_pqg_dsaparam.o
 src/pk/dsa/dsa_shared_secret.o src/pk/dsa/dsa_sign_hash.o src/pk/dsa/dsa_verify_hash.o \
 src/pk/dsa/dsa_verify_key.o src/pk/ecc/ecc.o src/pk/ecc/ecc_ansi_x963_export.o \
 src/pk/ecc/ecc_ansi_x963_import.o src/pk/ecc/ecc_decrypt_key.o src/pk/ecc/ecc_encrypt_key.o \
-src/pk/ecc/ecc_export.o src/pk/ecc/ecc_export_openssl.o src/pk/ecc/ecc_free.o \
-src/pk/ecc/ecc_get_curve.o src/pk/ecc/ecc_get_key.o src/pk/ecc/ecc_get_oid_str.o \
-src/pk/ecc/ecc_get_size.o src/pk/ecc/ecc_import.o src/pk/ecc/ecc_import_openssl.o \
-src/pk/ecc/ecc_import_x509.o src/pk/ecc/ecc_make_key.o src/pk/ecc/ecc_set_dp.o \
-src/pk/ecc/ecc_set_dp_internal.o src/pk/ecc/ecc_set_key.o src/pk/ecc/ecc_shared_secret.o \
-src/pk/ecc/ecc_sign_hash.o src/pk/ecc/ecc_sizes.o src/pk/ecc/ecc_test.o src/pk/ecc/ecc_verify_hash.o \
+src/pk/ecc/ecc_export.o src/pk/ecc/ecc_export_openssl.o src/pk/ecc/ecc_find_curve.o \
+src/pk/ecc/ecc_free.o src/pk/ecc/ecc_get_key.o src/pk/ecc/ecc_get_oid_str.o src/pk/ecc/ecc_get_size.o \
+src/pk/ecc/ecc_import.o src/pk/ecc/ecc_import_openssl.o src/pk/ecc/ecc_import_x509.o \
+src/pk/ecc/ecc_make_key.o src/pk/ecc/ecc_set_curve.o src/pk/ecc/ecc_set_curve_internal.o \
+src/pk/ecc/ecc_set_key.o src/pk/ecc/ecc_shared_secret.o src/pk/ecc/ecc_sign_hash.o \
+src/pk/ecc/ecc_sizes.o src/pk/ecc/ecc_test.o src/pk/ecc/ecc_verify_hash.o \
 src/pk/ecc/ltc_ecc_export_point.o src/pk/ecc/ltc_ecc_import_point.o src/pk/ecc/ltc_ecc_is_point.o \
 src/pk/ecc/ltc_ecc_is_point_at_infinity.o src/pk/ecc/ltc_ecc_map.o src/pk/ecc/ltc_ecc_mul2add.o \
 src/pk/ecc/ltc_ecc_mulmod.o src/pk/ecc/ltc_ecc_mulmod_timing.o src/pk/ecc/ltc_ecc_points.o \

--- a/src/headers/tomcrypt_pk.h
+++ b/src/headers/tomcrypt_pk.h
@@ -251,7 +251,7 @@ int  ecc_test(void);
 void ecc_sizes(int *low, int *high);
 int  ecc_get_size(const ecc_key *key);
 
-int  ecc_get_curve(const char* name_or_oid, const ltc_ecc_curve** cu);
+int  ecc_find_curve(const char* name_or_oid, const ltc_ecc_curve** cu);
 int  ecc_set_curve(const ltc_ecc_curve *cu, ecc_key *key);
 int  ecc_generate_key(prng_state *prng, int wprng, ecc_key *key);
 int  ecc_set_key(const unsigned char *in, unsigned long inlen, int type, ecc_key *key);

--- a/src/headers/tomcrypt_pk.h
+++ b/src/headers/tomcrypt_pk.h
@@ -252,7 +252,7 @@ void ecc_sizes(int *low, int *high);
 int  ecc_get_size(const ecc_key *key);
 
 int  ecc_get_curve(const char* name_or_oid, const ltc_ecc_curve** cu);
-int  ecc_set_dp(const ltc_ecc_curve *cu, ecc_key *key);
+int  ecc_set_curve(const ltc_ecc_curve *cu, ecc_key *key);
 int  ecc_generate_key(prng_state *prng, int wprng, ecc_key *key);
 int  ecc_set_key(const unsigned char *in, unsigned long inlen, int type, ecc_key *key);
 int  ecc_get_key(unsigned char *out, unsigned long *outlen, int type, const ecc_key *key);

--- a/src/headers/tomcrypt_private.h
+++ b/src/headers/tomcrypt_private.h
@@ -192,9 +192,9 @@ int dh_check_pubkey(const dh_key *key);
 
 /* ---- ECC Routines ---- */
 #ifdef LTC_MECC
-int ecc_set_dp_from_mpis(void *a, void *b, void *prime, void *order, void *gx, void *gy, unsigned long cofactor, ecc_key *key);
-int ecc_copy_dp(const ecc_key *srckey, ecc_key *key);
-int ecc_set_dp_by_size(int size, ecc_key *key);
+int ecc_set_curve_from_mpis(void *a, void *b, void *prime, void *order, void *gx, void *gy, unsigned long cofactor, ecc_key *key);
+int ecc_copy_curve(const ecc_key *srckey, ecc_key *key);
+int ecc_set_curve_by_size(int size, ecc_key *key);
 int ecc_import_subject_public_key_info(const unsigned char *in, unsigned long inlen, ecc_key *key);
 
 /* low level functions */

--- a/src/pk/ecc/ecc_ansi_x963_import.c
+++ b/src/pk/ecc/ecc_ansi_x963_import.c
@@ -41,11 +41,11 @@ int ecc_ansi_x963_import_ex(const unsigned char *in, unsigned long inlen, ecc_ke
    /* initialize key->dp */
    if (cu == NULL) {
       /* this case works only for uncompressed public keys  */
-      if ((err = ecc_set_dp_by_size((inlen-1)>>1, key)) != CRYPT_OK)                { return err; }
+      if ((err = ecc_set_curve_by_size((inlen-1)>>1, key)) != CRYPT_OK)             { return err; }
    }
    else {
       /* this one works for both compressed / uncompressed pubkeys */
-      if ((err = ecc_set_dp(cu, key)) != CRYPT_OK)                                  { return err; }
+      if ((err = ecc_set_curve(cu, key)) != CRYPT_OK)                               { return err; }
    }
 
    /* load public key */

--- a/src/pk/ecc/ecc_decrypt_key.c
+++ b/src/pk/ecc/ecc_decrypt_key.c
@@ -85,7 +85,7 @@ int ecc_decrypt_key(const unsigned char *in,  unsigned long  inlen,
    }
 
    /* import ECC key from packet */
-   if ((err = ecc_copy_dp(key, &pubkey)) != CRYPT_OK) { goto LBL_ERR; }
+   if ((err = ecc_copy_curve(key, &pubkey)) != CRYPT_OK) { goto LBL_ERR; }
    if ((err = ecc_set_key(decode[1].data, decode[1].size, PK_PUBLIC, &pubkey)) != CRYPT_OK) { goto LBL_ERR; }
 
    /* make shared key */

--- a/src/pk/ecc/ecc_encrypt_key.c
+++ b/src/pk/ecc/ecc_encrypt_key.c
@@ -52,7 +52,7 @@ int ecc_encrypt_key(const unsigned char *in,   unsigned long inlen,
     }
 
     /* make a random key and export the public copy */
-    if ((err = ecc_copy_dp(key, &pubkey)) != CRYPT_OK) { return err; }
+    if ((err = ecc_copy_curve(key, &pubkey)) != CRYPT_OK) { return err; }
     if ((err = ecc_generate_key(prng, wprng, &pubkey)) != CRYPT_OK) { return err; }
 
     pub_expt   = XMALLOC(ECC_BUF_SIZE);

--- a/src/pk/ecc/ecc_find_curve.c
+++ b/src/pk/ecc/ecc_find_curve.c
@@ -212,7 +212,7 @@ static int _name_match(const char *left, const char *right)
    return 0;
 }
 
-int ecc_get_curve(const char *name_or_oid, const ltc_ecc_curve **cu)
+int ecc_find_curve(const char *name_or_oid, const ltc_ecc_curve **cu)
 {
    int i, j;
    const char *OID = NULL;

--- a/src/pk/ecc/ecc_import.c
+++ b/src/pk/ecc/ecc_import.c
@@ -56,9 +56,9 @@ int ecc_import_ex(const unsigned char *in, unsigned long inlen, ecc_key *key, co
 
    /* allocate & initialize the key */
    if (cu == NULL) {
-      if ((err = ecc_set_dp_by_size(key_size, key)) != CRYPT_OK) { goto done; }
+      if ((err = ecc_set_curve_by_size(key_size, key)) != CRYPT_OK) { goto done; }
    } else {
-      if ((err = ecc_set_dp(cu, key)) != CRYPT_OK)               { goto done; }
+      if ((err = ecc_set_curve(cu, key)) != CRYPT_OK)               { goto done; }
    }
 
    if (flags[0] == 1) {

--- a/src/pk/ecc/ecc_import_openssl.c
+++ b/src/pk/ecc/ecc_import_openssl.c
@@ -37,7 +37,7 @@ static int _ecc_import_private_with_oid(const unsigned char *in, unsigned long i
       len = sizeof(OID);
       if ((err = pk_oid_num_to_str(curveoid, custom[0].size, OID, &len)) != CRYPT_OK) { goto error; }
       if ((err = ecc_get_curve(OID, &curve)) != CRYPT_OK)                             { goto error; }
-      if ((err = ecc_set_dp(curve, key)) != CRYPT_OK)                                 { goto error; }
+      if ((err = ecc_set_curve(curve, key)) != CRYPT_OK)                              { goto error; }
       /* load private+public key */
       err = ecc_set_key(bin_k, seq_priv[1].size, PK_PRIVATE, key);
    }
@@ -96,7 +96,7 @@ static int _ecc_import_private_with_curve(const unsigned char *in, unsigned long
       if ((err = mp_read_unsigned_bin(b, bin_b, len_b)) != CRYPT_OK)                           { goto error; }
       if ((err = ltc_ecc_import_point(bin_g, len_g, prime, a, b, gx, gy)) != CRYPT_OK)         { goto error; }
       /* load curve parameters */
-      if ((err = ecc_set_dp_from_mpis(a, b, prime, order, gx, gy, cofactor, key)) != CRYPT_OK) { goto error; }
+      if ((err = ecc_set_curve_from_mpis(a, b, prime, order, gx, gy, cofactor, key)) != CRYPT_OK) { goto error; }
       /* load private+public key */
       err = ecc_set_key(bin_k, len_k, PK_PRIVATE, key);
    }

--- a/src/pk/ecc/ecc_import_openssl.c
+++ b/src/pk/ecc/ecc_import_openssl.c
@@ -36,7 +36,7 @@ static int _ecc_import_private_with_oid(const unsigned char *in, unsigned long i
       /* load curve parameters for given curve OID */
       len = sizeof(OID);
       if ((err = pk_oid_num_to_str(curveoid, custom[0].size, OID, &len)) != CRYPT_OK) { goto error; }
-      if ((err = ecc_get_curve(OID, &curve)) != CRYPT_OK)                             { goto error; }
+      if ((err = ecc_find_curve(OID, &curve)) != CRYPT_OK)                            { goto error; }
       if ((err = ecc_set_curve(curve, key)) != CRYPT_OK)                              { goto error; }
       /* load private+public key */
       err = ecc_set_key(bin_k, seq_priv[1].size, PK_PRIVATE, key);

--- a/src/pk/ecc/ecc_import_x509.c
+++ b/src/pk/ecc/ecc_import_x509.c
@@ -27,7 +27,7 @@ static int _ecc_import_x509_with_oid(const unsigned char *in, unsigned long inle
       /* load curve parameters for given curve OID */
       len = sizeof(OID);
       if ((err = pk_oid_num_to_str(curveoid, len_oid, OID, &len)) != CRYPT_OK) { goto error; }
-      if ((err = ecc_get_curve(OID, &curve)) != CRYPT_OK)                      { goto error; }
+      if ((err = ecc_find_curve(OID, &curve)) != CRYPT_OK)                     { goto error; }
       if ((err = ecc_set_curve(curve, key)) != CRYPT_OK)                       { goto error; }
       /* load public key */
       err = ecc_set_key(bin_xy, len_xy, PK_PUBLIC, key);

--- a/src/pk/ecc/ecc_import_x509.c
+++ b/src/pk/ecc/ecc_import_x509.c
@@ -28,7 +28,7 @@ static int _ecc_import_x509_with_oid(const unsigned char *in, unsigned long inle
       len = sizeof(OID);
       if ((err = pk_oid_num_to_str(curveoid, len_oid, OID, &len)) != CRYPT_OK) { goto error; }
       if ((err = ecc_get_curve(OID, &curve)) != CRYPT_OK)                      { goto error; }
-      if ((err = ecc_set_dp(curve, key)) != CRYPT_OK)                          { goto error; }
+      if ((err = ecc_set_curve(curve, key)) != CRYPT_OK)                       { goto error; }
       /* load public key */
       err = ecc_set_key(bin_xy, len_xy, PK_PUBLIC, key);
    }
@@ -80,7 +80,7 @@ static int _ecc_import_x509_with_curve(const unsigned char *in, unsigned long in
       if ((err = mp_read_unsigned_bin(b, bin_b, len_b)) != CRYPT_OK)                           { goto error; }
       if ((err = ltc_ecc_import_point(bin_g, len_g, prime, a, b, gx, gy)) != CRYPT_OK)         { goto error; }
       /* load curve parameters */
-      if ((err = ecc_set_dp_from_mpis(a, b, prime, order, gx, gy, cofactor, key)) != CRYPT_OK) { goto error; }
+      if ((err = ecc_set_curve_from_mpis(a, b, prime, order, gx, gy, cofactor, key)) != CRYPT_OK) { goto error; }
       /* load public key */
       err = ecc_set_key(bin_xy, len_xy, PK_PUBLIC, key);
    }

--- a/src/pk/ecc/ecc_make_key.c
+++ b/src/pk/ecc/ecc_make_key.c
@@ -28,15 +28,15 @@ int ecc_make_key(prng_state *prng, int wprng, int keysize, ecc_key *key)
 {
    int err;
 
-   if ((err = ecc_set_dp_by_size(keysize, key)) != CRYPT_OK)   { return err; }
-   if ((err = ecc_generate_key(prng, wprng, key)) != CRYPT_OK) { return err; }
+   if ((err = ecc_set_curve_by_size(keysize, key)) != CRYPT_OK) { return err; }
+   if ((err = ecc_generate_key(prng, wprng, key)) != CRYPT_OK)  { return err; }
    return CRYPT_OK;
 }
 
 int ecc_make_key_ex(prng_state *prng, int wprng, ecc_key *key, const ltc_ecc_curve *cu)
 {
    int err;
-   if ((err = ecc_set_dp(cu, key)) != CRYPT_OK)                { return err; }
+   if ((err = ecc_set_curve(cu, key)) != CRYPT_OK)             { return err; }
    if ((err = ecc_generate_key(prng, wprng, key)) != CRYPT_OK) { return err; }
    return CRYPT_OK;
 }

--- a/src/pk/ecc/ecc_set_curve.c
+++ b/src/pk/ecc/ecc_set_curve.c
@@ -11,7 +11,7 @@
 
 #ifdef LTC_MECC
 
-int ecc_set_dp(const ltc_ecc_curve *cu, ecc_key *key)
+int ecc_set_curve(const ltc_ecc_curve *cu, ecc_key *key)
 {
    int err;
 
@@ -47,7 +47,7 @@ error:
    return err;
 }
 
-int ecc_set_dp_by_size(int size, ecc_key *key)
+int ecc_set_curve_by_size(int size, ecc_key *key)
 {
    const ltc_ecc_curve *cu = NULL;
    int err = CRYPT_ERROR;
@@ -78,7 +78,7 @@ int ecc_set_dp_by_size(int size, ecc_key *key)
       err = ecc_get_curve("SECP521R1", &cu);
    }
 
-   if (err == CRYPT_OK && cu != NULL) return ecc_set_dp(cu, key);
+   if (err == CRYPT_OK && cu != NULL) return ecc_set_curve(cu, key);
 
    return CRYPT_INVALID_ARG;
 }

--- a/src/pk/ecc/ecc_set_curve.c
+++ b/src/pk/ecc/ecc_set_curve.c
@@ -54,28 +54,28 @@ int ecc_set_curve_by_size(int size, ecc_key *key)
 
    /* for compatibility with libtomcrypt-1.17 the sizes below must match the specific curves */
    if (size <= 14) {
-      err = ecc_get_curve("SECP112R1", &cu);
+      err = ecc_find_curve("SECP112R1", &cu);
    }
    else if (size <= 16) {
-      err = ecc_get_curve("SECP128R1", &cu);
+      err = ecc_find_curve("SECP128R1", &cu);
    }
    else if (size <= 20) {
-      err = ecc_get_curve("SECP160R1", &cu);
+      err = ecc_find_curve("SECP160R1", &cu);
    }
    else if (size <= 24) {
-      err = ecc_get_curve("SECP192R1", &cu);
+      err = ecc_find_curve("SECP192R1", &cu);
    }
    else if (size <= 28) {
-      err = ecc_get_curve("SECP224R1", &cu);
+      err = ecc_find_curve("SECP224R1", &cu);
    }
    else if (size <= 32) {
-      err = ecc_get_curve("SECP256R1", &cu);
+      err = ecc_find_curve("SECP256R1", &cu);
    }
    else if (size <= 48) {
-      err = ecc_get_curve("SECP384R1", &cu);
+      err = ecc_find_curve("SECP384R1", &cu);
    }
    else if (size <= 66) {
-      err = ecc_get_curve("SECP521R1", &cu);
+      err = ecc_find_curve("SECP521R1", &cu);
    }
 
    if (err == CRYPT_OK && cu != NULL) return ecc_set_curve(cu, key);

--- a/src/pk/ecc/ecc_set_curve_internal.c
+++ b/src/pk/ecc/ecc_set_curve_internal.c
@@ -42,7 +42,7 @@ static void _ecc_oid_lookup(ecc_key *key)
    }
 }
 
-int ecc_copy_dp(const ecc_key *srckey, ecc_key *key)
+int ecc_copy_curve(const ecc_key *srckey, ecc_key *key)
 {
    unsigned long i;
    int err;
@@ -82,7 +82,7 @@ error:
    return err;
 }
 
-int ecc_set_dp_from_mpis(void *a, void *b, void *prime, void *order, void *gx, void *gy, unsigned long cofactor, ecc_key *key)
+int ecc_set_curve_from_mpis(void *a, void *b, void *prime, void *order, void *gx, void *gy, unsigned long cofactor, ecc_key *key)
 {
    int err;
 

--- a/src/pk/ecc/ecc_sign_hash.c
+++ b/src/pk/ecc/ecc_sign_hash.c
@@ -63,7 +63,7 @@ static int _ecc_sign_hash(const unsigned char *in,  unsigned long inlen,
 
    /* make up a key and export the public copy */
    do {
-      if ((err = ecc_copy_dp(key, &pubkey)) != CRYPT_OK)                   { goto errnokey; }
+      if ((err = ecc_copy_curve(key, &pubkey)) != CRYPT_OK)                { goto errnokey; }
       if ((err = ecc_generate_key(prng, wprng, &pubkey)) != CRYPT_OK)      { goto errnokey; }
 
       /* find r = x1 mod n */

--- a/tests/ecc_test.c
+++ b/tests/ecc_test.c
@@ -130,7 +130,7 @@ static int _ecc_issue108(void)
    Result = ltc_ecc_new_point();
 
    /* ECC-224 AKA SECP224R1 */
-   if ((err = ecc_get_curve("SECP224R1", &dp)) != CRYPT_OK)               { goto done; }
+   if ((err = ecc_find_curve("SECP224R1", &dp)) != CRYPT_OK)              { goto done; }
    /* read A */
    if ((err = mp_read_radix(a, (char *)dp->A,  16)) != CRYPT_OK)          { goto done; }
    /* read modulus */
@@ -446,7 +446,7 @@ int _ecc_new_api(void)
    unsigned long len16;
 
    for (i = 0; i < (int)(sizeof(names)/sizeof(names[0])); i++) {
-      DO(ecc_get_curve(names[i], &dp));
+      DO(ecc_find_curve(names[i], &dp));
       /* make new key */
       DO(ecc_make_key_ex(&yarrow_prng, find_prng ("yarrow"), &key, dp));
       len = sizeof(buf);
@@ -798,7 +798,7 @@ int _ecc_import_export(void) {
 
    DO(ecc_import_openssl(short_pub, sizeof(short_pub), &pub));
    DO(ecc_import_openssl(short_pri, sizeof(short_pri), &pri));
-   DO(ecc_get_curve("SECP256K1", &cu));
+   DO(ecc_find_curve("SECP256K1", &cu));
 
    /* import - raw keys */
    DO(ecc_set_curve(cu, &key));

--- a/tests/ecc_test.c
+++ b/tests/ecc_test.c
@@ -464,14 +464,14 @@ int _ecc_new_api(void)
       ecc_free(&pubkey);
 
       /* generate new key */
-      DO(ecc_set_dp(dp, &key));
+      DO(ecc_set_curve(dp, &key));
       DO(ecc_generate_key(&yarrow_prng, find_prng ("yarrow"), &key));
       len = sizeof(buf);
       DO(ecc_get_key(buf, &len, PK_PRIVATE, &key));
       ecc_free(&key);
 
       /* load exported private key */
-      DO(ecc_set_dp(dp, &privkey));
+      DO(ecc_set_curve(dp, &privkey));
       DO(ecc_set_key(buf, len, PK_PRIVATE, &privkey));
 
 #ifndef USE_TFM
@@ -481,7 +481,7 @@ int _ecc_new_api(void)
       DO(ecc_get_key(buf, &len, PK_PUBLIC|PK_COMPRESSED, &privkey));
       if (len != 1 + (unsigned)ecc_get_size(&privkey)) return CRYPT_FAIL_TESTVECTOR;
       /* load exported public+compressed key */
-      DO(ecc_set_dp(dp, &pubkey));
+      DO(ecc_set_curve(dp, &pubkey));
       DO(ecc_set_key(buf, len, PK_PUBLIC, &pubkey));
       ecc_free(&pubkey);
 #endif
@@ -491,7 +491,7 @@ int _ecc_new_api(void)
       DO(ecc_get_key(buf, &len, PK_PUBLIC, &privkey));
       if (len != 1 + 2 * (unsigned)ecc_get_size(&privkey)) return CRYPT_FAIL_TESTVECTOR;
       /* load exported public key */
-      DO(ecc_set_dp(dp, &pubkey));
+      DO(ecc_set_curve(dp, &pubkey));
       DO(ecc_set_key(buf, len, PK_PUBLIC, &pubkey));
 
       /* test signature */
@@ -801,15 +801,15 @@ int _ecc_import_export(void) {
    DO(ecc_get_curve("SECP256K1", &cu));
 
    /* import - raw keys */
-   DO(ecc_set_dp(cu, &key));
+   DO(ecc_set_curve(cu, &key));
    DO(ecc_set_key(raw_pri, sizeof(raw_pri),  PK_PRIVATE, &key));
    DO(_ecc_key_cmp(PK_PRIVATE, &pri, &key));
    ecc_free(&key);
-   DO(ecc_set_dp(cu, &key));
+   DO(ecc_set_curve(cu, &key));
    DO(ecc_set_key(raw_pub, sizeof(raw_pub),  PK_PUBLIC,  &key));
    DO(_ecc_key_cmp(PK_PUBLIC, &pub, &key));
    ecc_free(&key);
-   DO(ecc_set_dp(cu, &key));
+   DO(ecc_set_curve(cu, &key));
    DO(ecc_set_key(raw_pubc, sizeof(raw_pubc), PK_PUBLIC,  &key));
    DO(_ecc_key_cmp(PK_PUBLIC, &pub, &key));
    ecc_free(&key);


### PR DESCRIPTION
as discussed in #393 

Now we have similarly named:
* `int  ecc_get_curve(const char* name_or_oid, const ltc_ecc_curve** cu);`
* `int  ecc_set_curve(const ltc_ecc_curve *cu, ecc_key *key);`

I am not sure whether `ecc_get_curve` is proper here, maybe `ecc_find_curve` would be better?
