### PR TITLE
Fix OID issues

### DIFF
--- a/src/pk/asn1/der/object_identifier/der_decode_object_identifier.c
+++ b/src/pk/asn1/der/object_identifier/der_decode_object_identifier.c
@@ -71,8 +71,13 @@ int der_decode_object_identifier(const unsigned char *in,    unsigned long  inle
             y++;
          } else {
             if (y == 0) {
-               words[0] = t / 40;
-               words[1] = t % 40;
+               if (t <= 79) {
+                  words[0] = t / 40;
+                  words[1] = t % 40;
+               } else {
+                  words[0] = 2;
+                  words[1] = t - 80;
+               }
                y = 2;
             } else {
                words[y++] = t;

--- a/src/pk/asn1/der/object_identifier/der_length_object_identifier.c
+++ b/src/pk/asn1/der/object_identifier/der_length_object_identifier.c
@@ -48,8 +48,8 @@ int der_length_object_identifier(const unsigned long *words, unsigned long nword
       return CRYPT_INVALID_ARG;
    }
 
-   /* word1 = 0,1,2,3 and word2 0..39 */
-   if (words[0] > 3 || (words[0] < 2 && words[1] > 39)) {
+   /* word1 = 0,1,2 and word2 0..39 */
+   if (words[0] > 2 || (words[0] < 2 && words[1] > 39)) {
       return CRYPT_INVALID_ARG;
    }
 

--- a/tests/der_test.c
+++ b/tests/der_test.c
@@ -676,7 +676,7 @@ static void der_set_test(void)
 static void _der_oid_test(void)
 {
    static const unsigned char oid_x690_8_19_5_example[] = { 0x06, 0x03, 0x88, 0x37, 0x03 };
-   unsigned long len;
+   unsigned long len, oid[3];
    unsigned char buf[64];
 
    ltc_asn1_list *decoded_list, static_list[1];
@@ -691,6 +691,14 @@ static void _der_oid_test(void)
 
    DO(do_compare_testvector(buf, len, oid_x690_8_19_5_example, sizeof(oid_x690_8_19_5_example), "OID X6.90 Ch. 8.19.5 Example", 0));
 
+   oid[0] = 3;
+   oid[1] = 4;
+   oid[2] = 5;
+
+   len = sizeof(buf);
+   SHOULD_FAIL(der_encode_object_identifier(oid, 3, buf, &len));
+   len = sizeof(buf);
+   SHOULD_FAIL(der_length_object_identifier(oid, 3, &len));
 }
 
 static void der_flexi_test(void)

--- a/tests/der_test.c
+++ b/tests/der_test.c
@@ -673,6 +673,26 @@ static void der_set_test(void)
 
 */
 
+static void _der_oid_test(void)
+{
+   static const unsigned char oid_x690_8_19_5_example[] = { 0x06, 0x03, 0x88, 0x37, 0x03 };
+   unsigned long len;
+   unsigned char buf[64];
+
+   ltc_asn1_list *decoded_list, static_list[1];
+
+   len = sizeof(oid_x690_8_19_5_example);
+   DO(der_decode_sequence_flexi(oid_x690_8_19_5_example, &len, &decoded_list));
+
+   LTC_SET_ASN1(static_list, 0, LTC_ASN1_OBJECT_IDENTIFIER, (void *)decoded_list->data, decoded_list->size);
+   len = sizeof(buf);
+   DO(der_encode_object_identifier(decoded_list->data, decoded_list->size, buf, &len));
+   der_sequence_free(decoded_list);
+
+   DO(do_compare_testvector(buf, len, oid_x690_8_19_5_example, sizeof(oid_x690_8_19_5_example), "OID X6.90 Ch. 8.19.5 Example", 0));
+
+}
+
 static void der_flexi_test(void)
 {
    static const char printable_str[]    = "printable";
@@ -1588,6 +1608,8 @@ int der_test(void)
    der_toolong_test();
 
    der_cacert_test();
+
+   _der_oid_test();
 
    y = 0xffffff00;
 #if ULONG_MAX == ULLONG_MAX


### PR DESCRIPTION
This fixes 

1. the decoding of OID's in the root-node `2`
2. the possibility to encode OID's with a root-node of `3`
