### PR TITLE
Streams - add single call crypt functions

### DIFF
--- a/doc/crypt.tex
+++ b/doc/crypt.tex
@@ -1301,6 +1301,12 @@ At the end you have to terminate the state:
 err = chacha_done(&st);
 \end{verbatim}
 
+To encrypt plaintext (or decrypt ciphertext) using ChaCha for data already in
+memory with a single function call, the following function may be used.
+\begin{verbatim}
+err = chacha_memory(key, keylen, iv, ivlen, datain, datalen, rounds, dataout);
+\end{verbatim}
+
 \mysection{Salsa20 and XSalsa20}
 
 \textit{Salsa20} was Daniel Bernstein's submission to the EU eSTREAM
@@ -1359,6 +1365,18 @@ err = salsa20_keystream(&st, out_buffer, out_len);
 Finally, when finished you should wipe the state.
 \begin{verbatim}
 err = salsa20_done(&st);
+\end{verbatim}
+
+To encrypt plaintext (or decrypt ciphertext) using Salsa20 for data already in
+memory with a single function call, the following function may be used.
+\begin{verbatim}
+err = salsa20_memory(key, keylen, iv, ivlen, datain, datalen, rounds, dataout);
+\end{verbatim}
+
+To encrypt plaintext (or decrypt ciphertext) using XSalsa20 for data already in
+memory with a single function call, the following function may be used.
+\begin{verbatim}
+err = xsalsa20_memory(key, keylen, nonce, nonce_len, datain, datalen, rounds, dataout);
 \end{verbatim}
 
 For both \textit{Salsa20} and \textit{XSalsa20} rounds must be an even number
@@ -1427,6 +1445,12 @@ To do multiple encryptions and decryptions with the same key, you will want to s
 you do not need to re-run \textit{sosemanuk\_setup()} again, unless of course, you called
 \textit{sosemanuk\_done()}.
 
+To encrypt plaintext (or decrypt ciphertext) using Sosemanuk for data already in
+memory with a single function call, the following function may be used.
+\begin{verbatim}
+err = sosemanuk_memory(key, keylen, iv, ivlen, datain, datalen, dataout);
+\end{verbatim}
+
 \mysection{Rabbit}
 
 \textit{Rabbit}, along with Salsa20, Sosemanuk, and HC-128, was named one of the winners
@@ -1482,6 +1506,12 @@ using \textit{rabbit\_setiv()} if you saved the state and did not wipe it with \
 You will want to use a different IV but you do not need to call \textit{rabbit\_setup()} a 2nd time,
 unless of course, you skipped calling \textit{rabbit\_setiv()}.
 
+To encrypt plaintext (or decrypt ciphertext) using Rabbit for data already in
+memory with a single function call, the following function may be used.
+\begin{verbatim}
+err = rabbit_memory(key, keylen, iv, ivlen, datain, datalen, dataout);
+\end{verbatim}
+
 For more information, see: \newline
 \hspace{4em}- \url{http://www.ecrypt.eu.org/stream/p3ciphers/rabbit/rabbit_p3.pdf} \newline
 \hspace{4em}- \url{https://tools.ietf.org/html/rfc4503}
@@ -1515,6 +1545,12 @@ At the end you have to terminate the state:
 err = rc4_stream_done(&st);
 \end{verbatim}
 
+To encrypt plaintext (or decrypt ciphertext) using RC6 for data already in
+memory with a single function call, the following function may be used.
+\begin{verbatim}
+err = rc4_stream_memory(key, keylen, datain, datalen, dataout);
+\end{verbatim}
+
 \mysection{Sober128}
 
 Supported key size: must be multiple of 4 bytes
@@ -1540,6 +1576,12 @@ err = sober128_stream_keystream(&st, out_buffer, out_len);
 At the end you have to terminate the state:
 \begin{verbatim}
 err = sober128_stream_done(&st);
+\end{verbatim}
+
+To encrypt plaintext (or decrypt ciphertext) using Sober128 for data already in
+memory with a single function call, the following function may be used.
+\begin{verbatim}
+err = sober128_stream_memory(key, keylen, iv, ivlen, datain, datalen, dataout);
 \end{verbatim}
 
 \chapter{Authenticated Encryption}

--- a/libtomcrypt_VS2008.vcproj
+++ b/libtomcrypt_VS2008.vcproj
@@ -2583,6 +2583,10 @@
 					>
 				</File>
 				<File
+					RelativePath="src\stream\chacha\chacha_memory.c"
+					>
+				</File>
+				<File
 					RelativePath="src\stream\chacha\chacha_setup.c"
 					>
 				</File>
@@ -2598,12 +2602,20 @@
 					RelativePath="src\stream\rabbit\rabbit.c"
 					>
 				</File>
+				<File
+					RelativePath="src\stream\rabbit\rabbit_memory.c"
+					>
+				</File>
 			</Filter>
 			<Filter
 				Name="rc4"
 				>
 				<File
 					RelativePath="src\stream\rc4\rc4_stream.c"
+					>
+				</File>
+				<File
+					RelativePath="src\stream\rc4\rc4_stream_memory.c"
 					>
 				</File>
 				<File
@@ -2631,11 +2643,19 @@
 					>
 				</File>
 				<File
+					RelativePath="src\stream\salsa20\salsa20_memory.c"
+					>
+				</File>
+				<File
 					RelativePath="src\stream\salsa20\salsa20_setup.c"
 					>
 				</File>
 				<File
 					RelativePath="src\stream\salsa20\salsa20_test.c"
+					>
+				</File>
+				<File
+					RelativePath="src\stream\salsa20\xsalsa20_memory.c"
 					>
 				</File>
 				<File
@@ -2652,6 +2672,10 @@
 				>
 				<File
 					RelativePath="src\stream\sober128\sober128_stream.c"
+					>
+				</File>
+				<File
+					RelativePath="src\stream\sober128\sober128_stream_memory.c"
 					>
 				</File>
 				<File
@@ -2708,6 +2732,10 @@
 				>
 				<File
 					RelativePath="src\stream\sosemanuk\sosemanuk.c"
+					>
+				</File>
+				<File
+					RelativePath="src\stream\sosemanuk\sosemanuk_memory.c"
 					>
 				</File>
 				<File

--- a/makefile.mingw
+++ b/makefile.mingw
@@ -199,14 +199,17 @@ src/pk/rsa/rsa_sign_saltlen_get.o src/pk/rsa/rsa_verify_hash.o src/prngs/chacha2
 src/prngs/rc4.o src/prngs/rng_get_bytes.o src/prngs/rng_make_prng.o src/prngs/sober128.o \
 src/prngs/sprng.o src/prngs/yarrow.o src/stream/chacha/chacha_crypt.o src/stream/chacha/chacha_done.o \
 src/stream/chacha/chacha_ivctr32.o src/stream/chacha/chacha_ivctr64.o \
-src/stream/chacha/chacha_keystream.o src/stream/chacha/chacha_setup.o src/stream/chacha/chacha_test.o \
-src/stream/rabbit/rabbit.o src/stream/rc4/rc4_stream.o src/stream/rc4/rc4_test.o \
-src/stream/salsa20/salsa20_crypt.o src/stream/salsa20/salsa20_done.o \
+src/stream/chacha/chacha_keystream.o src/stream/chacha/chacha_memory.o \
+src/stream/chacha/chacha_setup.o src/stream/chacha/chacha_test.o src/stream/rabbit/rabbit.o \
+src/stream/rabbit/rabbit_memory.o src/stream/rc4/rc4_stream.o src/stream/rc4/rc4_stream_memory.o \
+src/stream/rc4/rc4_test.o src/stream/salsa20/salsa20_crypt.o src/stream/salsa20/salsa20_done.o \
 src/stream/salsa20/salsa20_ivctr64.o src/stream/salsa20/salsa20_keystream.o \
-src/stream/salsa20/salsa20_setup.o src/stream/salsa20/salsa20_test.o \
+src/stream/salsa20/salsa20_memory.o src/stream/salsa20/salsa20_setup.o \
+src/stream/salsa20/salsa20_test.o src/stream/salsa20/xsalsa20_memory.o \
 src/stream/salsa20/xsalsa20_setup.o src/stream/salsa20/xsalsa20_test.o \
-src/stream/sober128/sober128_stream.o src/stream/sober128/sober128_test.o \
-src/stream/sosemanuk/sosemanuk.o src/stream/sosemanuk/sosemanuk_test.o
+src/stream/sober128/sober128_stream.o src/stream/sober128/sober128_stream_memory.o \
+src/stream/sober128/sober128_test.o src/stream/sosemanuk/sosemanuk.o \
+src/stream/sosemanuk/sosemanuk_memory.o src/stream/sosemanuk/sosemanuk_test.o
 
 #List of test objects to compile
 TOBJECTS=tests/base16_test.o tests/base32_test.o tests/base64_test.o tests/cipher_hash_test.o \

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -192,14 +192,17 @@ src/pk/rsa/rsa_sign_saltlen_get.obj src/pk/rsa/rsa_verify_hash.obj src/prngs/cha
 src/prngs/rc4.obj src/prngs/rng_get_bytes.obj src/prngs/rng_make_prng.obj src/prngs/sober128.obj \
 src/prngs/sprng.obj src/prngs/yarrow.obj src/stream/chacha/chacha_crypt.obj src/stream/chacha/chacha_done.obj \
 src/stream/chacha/chacha_ivctr32.obj src/stream/chacha/chacha_ivctr64.obj \
-src/stream/chacha/chacha_keystream.obj src/stream/chacha/chacha_setup.obj src/stream/chacha/chacha_test.obj \
-src/stream/rabbit/rabbit.obj src/stream/rc4/rc4_stream.obj src/stream/rc4/rc4_test.obj \
-src/stream/salsa20/salsa20_crypt.obj src/stream/salsa20/salsa20_done.obj \
+src/stream/chacha/chacha_keystream.obj src/stream/chacha/chacha_memory.obj \
+src/stream/chacha/chacha_setup.obj src/stream/chacha/chacha_test.obj src/stream/rabbit/rabbit.obj \
+src/stream/rabbit/rabbit_memory.obj src/stream/rc4/rc4_stream.obj src/stream/rc4/rc4_stream_memory.obj \
+src/stream/rc4/rc4_test.obj src/stream/salsa20/salsa20_crypt.obj src/stream/salsa20/salsa20_done.obj \
 src/stream/salsa20/salsa20_ivctr64.obj src/stream/salsa20/salsa20_keystream.obj \
-src/stream/salsa20/salsa20_setup.obj src/stream/salsa20/salsa20_test.obj \
+src/stream/salsa20/salsa20_memory.obj src/stream/salsa20/salsa20_setup.obj \
+src/stream/salsa20/salsa20_test.obj src/stream/salsa20/xsalsa20_memory.obj \
 src/stream/salsa20/xsalsa20_setup.obj src/stream/salsa20/xsalsa20_test.obj \
-src/stream/sober128/sober128_stream.obj src/stream/sober128/sober128_test.obj \
-src/stream/sosemanuk/sosemanuk.obj src/stream/sosemanuk/sosemanuk_test.obj
+src/stream/sober128/sober128_stream.obj src/stream/sober128/sober128_stream_memory.obj \
+src/stream/sober128/sober128_test.obj src/stream/sosemanuk/sosemanuk.obj \
+src/stream/sosemanuk/sosemanuk_memory.obj src/stream/sosemanuk/sosemanuk_test.obj
 
 #List of test objects to compile
 TOBJECTS=tests/base16_test.obj tests/base32_test.obj tests/base64_test.obj tests/cipher_hash_test.obj \

--- a/makefile.unix
+++ b/makefile.unix
@@ -209,14 +209,17 @@ src/pk/rsa/rsa_sign_saltlen_get.o src/pk/rsa/rsa_verify_hash.o src/prngs/chacha2
 src/prngs/rc4.o src/prngs/rng_get_bytes.o src/prngs/rng_make_prng.o src/prngs/sober128.o \
 src/prngs/sprng.o src/prngs/yarrow.o src/stream/chacha/chacha_crypt.o src/stream/chacha/chacha_done.o \
 src/stream/chacha/chacha_ivctr32.o src/stream/chacha/chacha_ivctr64.o \
-src/stream/chacha/chacha_keystream.o src/stream/chacha/chacha_setup.o src/stream/chacha/chacha_test.o \
-src/stream/rabbit/rabbit.o src/stream/rc4/rc4_stream.o src/stream/rc4/rc4_test.o \
-src/stream/salsa20/salsa20_crypt.o src/stream/salsa20/salsa20_done.o \
+src/stream/chacha/chacha_keystream.o src/stream/chacha/chacha_memory.o \
+src/stream/chacha/chacha_setup.o src/stream/chacha/chacha_test.o src/stream/rabbit/rabbit.o \
+src/stream/rabbit/rabbit_memory.o src/stream/rc4/rc4_stream.o src/stream/rc4/rc4_stream_memory.o \
+src/stream/rc4/rc4_test.o src/stream/salsa20/salsa20_crypt.o src/stream/salsa20/salsa20_done.o \
 src/stream/salsa20/salsa20_ivctr64.o src/stream/salsa20/salsa20_keystream.o \
-src/stream/salsa20/salsa20_setup.o src/stream/salsa20/salsa20_test.o \
+src/stream/salsa20/salsa20_memory.o src/stream/salsa20/salsa20_setup.o \
+src/stream/salsa20/salsa20_test.o src/stream/salsa20/xsalsa20_memory.o \
 src/stream/salsa20/xsalsa20_setup.o src/stream/salsa20/xsalsa20_test.o \
-src/stream/sober128/sober128_stream.o src/stream/sober128/sober128_test.o \
-src/stream/sosemanuk/sosemanuk.o src/stream/sosemanuk/sosemanuk_test.o
+src/stream/sober128/sober128_stream.o src/stream/sober128/sober128_stream_memory.o \
+src/stream/sober128/sober128_test.o src/stream/sosemanuk/sosemanuk.o \
+src/stream/sosemanuk/sosemanuk_memory.o src/stream/sosemanuk/sosemanuk_test.o
 
 #List of test objects to compile (all goes to libtomcrypt_prof.a)
 TOBJECTS=tests/base16_test.o tests/base32_test.o tests/base64_test.o tests/cipher_hash_test.o \

--- a/makefile_include.mk
+++ b/makefile_include.mk
@@ -369,14 +369,17 @@ src/pk/rsa/rsa_sign_saltlen_get.o src/pk/rsa/rsa_verify_hash.o src/prngs/chacha2
 src/prngs/rc4.o src/prngs/rng_get_bytes.o src/prngs/rng_make_prng.o src/prngs/sober128.o \
 src/prngs/sprng.o src/prngs/yarrow.o src/stream/chacha/chacha_crypt.o src/stream/chacha/chacha_done.o \
 src/stream/chacha/chacha_ivctr32.o src/stream/chacha/chacha_ivctr64.o \
-src/stream/chacha/chacha_keystream.o src/stream/chacha/chacha_setup.o src/stream/chacha/chacha_test.o \
-src/stream/rabbit/rabbit.o src/stream/rc4/rc4_stream.o src/stream/rc4/rc4_test.o \
-src/stream/salsa20/salsa20_crypt.o src/stream/salsa20/salsa20_done.o \
+src/stream/chacha/chacha_keystream.o src/stream/chacha/chacha_memory.o \
+src/stream/chacha/chacha_setup.o src/stream/chacha/chacha_test.o src/stream/rabbit/rabbit.o \
+src/stream/rabbit/rabbit_memory.o src/stream/rc4/rc4_stream.o src/stream/rc4/rc4_stream_memory.o \
+src/stream/rc4/rc4_test.o src/stream/salsa20/salsa20_crypt.o src/stream/salsa20/salsa20_done.o \
 src/stream/salsa20/salsa20_ivctr64.o src/stream/salsa20/salsa20_keystream.o \
-src/stream/salsa20/salsa20_setup.o src/stream/salsa20/salsa20_test.o \
+src/stream/salsa20/salsa20_memory.o src/stream/salsa20/salsa20_setup.o \
+src/stream/salsa20/salsa20_test.o src/stream/salsa20/xsalsa20_memory.o \
 src/stream/salsa20/xsalsa20_setup.o src/stream/salsa20/xsalsa20_test.o \
-src/stream/sober128/sober128_stream.o src/stream/sober128/sober128_test.o \
-src/stream/sosemanuk/sosemanuk.o src/stream/sosemanuk/sosemanuk_test.o
+src/stream/sober128/sober128_stream.o src/stream/sober128/sober128_stream_memory.o \
+src/stream/sober128/sober128_test.o src/stream/sosemanuk/sosemanuk.o \
+src/stream/sosemanuk/sosemanuk_memory.o src/stream/sosemanuk/sosemanuk_test.o
 
 # List of test objects to compile (all goes to libtomcrypt_prof.a)
 TOBJECTS=tests/base16_test.o tests/base32_test.o tests/base64_test.o tests/cipher_hash_test.o \

--- a/src/headers/tomcrypt_cipher.h
+++ b/src/headers/tomcrypt_cipher.h
@@ -1009,6 +1009,9 @@ int chacha_crypt(chacha_state *st, const unsigned char *in, unsigned long inlen,
 int chacha_keystream(chacha_state *st, unsigned char *out, unsigned long outlen);
 int chacha_done(chacha_state *st);
 int chacha_test(void);
+int chacha_memory(const unsigned char *key,    unsigned long keylen,  unsigned long rounds,
+                  const unsigned char *iv,     unsigned long ivlen,   ulong64 counter,
+                  const unsigned char *datain, unsigned long datalen, unsigned char *dataout);
 
 #endif /* LTC_CHACHA */
 
@@ -1028,6 +1031,9 @@ int salsa20_crypt(salsa20_state *st, const unsigned char *in, unsigned long inle
 int salsa20_keystream(salsa20_state *st, unsigned char *out, unsigned long outlen);
 int salsa20_done(salsa20_state *st);
 int salsa20_test(void);
+int salsa20_memory(const unsigned char *key,    unsigned long keylen,  unsigned long rounds,
+                   const unsigned char *iv,     unsigned long ivlen,   ulong64 counter,
+                   const unsigned char *datain, unsigned long datalen, unsigned char *dataout);
 
 #endif /* LTC_SALSA20 */
 
@@ -1037,6 +1043,9 @@ int xsalsa20_setup(salsa20_state *st, const unsigned char *key,   unsigned long 
                                       const unsigned char *nonce, unsigned long noncelen,
                                       int rounds);
 int xsalsa20_test(void);
+int xsalsa20_memory(const unsigned char *key,    unsigned long keylen,   unsigned long rounds,
+                    const unsigned char *nonce,  unsigned long noncelen,
+                    const unsigned char *datain, unsigned long datalen,  unsigned char *dataout);
 
 #endif /* LTC_XSALSA20 */
 
@@ -1061,6 +1070,10 @@ int sosemanuk_crypt(sosemanuk_state *st, const unsigned char *in, unsigned long 
 int sosemanuk_keystream(sosemanuk_state *st, unsigned char *out, unsigned long outlen);
 int sosemanuk_done(sosemanuk_state *st);
 int sosemanuk_test(void);
+int sosemanuk_memory(const unsigned char *key,    unsigned long keylen,
+                     const unsigned char *iv,     unsigned long ivlen,
+                     const unsigned char *datain, unsigned long datalen,
+                     unsigned char *dataout);
 
 #endif /* LTC_SOSEMANUK */
 
@@ -1085,6 +1098,10 @@ int rabbit_crypt(rabbit_state* st, const unsigned char *in, unsigned long inlen,
 int rabbit_keystream(rabbit_state* st, unsigned char *out, unsigned long outlen);
 int rabbit_done(rabbit_state *st);
 int rabbit_test(void);
+int rabbit_memory(const unsigned char *key,    unsigned long keylen,
+                  const unsigned char *iv,     unsigned long ivlen,
+                  const unsigned char *datain, unsigned long datalen,
+                  unsigned char *dataout);
 
 #endif /* LTC_RABBIT */
 
@@ -1100,6 +1117,9 @@ int rc4_stream_crypt(rc4_state *st, const unsigned char *in, unsigned long inlen
 int rc4_stream_keystream(rc4_state *st, unsigned char *out, unsigned long outlen);
 int rc4_stream_done(rc4_state *st);
 int rc4_stream_test(void);
+int rc4_stream_memory(const unsigned char *key,    unsigned long keylen,
+                      const unsigned char *datain, unsigned long datalen,
+                      unsigned char *dataout);
 
 #endif /* LTC_RC4_STREAM */
 
@@ -1119,6 +1139,10 @@ int sober128_stream_crypt(sober128_state *st, const unsigned char *in, unsigned 
 int sober128_stream_keystream(sober128_state *st, unsigned char *out, unsigned long outlen);
 int sober128_stream_done(sober128_state *st);
 int sober128_stream_test(void);
+int sober128_stream_memory(const unsigned char *key,    unsigned long keylen,
+                           const unsigned char *iv,     unsigned long ivlen,
+                           const unsigned char *datain, unsigned long datalen,
+                           unsigned char *dataout);
 
 #endif /* LTC_SOBER128_STREAM */
 

--- a/src/stream/chacha/chacha_memory.c
+++ b/src/stream/chacha/chacha_memory.c
@@ -1,0 +1,51 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ */
+
+#include "tomcrypt_private.h"
+
+#ifdef LTC_CHACHA
+
+/**
+   Encrypt (or decrypt) bytes of ciphertext (or plaintext) with ChaCha
+   @param key     The key
+   @param keylen  The key length
+   @param iv      The initial vector
+   @param ivlen   The initial vector length
+   @param datain  The plaintext (or ciphertext)
+   @param datalen The length of the input and output (octets)
+   @param rounds  The number of rounds
+   @param dataout [out] The ciphertext (or plaintext)
+   @return CRYPT_OK if successful
+*/
+int chacha_memory(const unsigned char *key,    unsigned long keylen,  unsigned long rounds,
+                  const unsigned char *iv,     unsigned long ivlen,   ulong64 counter,
+                  const unsigned char *datain, unsigned long datalen, unsigned char *dataout)
+{
+   chacha_state st;
+   int err;
+
+   LTC_ARGCHK(ivlen <= 8 || counter < 4294967296);       /* 2**32 */
+
+   if ((err = chacha_setup(&st, key, keylen, rounds))       != CRYPT_OK) goto WIPE_KEY;
+   if (ivlen > 8) {
+        if ((err = chacha_ivctr32(&st, iv, ivlen, counter)) != CRYPT_OK) goto WIPE_KEY;
+   } else {
+        if ((err = chacha_ivctr64(&st, iv, ivlen, counter)) != CRYPT_OK) goto WIPE_KEY;
+   }
+   err = chacha_crypt(&st, datain, datalen, dataout);
+WIPE_KEY:
+   chacha_done(&st);
+   return err;
+}
+
+#endif /* LTC_CHACHA */
+
+/* ref:         $Format:%D$ */
+/* git commit:  $Format:%H$ */
+/* commit time: $Format:%ai$ */

--- a/src/stream/chacha/chacha_test.c
+++ b/src/stream/chacha/chacha_test.c
@@ -40,25 +40,38 @@ int chacha_test(void)
    int err;
 
    len = strlen(pt);
-   /* crypt piece by piece */
+
+   /* crypt piece by piece - using chacha_ivctr32() */
    if ((err = chacha_setup(&st, k, sizeof(k), 20)) != CRYPT_OK)                            return err;
    if ((err = chacha_ivctr32(&st, n, sizeof(n), 1)) != CRYPT_OK)                           return err;
-   if ((err = chacha_crypt(&st, (unsigned char*)pt,      35,       out)) != CRYPT_OK)      return err;
+   if ((err = chacha_crypt(&st, (unsigned char*)pt,      35,       out     )) != CRYPT_OK) return err;
    if ((err = chacha_crypt(&st, (unsigned char*)pt + 35, 35,       out + 35)) != CRYPT_OK) return err;
    if ((err = chacha_crypt(&st, (unsigned char*)pt + 70,  5,       out + 70)) != CRYPT_OK) return err;
    if ((err = chacha_crypt(&st, (unsigned char*)pt + 75,  5,       out + 75)) != CRYPT_OK) return err;
    if ((err = chacha_crypt(&st, (unsigned char*)pt + 80, len - 80, out + 80)) != CRYPT_OK) return err;
    if (compare_testvector(out, len, ct, sizeof(ct), "CHACHA-TV1", 1))                      return CRYPT_FAIL_TESTVECTOR;
-   /* crypt in one go */
+
+   /* crypt in one go - using chacha_ivctr32() */
    if ((err = chacha_setup(&st, k, sizeof(k), 20)) != CRYPT_OK)                            return err;
    if ((err = chacha_ivctr32(&st, n, sizeof(n), 1)) != CRYPT_OK)                           return err;
    if ((err = chacha_crypt(&st, (unsigned char*)pt, len, out)) != CRYPT_OK)                return err;
    if (compare_testvector(out, len, ct, sizeof(ct), "CHACHA-TV2", 1))                      return CRYPT_FAIL_TESTVECTOR;
+
    /* crypt in one go - using chacha_ivctr64() */
    if ((err = chacha_setup(&st, k, sizeof(k), 20)) != CRYPT_OK)                            return err;
    if ((err = chacha_ivctr64(&st, n + 4, sizeof(n) - 4, 1)) != CRYPT_OK)                   return err;
    if ((err = chacha_crypt(&st, (unsigned char*)pt, len, out)) != CRYPT_OK)                return err;
    if (compare_testvector(out, len, ct, sizeof(ct), "CHACHA-TV3", 1))                      return CRYPT_FAIL_TESTVECTOR;
+
+   /* crypt in a single call using 32-bit counter with a value of 1 */
+   if ((err = chacha_memory(k, sizeof(k), 20,
+                            n, sizeof(n), 1, (unsigned char*)pt, len, out)) != CRYPT_OK)   return err;
+   if (compare_testvector(out, len, ct, sizeof(ct), "CHACHA-TV4", 1))                      return CRYPT_FAIL_TESTVECTOR;
+
+   /* crypt in a single call using 64-bit counter with a value of 1 */
+   if ((err = chacha_memory(k, sizeof(k), 20,
+                            n + 4, sizeof(n) - 4, 1, (unsigned char*)pt, len, out)) != CRYPT_OK)  return err;
+   if (compare_testvector(out, len, ct, sizeof(ct), "CHACHA-TV5", 1))                      return CRYPT_FAIL_TESTVECTOR;
 
    return CRYPT_OK;
 #endif

--- a/src/stream/rabbit/rabbit.c
+++ b/src/stream/rabbit/rabbit.c
@@ -421,19 +421,25 @@ int rabbit_test(void)
          if ((err = rabbit_crypt(&st, (unsigned char*)pt +  5, 29, out +  5)) != CRYPT_OK) return err;
          if ((err = rabbit_crypt(&st, (unsigned char*)pt + 34,  5, out + 34)) != CRYPT_OK) return err;
          if (compare_testvector(out, ptlen, ct, ptlen, "RABBIT-TV3", 1))   return CRYPT_FAIL_TESTVECTOR;
+
+      /* --- Test 4 (crypt in a single call) ------------------------------------ */
+
+         if ((err = rabbit_memory(k, sizeof(k), iv, sizeof(iv),
+                                   (unsigned char*)pt, sizeof(pt), out))      != CRYPT_OK) return err;
+         if (compare_testvector(out, ptlen, ct, ptlen, "RABBIT-TV4", 1))   return CRYPT_FAIL_TESTVECTOR;
          /* use 'out' (ciphertext) in the next decryption test */
 
-      /* --- Test 4 (decrypt ciphertext) ------------------------------------ */
+      /* --- Test 5 (decrypt ciphertext) ------------------------------------ */
 
          /* decrypt ct (out) and compare with pt (start with only setiv() to reset) */
          if ((err = rabbit_setiv(&st, iv, sizeof(iv)))                        != CRYPT_OK) return err;
          if ((err = rabbit_crypt(&st, out, ptlen, out2))                      != CRYPT_OK) return err;
-         if (compare_testvector(out2, ptlen, pt, ptlen, "RABBIT-TV4", 1))  return CRYPT_FAIL_TESTVECTOR;
+         if (compare_testvector(out2, ptlen, pt, ptlen, "RABBIT-TV5", 1))  return CRYPT_FAIL_TESTVECTOR;
 
-      /* --- Test 5 (wipe state, incl key) ---------------------------------- */
+      /* --- Test 6 (wipe state, incl key) ---------------------------------- */
 
          if ((err = rabbit_done(&st))                      != CRYPT_OK) return err;
-         if (compare_testvector(&st, sizeof(st), nulls, sizeof(st), "RABBIT-TV5", 1))  return CRYPT_FAIL_TESTVECTOR;
+         if (compare_testvector(&st, sizeof(st), nulls, sizeof(st), "RABBIT-TV6", 1))  return CRYPT_FAIL_TESTVECTOR;
 
       }
 

--- a/src/stream/rabbit/rabbit_memory.c
+++ b/src/stream/rabbit/rabbit_memory.c
@@ -1,0 +1,50 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ */
+
+/* The implementation is based on:
+ * chacha-ref.c version 20080118
+ * Public domain from D. J. Bernstein
+ */
+
+#include "tomcrypt_private.h"
+
+#ifdef LTC_RABBIT
+
+/**
+   Encrypt (or decrypt) bytes of ciphertext (or plaintext) with Rabbit
+   @param key     The key
+   @param keylen  The key length
+   @param iv      The initial vector
+   @param ivlen   The initial vector length
+   @param datain  The plaintext (or ciphertext)
+   @param datalen The length of the input and output (octets)
+   @param dataout [out] The ciphertext (or plaintext)
+   @return CRYPT_OK if successful
+*/
+int rabbit_memory(const unsigned char *key,    unsigned long keylen,
+                  const unsigned char *iv,     unsigned long ivlen,
+                  const unsigned char *datain, unsigned long datalen,
+                  unsigned char *dataout)
+{
+   rabbit_state st;
+   int err;
+
+   if ((err = rabbit_setup(&st, key, keylen)) != CRYPT_OK) goto WIPE_KEY;
+   if ((err = rabbit_setiv(&st, iv, ivlen))   != CRYPT_OK) goto WIPE_KEY;
+   err = rabbit_crypt(&st, datain, datalen, dataout);
+WIPE_KEY:
+   rabbit_done(&st);
+   return err;
+}
+
+#endif /* LTC_RABBIT */
+
+/* ref:         $Format:%D$ */
+/* git commit:  $Format:%H$ */
+/* commit time: $Format:%ai$ */

--- a/src/stream/rc4/rc4_stream_memory.c
+++ b/src/stream/rc4/rc4_stream_memory.c
@@ -1,0 +1,41 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ */
+
+#include "tomcrypt_private.h"
+
+#ifdef LTC_RC4_STREAM
+
+/**
+   Encrypt (or decrypt) bytes of ciphertext (or plaintext) with RC4
+   @param key     The key
+   @param keylen  The key length
+   @param datain  The plaintext (or ciphertext)
+   @param datalen The length of the input and output (octets)
+   @param dataout [out] The ciphertext (or plaintext)
+   @return CRYPT_OK if successful
+*/
+int rc4_stream_memory(const unsigned char *key,    unsigned long keylen,
+                      const unsigned char *datain, unsigned long datalen,
+                      unsigned char *dataout)
+{
+   rc4_state st;
+   int err;
+
+   if ((err = rc4_stream_setup(&st, key, keylen)) != CRYPT_OK) goto WIPE_KEY;
+   err = rc4_stream_crypt(&st, datain, datalen, dataout);
+WIPE_KEY:
+   rc4_stream_done(&st);
+   return err;
+}
+
+#endif /* LTC_RC4_STREAM */
+
+/* ref:         $Format:%D$ */
+/* git commit:  $Format:%H$ */
+/* commit time: $Format:%ai$ */

--- a/src/stream/rc4/rc4_test.c
+++ b/src/stream/rc4/rc4_test.c
@@ -25,8 +25,12 @@ int rc4_stream_test(void)
 
    if ((err = rc4_stream_setup(&st, key, sizeof(key))) != CRYPT_OK)    return err;
    if ((err = rc4_stream_crypt(&st, pt, sizeof(pt), buf)) != CRYPT_OK) return err;
-   if (compare_testvector(buf, sizeof(ct), ct, sizeof(ct), "RC4", 0))  return CRYPT_FAIL_TESTVECTOR;
+   if (compare_testvector(buf, sizeof(ct), ct, sizeof(ct), "RC4-TV1", 0))  return CRYPT_FAIL_TESTVECTOR;
    if ((err = rc4_stream_done(&st)) != CRYPT_OK)                       return err;
+
+   /* crypt in a single call */
+   if ((err = rc4_stream_memory(key, sizeof(key), pt, sizeof(pt), buf)) != CRYPT_OK) return err;
+   if (compare_testvector(buf, sizeof(ct), ct, sizeof(ct), "RC4-TV2", 0))  return CRYPT_FAIL_TESTVECTOR;
 
    return CRYPT_OK;
 #endif

--- a/src/stream/salsa20/salsa20_memory.c
+++ b/src/stream/salsa20/salsa20_memory.c
@@ -1,0 +1,45 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ */
+
+#include "tomcrypt_private.h"
+
+#ifdef LTC_SALSA20
+
+/**
+   Encrypt (or decrypt) bytes of ciphertext (or plaintext) with Salsa20
+   @param key     The key
+   @param keylen  The key length
+   @param iv      The initial vector
+   @param ivlen   The initial vector length
+   @param datain  The plaintext (or ciphertext)
+   @param datalen The length of the input and output (octets)
+   @param rounds  The number of rounds
+   @param dataout [out] The ciphertext (or plaintext)
+   @return CRYPT_OK if successful
+*/
+int salsa20_memory(const unsigned char *key,    unsigned long keylen,  unsigned long rounds,
+                   const unsigned char *iv,     unsigned long ivlen,   ulong64 counter,
+                   const unsigned char *datain, unsigned long datalen, unsigned char *dataout)
+{
+   salsa20_state st;
+   int err;
+
+   if ((err = salsa20_setup(&st, key, keylen, rounds))  != CRYPT_OK) goto WIPE_KEY;
+   if ((err = salsa20_ivctr64(&st, iv, ivlen, counter)) != CRYPT_OK) goto WIPE_KEY;
+   err = salsa20_crypt(&st, datain, datalen, dataout);
+WIPE_KEY:
+   salsa20_done(&st);
+   return err;
+}
+
+#endif /* LTC_SALSA20 */
+
+/* ref:         $Format:%D$ */
+/* git commit:  $Format:%H$ */
+/* commit time: $Format:%ai$ */

--- a/src/stream/salsa20/salsa20_test.c
+++ b/src/stream/salsa20/salsa20_test.c
@@ -43,21 +43,26 @@ int salsa20_test(void)
    /* crypt piece by piece */
    counter = 0;
    rounds  = 12;
-   if ((err = salsa20_setup(&st, k, sizeof(k), rounds)) != CRYPT_OK)                        return err;
-   if ((err = salsa20_ivctr64(&st, n, sizeof(n), counter)) != CRYPT_OK)                     return err;
-   if ((err = salsa20_crypt(&st, (unsigned char*)pt,       5,       out)) != CRYPT_OK)      return err;
+   if ((err = salsa20_setup(&st, k, sizeof(k), rounds))                        != CRYPT_OK) return err;
+   if ((err = salsa20_ivctr64(&st, n, sizeof(n), counter))                     != CRYPT_OK) return err;
+   if ((err = salsa20_crypt(&st, (unsigned char*)pt,       5,       out))      != CRYPT_OK) return err;
    if ((err = salsa20_crypt(&st, (unsigned char*)pt +  5, 25,       out +  5)) != CRYPT_OK) return err;
    if ((err = salsa20_crypt(&st, (unsigned char*)pt + 30, 10,       out + 30)) != CRYPT_OK) return err;
    if ((err = salsa20_crypt(&st, (unsigned char*)pt + 40, len - 40, out + 40)) != CRYPT_OK) return err;
-   if (compare_testvector(out, len, ct, sizeof(ct), "SALSA20-TV1", 1))                      return CRYPT_FAIL_TESTVECTOR;
+   if (compare_testvector(out, len, ct, sizeof(ct), "SALSA20-TV1", 1))        return CRYPT_FAIL_TESTVECTOR;
 
    /* crypt in one go - using salsa20_ivctr64() */
    counter = 0;
    rounds  = 20;
-   if ((err = salsa20_setup(&st, k, sizeof(k), rounds)) != CRYPT_OK)                        return err;
-   if ((err = salsa20_ivctr64(&st, n, sizeof(n), counter)) != CRYPT_OK)                     return err;
-   if ((err = salsa20_crypt(&st, (unsigned char*)pt, len, out)) != CRYPT_OK)                return err;
-   if (compare_testvector(out, len, ct2, sizeof(ct), "SALSA20-TV2", 1))                     return CRYPT_FAIL_TESTVECTOR;
+   if ((err = salsa20_setup(&st, k, sizeof(k), rounds))         != CRYPT_OK)  return err;
+   if ((err = salsa20_ivctr64(&st, n, sizeof(n), counter))      != CRYPT_OK)  return err;
+   if ((err = salsa20_crypt(&st, (unsigned char*)pt, len, out)) != CRYPT_OK)  return err;
+   if (compare_testvector(out, len, ct2, sizeof(ct2), "SALSA20-TV2", 1))      return CRYPT_FAIL_TESTVECTOR;
+
+   /* crypt in a single call */
+   if ((err = salsa20_memory(k, sizeof(k), rounds, n, sizeof(n), counter,
+                                 (unsigned char*)pt, len, out)) != CRYPT_OK)  return err;
+   if (compare_testvector(out, len, ct2, sizeof(ct2), "SALSA20-TV3", 1))      return CRYPT_FAIL_TESTVECTOR;
 
    {
        /* keystream
@@ -77,7 +82,7 @@ int salsa20_test(void)
        if ((err = salsa20_ivctr64(&st, n3, sizeof(n3), counter3)) != CRYPT_OK)     return err;
        if ((err = salsa20_keystream(&st, out, 64))                != CRYPT_OK)     return err;
        if ((err = salsa20_done(&st))                              != CRYPT_OK)     return err;
-       if (compare_testvector(out, 64, ct3, sizeof(ct3), "SALSA20-TV3", 1))        return CRYPT_FAIL_TESTVECTOR;
+       if (compare_testvector(out, 64, ct3, sizeof(ct3), "SALSA20-TV4", 1))        return CRYPT_FAIL_TESTVECTOR;
    }
 
    return CRYPT_OK;

--- a/src/stream/salsa20/xsalsa20_memory.c
+++ b/src/stream/salsa20/xsalsa20_memory.c
@@ -1,0 +1,44 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ */
+
+#include "tomcrypt_private.h"
+
+#ifdef LTC_XSALSA20
+
+/**
+   Encrypt (or decrypt) bytes of ciphertext (or plaintext) with XSalsa20
+   @param key      The key
+   @param keylen   The key length
+   @param nonce    The initial vector
+   @param noncelen The initial vector length
+   @param datain   The plaintext (or ciphertext)
+   @param datalen  The length of the input and output (octets)
+   @param rounds   The number of rounds
+   @param dataout  [out] The ciphertext (or plaintext)
+   @return CRYPT_OK if successful
+*/
+int xsalsa20_memory(const unsigned char *key,    unsigned long keylen,   unsigned long rounds,
+                    const unsigned char *nonce,  unsigned long noncelen,
+                    const unsigned char *datain, unsigned long datalen,  unsigned char *dataout)
+{
+   salsa20_state st;
+   int err;
+
+   if ((err = xsalsa20_setup(&st, key, keylen, nonce, noncelen, rounds)) != CRYPT_OK) goto WIPE_KEY;
+   err = salsa20_crypt(&st, datain, datalen, dataout);
+WIPE_KEY:
+   salsa20_done(&st);
+   return err;
+}
+
+#endif /* LTC_XSALSA20 */
+
+/* ref:         $Format:%D$ */
+/* git commit:  $Format:%H$ */
+/* commit time: $Format:%ai$ */

--- a/src/stream/salsa20/xsalsa20_test.c
+++ b/src/stream/salsa20/xsalsa20_test.c
@@ -57,6 +57,12 @@ int xsalsa20_test(void)
         if ((err = salsa20_done(&st))                               != CRYPT_OK)  return err;
 
         if (compare_testvector(msg, msglen, msg2, msglen, "XSALSA20-TV1", 1))  return CRYPT_FAIL_TESTVECTOR;
+
+
+        /* round trip with two single function calls */
+        if ((err = xsalsa20_memory(key, sizeof(key), 20, nonce, sizeof(nonce), msg, msglen, ciphertext))  != CRYPT_OK)                return err;
+        if ((err = xsalsa20_memory(key, sizeof(key), 20, nonce, sizeof(nonce), ciphertext, msglen, msg2)) != CRYPT_OK)                return err;
+        if (compare_testvector(msg, msglen, msg2, msglen, "XSALSA20-TV2", 1))  return CRYPT_FAIL_TESTVECTOR;
     }
 
 #ifdef LTC_SHA256
@@ -78,7 +84,7 @@ int xsalsa20_test(void)
        if ((err = salsa20_keystream(&st, keystream, keystreamlen))   != CRYPT_OK)  return err;
        if ((err = salsa20_done(&st))                                 != CRYPT_OK)  return err;
        if ((err = _sha256(hash, keystream, keystreamlen))            != CRYPT_OK)  return err;
-       if (compare_testvector(hash, sizeof(hash), expecthash, sizeof(expecthash),   "XSALSA20-TV2", 1))  return CRYPT_FAIL_TESTVECTOR;
+       if (compare_testvector(hash, sizeof(hash), expecthash, sizeof(expecthash),   "XSALSA20-TV3", 1))  return CRYPT_FAIL_TESTVECTOR;
    }
 #endif
 

--- a/src/stream/sober128/sober128_stream_memory.c
+++ b/src/stream/sober128/sober128_stream_memory.c
@@ -1,0 +1,45 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ */
+
+#include "tomcrypt_private.h"
+
+#ifdef LTC_SOBER128_STREAM
+
+/**
+   Encrypt (or decrypt) bytes of ciphertext (or plaintext) with SOBER128
+   @param key     The key
+   @param keylen  The key length
+   @param iv      The initial vector
+   @param ivlen   The initial vector length
+   @param datain  The plaintext (or ciphertext)
+   @param datalen The length of the input and output (octets)
+   @param dataout [out] The ciphertext (or plaintext)
+   @return CRYPT_OK if successful
+*/
+int sober128_stream_memory(const unsigned char *key,    unsigned long keylen,
+                           const unsigned char *iv,     unsigned long ivlen,
+                           const unsigned char *datain, unsigned long datalen,
+                           unsigned char *dataout)
+{
+   sober128_state st;
+   int err;
+
+   if ((err = sober128_stream_setup(&st, key, keylen)) != CRYPT_OK) goto WIPE_KEY;
+   if ((err = sober128_stream_setiv(&st, iv, ivlen))   != CRYPT_OK) goto WIPE_KEY;
+   err = sober128_stream_crypt(&st, datain, datalen, dataout);
+WIPE_KEY:
+   sober128_stream_done(&st);
+   return err;
+}
+
+#endif /* LTC_SOBER128_STREAM */
+
+/* ref:         $Format:%D$ */
+/* git commit:  $Format:%H$ */
+/* commit time: $Format:%ai$ */

--- a/src/stream/sober128/sober128_test.c
+++ b/src/stream/sober128/sober128_test.c
@@ -31,9 +31,17 @@ int sober128_stream_test(void)
    if ((err = sober128_stream_setiv(&st, iv, sizeof(iv))) != CRYPT_OK)   return err;
    if ((err = sober128_stream_crypt(&st, src, len, dst)) != CRYPT_OK)    return err;
    if ((err = sober128_stream_done(&st)) != CRYPT_OK)                    return err;
-   if (compare_testvector(dst, len, out, len, "SOBER-128", 0)) {
+   if (compare_testvector(dst, len, out, len, "SOBER-128-TV1", 0)) {
       return CRYPT_FAIL_TESTVECTOR;
    }
+
+   /* crypt in a single call */
+   if ((err = sober128_stream_memory(key, sizeof(key), iv, sizeof(iv),
+                                            src, len, dst)) != CRYPT_OK) return err;
+   if (compare_testvector(dst, len, out, len, "SOBER-128-TV2", 0)) {
+      return CRYPT_FAIL_TESTVECTOR;
+   }
+
    return CRYPT_OK;
 #endif
 }

--- a/src/stream/sosemanuk/sosemanuk_memory.c
+++ b/src/stream/sosemanuk/sosemanuk_memory.c
@@ -1,0 +1,45 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ */
+
+#include "tomcrypt_private.h"
+
+#ifdef LTC_SOSEMANUK
+
+/**
+   Encrypt (or decrypt) bytes of ciphertext (or plaintext) with Sosemanuk
+   @param key     The key
+   @param keylen  The key length
+   @param iv      The initial vector
+   @param ivlen   The initial vector length
+   @param datain  The plaintext (or ciphertext)
+   @param datalen The length of the input and output (octets)
+   @param dataout [out] The ciphertext (or plaintext)
+   @return CRYPT_OK if successful
+*/
+int sosemanuk_memory(const unsigned char *key,    unsigned long keylen,
+                     const unsigned char *iv,     unsigned long ivlen,
+                     const unsigned char *datain, unsigned long datalen,
+                     unsigned char *dataout)
+{
+   sosemanuk_state st;
+   int err;
+
+   if ((err = sosemanuk_setup(&st, key, keylen)) != CRYPT_OK) goto WIPE_KEY;
+   if ((err = sosemanuk_setiv(&st, iv, ivlen))   != CRYPT_OK) goto WIPE_KEY;
+   err = sosemanuk_crypt(&st, datain, datalen, dataout);
+WIPE_KEY:
+   sosemanuk_done(&st);
+   return err;
+}
+
+#endif /* LTC_SOSEMANUK */
+
+/* ref:         $Format:%D$ */
+/* git commit:  $Format:%H$ */
+/* commit time: $Format:%ai$ */

--- a/src/stream/sosemanuk/sosemanuk_test.c
+++ b/src/stream/sosemanuk/sosemanuk_test.c
@@ -44,6 +44,11 @@ int sosemanuk_test(void)
        if ((err = sosemanuk_crypt(&st, (unsigned char*)pt, len, out)) != CRYPT_OK) return err;
        if (compare_testvector(out, len, ct, sizeof(ct), "SOSEMANUK-TV2", 1))       return CRYPT_FAIL_TESTVECTOR;
 
+       /* crypt in a single call */
+       if ((err = sosemanuk_memory(k, sizeof(k), n, sizeof(n),
+                                       (unsigned char*)pt, len, out)) != CRYPT_OK) return err;
+       if (compare_testvector(out, len, ct, sizeof(ct), "SOSEMANUK-TV3", 1))       return CRYPT_FAIL_TESTVECTOR;
+
    }
    {
        /* keystream
@@ -70,7 +75,7 @@ int sosemanuk_test(void)
        if ((err = sosemanuk_setiv(&st, n3, sizeof(n3)))      != CRYPT_OK)     return err;
        if ((err = sosemanuk_keystream(&st, out, 64))         != CRYPT_OK)     return err;
        if ((err = sosemanuk_done(&st))                       != CRYPT_OK)     return err;
-       if (compare_testvector(out, 64, ct3, sizeof(ct3), "SOSEMANUK-TV3", 1)) return CRYPT_FAIL_TESTVECTOR;
+       if (compare_testvector(out, 64, ct3, sizeof(ct3), "SOSEMANUK-TV4", 1)) return CRYPT_FAIL_TESTVECTOR;
    }
 
    return CRYPT_OK;


### PR DESCRIPTION
Added single-call crypt functions to each of the stream ciphers using the \<cipher\>_memory() naming convention.

### Checklist
* [x] documentation is added or updated
* [x] tests are added or updated
