### PR TITLE
makefile.shared: Support rlibtool.

### DIFF
--- a/makefile.shared
+++ b/makefile.shared
@@ -16,19 +16,24 @@
 
 PLATFORM := $(shell uname | sed -e 's/_.*//')
 
+ifeq ($(LIBTOOL),rlibtool)
+  TGTLIBTOOL:=slibtool-shared
+endif
+
 ifndef LIBTOOL
   ifeq ($(PLATFORM), Darwin)
     LIBTOOL:=glibtool
   else
     LIBTOOL:=libtool
   endif
+  TGTLIBTOOL=$(LIBTOOL)
 endif
 ifeq ($(PLATFORM), CYGWIN)
   NO_UNDEFINED:=-no-undefined
 endif
-LTCOMPILE = $(LIBTOOL) --mode=compile --tag=CC $(CC)
-INSTALL_CMD = $(LIBTOOL) --mode=install install
-UNINSTALL_CMD = $(LIBTOOL) --mode=uninstall rm
+LTCOMPILE = $(TGTLIBTOOL) --mode=compile --tag=CC $(CC)
+INSTALL_CMD = $(TGTLIBTOOL) --mode=install install
+UNINSTALL_CMD = $(TGTLIBTOOL) --mode=uninstall rm
 
 #Output filenames for various targets.
 ifndef LIBNAME
@@ -49,15 +54,15 @@ src/ciphers/aes/aes_enc.o: src/ciphers/aes/aes.c src/ciphers/aes/aes_tab.c
 LOBJECTS = $(OBJECTS:.o=.lo)
 
 $(LIBNAME): $(OBJECTS)
-	$(LIBTOOL) --mode=link --tag=CC $(CC) $(LTC_LDFLAGS) $(LOBJECTS) $(EXTRALIBS) -o $@ -rpath $(LIBPATH) -version-info $(VERSION_LT) $(NO_UNDEFINED)
+	$(TGTLIBTOOL) --mode=link --tag=CC $(CC) $(LTC_LDFLAGS) $(LOBJECTS) $(EXTRALIBS) -o $@ -rpath $(LIBPATH) -version-info $(VERSION_LT) $(NO_UNDEFINED)
 
 test: $(call print-help,test,Builds the library and the 'test' application to run all self-tests) $(LIBNAME) $(TOBJECTS)
-	$(LIBTOOL) --mode=link --tag=CC $(CC) $(LTC_LDFLAGS) -o $(TEST) $(TOBJECTS) $(LIBNAME) $(EXTRALIBS)
+	$(TGTLIBTOOL) --mode=link --tag=CC $(CC) $(LTC_LDFLAGS) -o $(TEST) $(TOBJECTS) $(LIBNAME) $(EXTRALIBS)
 
 # build the demos from a template
 define DEMO_template
 $(1): $(call print-help,$(1),Builds the library and the '$(1)' demo) demos/$(1).o $$(LIBNAME)
-	$$(LIBTOOL) --mode=link --tag=CC $$(CC) $$(LTC_LDFLAGS) $$^ $$(EXTRALIBS) -o $(1)
+	$$(TGTLIBTOOL) --mode=link --tag=CC $$(CC) $$(LTC_LDFLAGS) $$^ $$(EXTRALIBS) -o $(1)
 endef
 
 $(foreach demo, $(strip $(DEMOS)), $(eval $(call DEMO_template,$(demo))))


### PR DESCRIPTION
When building libtomcrypt with rlibtool instead of libtool it will fail when rlibtool fails to parse the generated libtool which does not exist.

Since rlibtool should be the default choice for most slibtool users in the future this patch will use slibtool-shared instead of rlibtool which will correctly build the shared library.

This could also help build the shared library on additional targets and hosts where the stock libtool does not have shared libraries enabled.