### PR TITLE
pbes: some linting

### DIFF
--- a/src/misc/pbes/pbes.c
+++ b/src/misc/pbes/pbes.c
@@ -20,7 +20,7 @@
 */
 int pbes_decrypt(const pbes_arg  *arg, unsigned char *dec_data, unsigned long *dec_size)
 {
-   int err, hid = -1, cid = -1;
+   int err, hid, cid;
    unsigned char k[32], *iv;
    unsigned long klen, keylen, dlen;
    long diff;

--- a/src/misc/pbes/pbes1.c
+++ b/src/misc/pbes/pbes1.c
@@ -31,7 +31,7 @@ static int _pkcs_12_wrap(const unsigned char *password, unsigned long password_l
    if (*outlen < 32) return CRYPT_INVALID_ARG;
    pw = XMALLOC(pwlen + 2);
    if (pw == NULL) return CRYPT_MEM;
-   if ((err = pkcs12_utf8_to_utf16(password, password_len, pw, &pwlen) != CRYPT_OK)) goto LBL_ERROR;
+   if ((err = pkcs12_utf8_to_utf16(password, password_len, pw, &pwlen)) != CRYPT_OK) goto LBL_ERROR;
    pw[pwlen++] = 0;
    pw[pwlen++] = 0;
    /* derive KEY */

--- a/src/misc/pbes/pbes2.c
+++ b/src/misc/pbes/pbes2.c
@@ -10,8 +10,8 @@
 
 #ifdef LTC_PBES
 
-static const char *_oid_pbes2 =  "1.2.840.113549.1.5.13";
-static const char *_oid_pbkdf2 = "1.2.840.113549.1.5.12";
+static const char * const _oid_pbes2 =  "1.2.840.113549.1.5.13";
+static const char * const _oid_pbkdf2 = "1.2.840.113549.1.5.12";
 
 typedef struct {
    const char *oid;


### PR DESCRIPTION
another point : the definition of `oid_to_pbes` is duplicated
https://github.com/libtom/libtomcrypt/blob/develop/src/misc/pbes/pbes1.c#L59-L62
https://github.com/libtom/libtomcrypt/blob/develop/src/misc/pbes/pbes2.c#L40-L43
