### PR TITLE
Make LTC_ECCSIG_RFC7518 strict (again) 

### DIFF
--- a/src/pk/ecc/ecc_verify_hash.c
+++ b/src/pk/ecc/ecc_verify_hash.c
@@ -76,11 +76,11 @@ int ecc_verify_hash_ex(const unsigned char *sig,  unsigned long siglen,
    }
    else if (sigformat == LTC_ECCSIG_RFC7518) {
       /* RFC7518 format - raw (r,s) */
-      if ((siglen % 2) == 1) {
+      i = mp_unsigned_bin_size(key->dp.order);
+      if (siglen != (2 * i)) {
          err = CRYPT_INVALID_PACKET;
          goto error;
       }
-      i = siglen / 2;
       if ((err = mp_read_unsigned_bin(r, (unsigned char *)sig,   i)) != CRYPT_OK)                       { goto error; }
       if ((err = mp_read_unsigned_bin(s, (unsigned char *)sig+i, i)) != CRYPT_OK)                       { goto error; }
    }


### PR DESCRIPTION
This is basically a revert of my PR - Less strict ecc_verify_hash_ex (as it was before ecc_recover_key) #443

It enforces the strict verification mode for `LTC_ECCSIG_RFC7518` but allow relaxed variant via `LTC_ECCSIG_RFC7518_RELAXED`.

I have changed my mind after investigation the latest wycheproof test suit. it seems that since approx. a yar ago wycheproof guys (=google) did change the status of some "acceptable" cases to "invalid". In other words what is declared today as "acceptable" is a candidate for tomorrow's "invalid".

So my new proposal is either enforce the strict length validation (the size of the signature should always be twice the number of bytes of the size of the order) or this PR.

Cc: @sjaeckel @rmw42  
