### PR TITLE
Wycheproof failing PKCS7 depadding test

### DIFF
--- a/src/misc/padding/padding_depad.c
+++ b/src/misc/padding/padding_depad.c
@@ -36,7 +36,7 @@ int padding_depad(const unsigned char *data, unsigned long *length, unsigned lon
    if (type < LTC_PAD_ONE_AND_ZERO) {
       pad = data[padded_length - 1];
 
-      if (pad > padded_length) return CRYPT_INVALID_ARG;
+      if (pad > padded_length || pad == 0) return CRYPT_INVALID_ARG;
 
       unpadded_length = padded_length - pad;
    } else {

--- a/tests/padding_test.c
+++ b/tests/padding_test.c
@@ -194,6 +194,18 @@ int padding_test(void)
       }
    }
 
+   /* wycheproof failing test - https://github.com/libtom/libtomcrypt/pull/454 */
+   {
+      unsigned char data[] = { 0x47,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00 };
+      unsigned long len = sizeof(data);
+      int err;
+
+      err = padding_depad(data, &len, (LTC_PAD_PKCS7 | 16));
+      if (err == CRYPT_OK) {
+         fprintf(stderr, "XXX-FIXME padding_depad should fail (err=%d len=%lu)\n", err, len);
+         /* return CRYPT_FAIL_TESTVECTOR; */
+      }
+   }
 
    return CRYPT_OK;
 }

--- a/tests/padding_test.c
+++ b/tests/padding_test.c
@@ -201,10 +201,7 @@ int padding_test(void)
       int err;
 
       err = padding_depad(data, &len, (LTC_PAD_PKCS7 | 16));
-      if (err == CRYPT_OK) {
-         fprintf(stderr, "XXX-FIXME padding_depad should fail (err=%d len=%lu)\n", err, len);
-         /* return CRYPT_FAIL_TESTVECTOR; */
-      }
+      if (err == CRYPT_OK) return CRYPT_FAIL_TESTVECTOR; /* should fail */
    }
 
    return CRYPT_OK;


### PR DESCRIPTION
The wycheproof failing test:
```
        {
          "tcId" : 29,
          "comment" : "zero padding",
          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
          "iv" : "23468aa734f5f0f19827316ff168e94f",
          "msg" : "3031323334353637383941424344454647",
          "ct" : "fbcbdfdaaf17980be939c0b243266ecb1188ff22f6563f6173440547d1e0dfd8",
          "result" : "invalid",
          "flags" : [
            "BadPadding"
          ]
        },
```

After decryption the last block looks like this (hex):
```
47,00,00,00,00,00,00,00,00,00,00,00,00,00,00,00
```

Which is expected to fail when using LTC_PAD_PKCS7 depadding.
