### PR TITLE
Avoid LTC_ARGCHK in void functions

### DIFF
--- a/src/misc/copy_or_zeromem.c
+++ b/src/misc/copy_or_zeromem.c
@@ -29,8 +29,8 @@ void copy_or_zeromem(const unsigned char* src, unsigned char* dest, unsigned lon
 #endif
    unsigned char mask = 0xff; /* initialize mask at all ones */
 
-   LTC_ARGCHK(src  != NULL);
-   LTC_ARGCHK(dest != NULL);
+   LTC_ARGCHKVD(src  != NULL);
+   LTC_ARGCHKVD(dest != NULL);
 
    if (coz != 0) coz = 1;
    y = 0;


### PR DESCRIPTION
By default LTC_ARGCHK never returns (it aborts). 

However, with `ARGTYPE == 4` it calls `return CRYPT_INVALID_ARG` which causes compiler warnings.