### PR TITLE
Fix gcc 8.3 warning (stringop-truncation)

### DIFF
--- a/src/misc/ssh/ssh_encode_sequence_multi.c
+++ b/src/misc/ssh/ssh_encode_sequence_multi.c
@@ -121,7 +121,7 @@ int ssh_encode_sequence_multi(unsigned char *out, unsigned long *outlen, ...)
             size = strlen(sdata);
             STORE32H(size, out);
             out += 4;
-            XSTRNCPY((char *)out, sdata, size);
+            XMEMCPY(out, sdata, size);
             out += size;
             break;
          case LTC_SSHDATA_MPINT:


### PR DESCRIPTION
Warning related to `ssh_encode_sequence_multi.c`

```
In file included from src/headers/tomcrypt.h:22,
                 from src/headers/tomcrypt_private.h:10,
                 from src/misc/ssh/ssh_encode_sequence_multi.c:9:
src/misc/ssh/ssh_encode_sequence_multi.c: In function 'ssh_encode_sequence_multi':
src/headers/tomcrypt_custom.h:49:18: error: 'strncpy' output truncated before terminating nul copying as many bytes from a string as its length [-Werror=stringop-truncation]
 #define XSTRNCPY strncpy
src/misc/ssh/ssh_encode_sequence_multi.c:124:13: note: in expansion of macro 'XSTRNCPY'
             XSTRNCPY((char *)out, sdata, size);
             ^~~~~~~~
src/misc/ssh/ssh_encode_sequence_multi.c:121:20: note: length computed here
             size = strlen(sdata);
                    ^~~~~~~~~~~~~
```