### PR TITLE
check range in _rijndael_ecb_ functions

### DIFF
--- a/src/ciphers/aes/aes.c
+++ b/src/ciphers/aes/aes.c
@@ -295,6 +295,10 @@ int ECB_ENC(const unsigned char *pt, unsigned char *ct, const symmetric_key *ske
     LTC_ARGCHK(skey != NULL);
 
     Nr = skey->rijndael.Nr;
+
+    if (Nr < 2 || Nr > 16)
+        return CRYPT_INVALID_ROUNDS;
+
     rk = skey->rijndael.eK;
 
     /*
@@ -475,6 +479,10 @@ int ECB_DEC(const unsigned char *ct, unsigned char *pt, const symmetric_key *ske
     LTC_ARGCHK(skey != NULL);
 
     Nr = skey->rijndael.Nr;
+
+    if (Nr < 2 || Nr > 16)
+        return CRYPT_INVALID_ROUNDS;
+
     rk = skey->rijndael.dK;
 
     /*


### PR DESCRIPTION
There is no check that the 'skey' structure has been properly
initialized. For example, the skey->rijndael.Nr is assumed to contain a
positive number corresponding to the number of AES rounds to perform. In
_rijndael_ecb_encrypt the skey->rijndael.Nr is subtracted by two, which
can result in an integer underflow if the structure hasn't been
initialized correctly.

By clamping the value for skey->rijndael.Nr into the valid rounds for
AES we can return an error instead of ending up reading outside the
boundaries (of skey->rijndael.eK).

I've also been running the tests
```bash
./testme.sh "makefile -j8" "-DUSE_LTM -DLTM_DESC -I../libtommath" ../libtommath/libtommath.a test
```
And I couldn't spot any errors, full log can be found [here](http://ix.io/1Qlt).
