### PR TITLE
add Xcode building support

### DIFF
--- a/TomCrypt.xcodeproj
+++ b/TomCrypt.xcodeproj
@@ -1,0 +1,1 @@
+macos/TomCrypt.xcodeproj

--- a/macos/TomCrypt.xcodeproj/project.pbxproj
+++ b/macos/TomCrypt.xcodeproj/project.pbxproj
@@ -1,0 +1,3085 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		159595B723691D6F007DBE15 /* compare_testvector.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595936A23691D6D007DBE15 /* compare_testvector.c */; };
+		159595B823691D6F007DBE15 /* error_to_string.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595936B23691D6D007DBE15 /* error_to_string.c */; };
+		159595B923691D6F007DBE15 /* copy_or_zeromem.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595936C23691D6D007DBE15 /* copy_or_zeromem.c */; };
+		159595BA23691D6F007DBE15 /* pkcs12_utf8_to_utf16.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595936E23691D6D007DBE15 /* pkcs12_utf8_to_utf16.c */; };
+		159595BB23691D6F007DBE15 /* pkcs12_kdf.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595936F23691D6D007DBE15 /* pkcs12_kdf.c */; };
+		159595BC23691D6F007DBE15 /* pbes1.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595937123691D6D007DBE15 /* pbes1.c */; };
+		159595BD23691D6F007DBE15 /* pbes2.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595937223691D6D007DBE15 /* pbes2.c */; };
+		159595BE23691D6F007DBE15 /* pbes.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595937323691D6D007DBE15 /* pbes.c */; };
+		159595BF23691D6F007DBE15 /* crypt_unregister_prng.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595937523691D6D007DBE15 /* crypt_unregister_prng.c */; };
+		159595C023691D6F007DBE15 /* crypt_unregister_cipher.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595937623691D6D007DBE15 /* crypt_unregister_cipher.c */; };
+		159595C123691D6F007DBE15 /* crypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595937723691D6D007DBE15 /* crypt.c */; };
+		159595C223691D6F007DBE15 /* crypt_find_cipher_any.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595937823691D6D007DBE15 /* crypt_find_cipher_any.c */; };
+		159595C323691D6F007DBE15 /* crypt_prng_descriptor.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595937923691D6D007DBE15 /* crypt_prng_descriptor.c */; };
+		159595C423691D6F007DBE15 /* crypt_constants.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595937A23691D6D007DBE15 /* crypt_constants.c */; };
+		159595C523691D6F007DBE15 /* crypt_prng_is_valid.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595937B23691D6D007DBE15 /* crypt_prng_is_valid.c */; };
+		159595C623691D6F007DBE15 /* crypt_prng_rng_descriptor.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595937C23691D6D007DBE15 /* crypt_prng_rng_descriptor.c */; };
+		159595C723691D6F007DBE15 /* crypt_cipher_is_valid.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595937D23691D6D007DBE15 /* crypt_cipher_is_valid.c */; };
+		159595C823691D6F007DBE15 /* crypt_find_hash_oid.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595937E23691D6D007DBE15 /* crypt_find_hash_oid.c */; };
+		159595C923691D6F007DBE15 /* crypt_hash_descriptor.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595937F23691D6D007DBE15 /* crypt_hash_descriptor.c */; };
+		159595CA23691D6F007DBE15 /* crypt_register_all_ciphers.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595938023691D6D007DBE15 /* crypt_register_all_ciphers.c */; };
+		159595CB23691D6F007DBE15 /* crypt_register_prng.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595938123691D6D007DBE15 /* crypt_register_prng.c */; };
+		159595CC23691D6F007DBE15 /* crypt_register_cipher.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595938223691D6D007DBE15 /* crypt_register_cipher.c */; };
+		159595CD23691D6F007DBE15 /* crypt_find_hash.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595938323691D6D007DBE15 /* crypt_find_hash.c */; };
+		159595CE23691D6F007DBE15 /* crypt_inits.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595938423691D6D007DBE15 /* crypt_inits.c */; };
+		159595CF23691D6F007DBE15 /* crypt_cipher_descriptor.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595938523691D6D007DBE15 /* crypt_cipher_descriptor.c */; };
+		159595D023691D6F007DBE15 /* crypt_register_all_hashes.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595938623691D6D007DBE15 /* crypt_register_all_hashes.c */; };
+		159595D123691D6F007DBE15 /* crypt_find_cipher.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595938723691D6D007DBE15 /* crypt_find_cipher.c */; };
+		159595D223691D6F007DBE15 /* crypt_find_hash_id.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595938823691D6D007DBE15 /* crypt_find_hash_id.c */; };
+		159595D323691D6F007DBE15 /* crypt_ltc_mp_descriptor.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595938923691D6D007DBE15 /* crypt_ltc_mp_descriptor.c */; };
+		159595D423691D6F007DBE15 /* crypt_find_cipher_id.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595938A23691D6D007DBE15 /* crypt_find_cipher_id.c */; };
+		159595D523691D6F007DBE15 /* crypt_register_hash.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595938B23691D6D007DBE15 /* crypt_register_hash.c */; };
+		159595D623691D6F007DBE15 /* crypt_hash_is_valid.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595938C23691D6D007DBE15 /* crypt_hash_is_valid.c */; };
+		159595D723691D6F007DBE15 /* crypt_find_prng.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595938D23691D6D007DBE15 /* crypt_find_prng.c */; };
+		159595D823691D6F007DBE15 /* crypt_argchk.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595938E23691D6D007DBE15 /* crypt_argchk.c */; };
+		159595D923691D6F007DBE15 /* crypt_sizes.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595938F23691D6D007DBE15 /* crypt_sizes.c */; };
+		159595DA23691D6F007DBE15 /* crypt_find_hash_any.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595939023691D6D007DBE15 /* crypt_find_hash_any.c */; };
+		159595DB23691D6F007DBE15 /* crypt_register_all_prngs.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595939123691D6D007DBE15 /* crypt_register_all_prngs.c */; };
+		159595DC23691D6F007DBE15 /* crypt_fsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595939223691D6D007DBE15 /* crypt_fsa.c */; };
+		159595DD23691D6F007DBE15 /* crypt_unregister_hash.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595939323691D6D007DBE15 /* crypt_unregister_hash.c */; };
+		159595DE23691D6F007DBE15 /* bcrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595939523691D6D007DBE15 /* bcrypt.c */; };
+		159595DF23691D6F007DBE15 /* base64_decode.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595939723691D6D007DBE15 /* base64_decode.c */; };
+		159595E023691D6F007DBE15 /* base64_encode.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595939823691D6D007DBE15 /* base64_encode.c */; };
+		159595E123691D6F007DBE15 /* pkcs_5_1.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595939A23691D6D007DBE15 /* pkcs_5_1.c */; };
+		159595E223691D6F007DBE15 /* pkcs_5_2.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595939B23691D6D007DBE15 /* pkcs_5_2.c */; };
+		159595E323691D6F007DBE15 /* pkcs_5_test.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595939C23691D6D007DBE15 /* pkcs_5_test.c */; };
+		159595E423691D6F007DBE15 /* crc32.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595939D23691D6D007DBE15 /* crc32.c */; };
+		159595E523691D6F007DBE15 /* burn_stack.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595939E23691D6D007DBE15 /* burn_stack.c */; };
+		159595E623691D6F007DBE15 /* hkdf_test.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593A023691D6D007DBE15 /* hkdf_test.c */; };
+		159595E723691D6F007DBE15 /* hkdf.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593A123691D6D007DBE15 /* hkdf.c */; };
+		159595E823691D6F007DBE15 /* ssh_decode_sequence_multi.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593A323691D6D007DBE15 /* ssh_decode_sequence_multi.c */; };
+		159595E923691D6F007DBE15 /* ssh_encode_sequence_multi.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593A423691D6D007DBE15 /* ssh_encode_sequence_multi.c */; };
+		159595EA23691D6F007DBE15 /* base16_encode.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593A623691D6D007DBE15 /* base16_encode.c */; };
+		159595EB23691D6F007DBE15 /* base16_decode.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593A723691D6D007DBE15 /* base16_decode.c */; };
+		159595EC23691D6F007DBE15 /* padding_pad.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593A923691D6D007DBE15 /* padding_pad.c */; };
+		159595ED23691D6F007DBE15 /* padding_depad.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593AA23691D6D007DBE15 /* padding_depad.c */; };
+		159595EE23691D6F007DBE15 /* base32_decode.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593AC23691D6D007DBE15 /* base32_decode.c */; };
+		159595EF23691D6F007DBE15 /* base32_encode.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593AD23691D6D007DBE15 /* base32_encode.c */; };
+		159595F023691D6F007DBE15 /* zeromem.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593AE23691D6D007DBE15 /* zeromem.c */; };
+		159595F123691D6F007DBE15 /* mem_neq.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593AF23691D6D007DBE15 /* mem_neq.c */; };
+		159595F223691D6F007DBE15 /* adler32.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593B023691D6D007DBE15 /* adler32.c */; };
+		159595F323691D6F007DBE15 /* der_decode_octet_string.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593B523691D6D007DBE15 /* der_decode_octet_string.c */; };
+		159595F423691D6F007DBE15 /* der_encode_octet_string.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593B623691D6D007DBE15 /* der_encode_octet_string.c */; };
+		159595F523691D6F007DBE15 /* der_length_octet_string.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593B723691D6D007DBE15 /* der_length_octet_string.c */; };
+		159595F623691D6F007DBE15 /* der_length_bit_string.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593B923691D6D007DBE15 /* der_length_bit_string.c */; };
+		159595F723691D6F007DBE15 /* der_encode_raw_bit_string.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593BA23691D6D007DBE15 /* der_encode_raw_bit_string.c */; };
+		159595F823691D6F007DBE15 /* der_decode_raw_bit_string.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593BB23691D6D007DBE15 /* der_decode_raw_bit_string.c */; };
+		159595F923691D6F007DBE15 /* der_encode_bit_string.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593BC23691D6D007DBE15 /* der_encode_bit_string.c */; };
+		159595FA23691D6F007DBE15 /* der_decode_bit_string.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593BD23691D6D007DBE15 /* der_decode_bit_string.c */; };
+		159595FB23691D6F007DBE15 /* der_encode_object_identifier.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593BF23691D6D007DBE15 /* der_encode_object_identifier.c */; };
+		159595FC23691D6F007DBE15 /* der_decode_object_identifier.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593C023691D6D007DBE15 /* der_decode_object_identifier.c */; };
+		159595FD23691D6F007DBE15 /* der_length_object_identifier.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593C123691D6D007DBE15 /* der_length_object_identifier.c */; };
+		159595FE23691D6F007DBE15 /* der_encode_utf8_string.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593C323691D6D007DBE15 /* der_encode_utf8_string.c */; };
+		159595FF23691D6F007DBE15 /* der_decode_utf8_string.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593C423691D6D007DBE15 /* der_decode_utf8_string.c */; };
+		1595960023691D6F007DBE15 /* der_length_utf8_string.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593C523691D6D007DBE15 /* der_length_utf8_string.c */; };
+		1595960123691D6F007DBE15 /* der_encode_asn1_identifier.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593C723691D6D007DBE15 /* der_encode_asn1_identifier.c */; };
+		1595960223691D6F007DBE15 /* der_length_asn1_identifier.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593C823691D6D007DBE15 /* der_length_asn1_identifier.c */; };
+		1595960323691D6F007DBE15 /* der_encode_asn1_length.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593C923691D6D007DBE15 /* der_encode_asn1_length.c */; };
+		1595960423691D6F007DBE15 /* der_decode_asn1_identifier.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593CA23691D6D007DBE15 /* der_decode_asn1_identifier.c */; };
+		1595960523691D6F007DBE15 /* der_length_asn1_length.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593CB23691D6D007DBE15 /* der_length_asn1_length.c */; };
+		1595960623691D6F007DBE15 /* der_decode_asn1_length.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593CC23691D6D007DBE15 /* der_decode_asn1_length.c */; };
+		1595960723691D6F007DBE15 /* der_asn1_maps.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593CD23691D6D007DBE15 /* der_asn1_maps.c */; };
+		1595960823691D6F007DBE15 /* der_decode_generalizedtime.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593CF23691D6D007DBE15 /* der_decode_generalizedtime.c */; };
+		1595960923691D6F007DBE15 /* der_encode_generalizedtime.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593D023691D6D007DBE15 /* der_encode_generalizedtime.c */; };
+		1595960A23691D6F007DBE15 /* der_length_generalizedtime.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593D123691D6D007DBE15 /* der_length_generalizedtime.c */; };
+		1595960B23691D6F007DBE15 /* der_length_short_integer.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593D323691D6D007DBE15 /* der_length_short_integer.c */; };
+		1595960C23691D6F007DBE15 /* der_encode_short_integer.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593D423691D6D007DBE15 /* der_encode_short_integer.c */; };
+		1595960D23691D6F007DBE15 /* der_decode_short_integer.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593D523691D6D007DBE15 /* der_decode_short_integer.c */; };
+		1595960E23691D6F007DBE15 /* der_decode_choice.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593D723691D6D007DBE15 /* der_decode_choice.c */; };
+		1595960F23691D6F007DBE15 /* der_length_ia5_string.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593D923691D6D007DBE15 /* der_length_ia5_string.c */; };
+		1595961023691D6F007DBE15 /* der_encode_ia5_string.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593DA23691D6D007DBE15 /* der_encode_ia5_string.c */; };
+		1595961123691D6F007DBE15 /* der_decode_ia5_string.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593DB23691D6D007DBE15 /* der_decode_ia5_string.c */; };
+		1595961223691D6F007DBE15 /* der_decode_teletex_string.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593DD23691D6D007DBE15 /* der_decode_teletex_string.c */; };
+		1595961323691D6F007DBE15 /* der_length_teletex_string.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593DE23691D6D007DBE15 /* der_length_teletex_string.c */; };
+		1595961423691D6F007DBE15 /* der_decode_boolean.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593E023691D6D007DBE15 /* der_decode_boolean.c */; };
+		1595961523691D6F007DBE15 /* der_length_boolean.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593E123691D6D007DBE15 /* der_length_boolean.c */; };
+		1595961623691D6F007DBE15 /* der_encode_boolean.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593E223691D6D007DBE15 /* der_encode_boolean.c */; };
+		1595961723691D6F007DBE15 /* der_length_integer.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593E423691D6D007DBE15 /* der_length_integer.c */; };
+		1595961823691D6F007DBE15 /* der_decode_integer.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593E523691D6D007DBE15 /* der_decode_integer.c */; };
+		1595961923691D6F007DBE15 /* der_encode_integer.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593E623691D6D007DBE15 /* der_encode_integer.c */; };
+		1595961A23691D6F007DBE15 /* der_encode_custom_type.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593E823691D6D007DBE15 /* der_encode_custom_type.c */; };
+		1595961B23691D6F007DBE15 /* der_decode_custom_type.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593E923691D6D007DBE15 /* der_decode_custom_type.c */; };
+		1595961C23691D6F007DBE15 /* der_length_custom_type.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593EA23691D6D007DBE15 /* der_length_custom_type.c */; };
+		1595961D23691D6F007DBE15 /* der_encode_setof.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593EC23691D6D007DBE15 /* der_encode_setof.c */; };
+		1595961E23691D6F007DBE15 /* der_encode_set.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593ED23691D6D007DBE15 /* der_encode_set.c */; };
+		1595961F23691D6F007DBE15 /* der_encode_sequence_ex.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593EF23691D6E007DBE15 /* der_encode_sequence_ex.c */; };
+		1595962023691D6F007DBE15 /* der_sequence_shrink.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593F023691D6E007DBE15 /* der_sequence_shrink.c */; };
+		1595962123691D6F007DBE15 /* der_length_sequence.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593F123691D6E007DBE15 /* der_length_sequence.c */; };
+		1595962223691D6F007DBE15 /* der_decode_sequence_ex.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593F223691D6E007DBE15 /* der_decode_sequence_ex.c */; };
+		1595962323691D6F007DBE15 /* der_decode_sequence_multi.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593F323691D6E007DBE15 /* der_decode_sequence_multi.c */; };
+		1595962423691D6F007DBE15 /* der_decode_sequence_flexi.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593F423691D6E007DBE15 /* der_decode_sequence_flexi.c */; };
+		1595962523691D6F007DBE15 /* der_encode_sequence_multi.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593F523691D6E007DBE15 /* der_encode_sequence_multi.c */; };
+		1595962623691D6F007DBE15 /* der_sequence_free.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593F623691D6E007DBE15 /* der_sequence_free.c */; };
+		1595962723691D6F007DBE15 /* der_encode_printable_string.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593F823691D6E007DBE15 /* der_encode_printable_string.c */; };
+		1595962823691D6F007DBE15 /* der_length_printable_string.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593F923691D6E007DBE15 /* der_length_printable_string.c */; };
+		1595962923691D6F007DBE15 /* der_decode_printable_string.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593FA23691D6E007DBE15 /* der_decode_printable_string.c */; };
+		1595962A23691D6F007DBE15 /* der_encode_utctime.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593FC23691D6E007DBE15 /* der_encode_utctime.c */; };
+		1595962B23691D6F007DBE15 /* der_length_utctime.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593FD23691D6E007DBE15 /* der_length_utctime.c */; };
+		1595962C23691D6F007DBE15 /* der_decode_utctime.c in Sources */ = {isa = PBXBuildFile; fileRef = 159593FE23691D6E007DBE15 /* der_decode_utctime.c */; };
+		1595962D23691D6F007DBE15 /* x509_encode_subject_public_key_info.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595940023691D6E007DBE15 /* x509_encode_subject_public_key_info.c */; };
+		1595962E23691D6F007DBE15 /* x509_decode_public_key_from_certificate.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595940123691D6E007DBE15 /* x509_decode_public_key_from_certificate.c */; };
+		1595962F23691D6F007DBE15 /* x509_decode_subject_public_key_info.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595940223691D6E007DBE15 /* x509_decode_subject_public_key_info.c */; };
+		1595963023691D6F007DBE15 /* pk_get_oid.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595940423691D6E007DBE15 /* pk_get_oid.c */; };
+		1595963123691D6F007DBE15 /* pk_oid_str.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595940523691D6E007DBE15 /* pk_oid_str.c */; };
+		1595963223691D6F007DBE15 /* pk_oid_cmp.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595940623691D6E007DBE15 /* pk_oid_cmp.c */; };
+		1595963323691D6F007DBE15 /* pkcs8_decode_flexi.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595940823691D6E007DBE15 /* pkcs8_decode_flexi.c */; };
+		1595963423691D6F007DBE15 /* dh_import.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595940A23691D6E007DBE15 /* dh_import.c */; };
+		1595963523691D6F007DBE15 /* dh_set.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595940B23691D6E007DBE15 /* dh_set.c */; };
+		1595963623691D6F007DBE15 /* dh_shared_secret.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595940C23691D6E007DBE15 /* dh_shared_secret.c */; };
+		1595963723691D6F007DBE15 /* dh_export_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595940D23691D6E007DBE15 /* dh_export_key.c */; };
+		1595963823691D6F007DBE15 /* dh_set_pg_dhparam.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595940E23691D6E007DBE15 /* dh_set_pg_dhparam.c */; };
+		1595963923691D6F007DBE15 /* dh_check_pubkey.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595940F23691D6E007DBE15 /* dh_check_pubkey.c */; };
+		1595963A23691D6F007DBE15 /* dh_free.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595941023691D6E007DBE15 /* dh_free.c */; };
+		1595963B23691D6F007DBE15 /* dh_generate_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595941123691D6E007DBE15 /* dh_generate_key.c */; };
+		1595963C23691D6F007DBE15 /* dh.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595941223691D6E007DBE15 /* dh.c */; };
+		1595963D23691D6F007DBE15 /* dh_export.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595941323691D6E007DBE15 /* dh_export.c */; };
+		1595963E23691D6F007DBE15 /* rsa_verify_hash.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595941523691D6E007DBE15 /* rsa_verify_hash.c */; };
+		1595963F23691D6F007DBE15 /* rsa_import_pkcs8.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595941623691D6E007DBE15 /* rsa_import_pkcs8.c */; };
+		1595964023691D6F007DBE15 /* rsa_exptmod.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595941723691D6E007DBE15 /* rsa_exptmod.c */; };
+		1595964123691D6F007DBE15 /* rsa_decrypt_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595941823691D6E007DBE15 /* rsa_decrypt_key.c */; };
+		1595964223691D6F007DBE15 /* rsa_encrypt_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595941923691D6E007DBE15 /* rsa_encrypt_key.c */; };
+		1595964323691D6F007DBE15 /* rsa_import.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595941A23691D6E007DBE15 /* rsa_import.c */; };
+		1595964423691D6F007DBE15 /* rsa_sign_hash.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595941B23691D6E007DBE15 /* rsa_sign_hash.c */; };
+		1595964523691D6F007DBE15 /* rsa_set.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595941C23691D6E007DBE15 /* rsa_set.c */; };
+		1595964623691D6F007DBE15 /* rsa_import_x509.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595941D23691D6E007DBE15 /* rsa_import_x509.c */; };
+		1595964723691D6F007DBE15 /* rsa_make_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595941E23691D6E007DBE15 /* rsa_make_key.c */; };
+		1595964823691D6F007DBE15 /* rsa_export.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595941F23691D6E007DBE15 /* rsa_export.c */; };
+		1595964923691D6F007DBE15 /* rsa_sign_saltlen_get.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595942023691D6E007DBE15 /* rsa_sign_saltlen_get.c */; };
+		1595964A23691D6F007DBE15 /* rsa_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595942123691D6E007DBE15 /* rsa_key.c */; };
+		1595964B23691D6F007DBE15 /* rsa_get_size.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595942223691D6E007DBE15 /* rsa_get_size.c */; };
+		1595964C23691D6F007DBE15 /* dsa_make_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595942423691D6E007DBE15 /* dsa_make_key.c */; };
+		1595964D23691D6F007DBE15 /* dsa_verify_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595942523691D6E007DBE15 /* dsa_verify_key.c */; };
+		1595964E23691D6F007DBE15 /* dsa_set.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595942623691D6E007DBE15 /* dsa_set.c */; };
+		1595964F23691D6F007DBE15 /* dsa_sign_hash.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595942723691D6E007DBE15 /* dsa_sign_hash.c */; };
+		1595965023691D6F007DBE15 /* dsa_shared_secret.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595942823691D6E007DBE15 /* dsa_shared_secret.c */; };
+		1595965123691D6F007DBE15 /* dsa_generate_pqg.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595942923691D6E007DBE15 /* dsa_generate_pqg.c */; };
+		1595965223691D6F007DBE15 /* dsa_import.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595942A23691D6E007DBE15 /* dsa_import.c */; };
+		1595965323691D6F007DBE15 /* dsa_decrypt_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595942B23691D6E007DBE15 /* dsa_decrypt_key.c */; };
+		1595965423691D6F007DBE15 /* dsa_set_pqg_dsaparam.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595942C23691D6E007DBE15 /* dsa_set_pqg_dsaparam.c */; };
+		1595965523691D6F007DBE15 /* dsa_export.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595942D23691D6E007DBE15 /* dsa_export.c */; };
+		1595965623691D6F007DBE15 /* dsa_verify_hash.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595942E23691D6E007DBE15 /* dsa_verify_hash.c */; };
+		1595965723691D6F007DBE15 /* dsa_generate_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595942F23691D6E007DBE15 /* dsa_generate_key.c */; };
+		1595965823691D6F007DBE15 /* dsa_free.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595943023691D6E007DBE15 /* dsa_free.c */; };
+		1595965923691D6F007DBE15 /* dsa_encrypt_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595943123691D6E007DBE15 /* dsa_encrypt_key.c */; };
+		1595965A23691D6F007DBE15 /* ec25519_export.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595943323691D6E007DBE15 /* ec25519_export.c */; };
+		1595965B23691D6F007DBE15 /* ec25519_import_pkcs8.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595943423691D6E007DBE15 /* ec25519_import_pkcs8.c */; };
+		1595965C23691D6F007DBE15 /* tweetnacl.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595943523691D6E007DBE15 /* tweetnacl.c */; };
+		1595965D23691D6F007DBE15 /* ed25519_export.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595943723691D6E007DBE15 /* ed25519_export.c */; };
+		1595965E23691D6F007DBE15 /* ed25519_import_pkcs8.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595943823691D6E007DBE15 /* ed25519_import_pkcs8.c */; };
+		1595965F23691D6F007DBE15 /* ed25519_import_raw.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595943923691D6E007DBE15 /* ed25519_import_raw.c */; };
+		1595966023691D6F007DBE15 /* ed25519_import_x509.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595943A23691D6E007DBE15 /* ed25519_import_x509.c */; };
+		1595966123691D6F007DBE15 /* ed25519_sign.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595943B23691D6E007DBE15 /* ed25519_sign.c */; };
+		1595966223691D6F007DBE15 /* ed25519_make_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595943C23691D6E007DBE15 /* ed25519_make_key.c */; };
+		1595966323691D6F007DBE15 /* ed25519_verify.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595943D23691D6E007DBE15 /* ed25519_verify.c */; };
+		1595966423691D6F007DBE15 /* ed25519_import.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595943E23691D6E007DBE15 /* ed25519_import.c */; };
+		1595966523691D6F007DBE15 /* ecc_import_x509.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595944023691D6E007DBE15 /* ecc_import_x509.c */; };
+		1595966623691D6F007DBE15 /* ecc_set_curve.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595944123691D6E007DBE15 /* ecc_set_curve.c */; };
+		1595966723691D6F007DBE15 /* ecc_recover_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595944223691D6E007DBE15 /* ecc_recover_key.c */; };
+		1595966823691D6F007DBE15 /* ecc_export_openssl.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595944323691D6E007DBE15 /* ecc_export_openssl.c */; };
+		1595966923691D6F007DBE15 /* ltc_ecc_projective_add_point.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595944423691D6E007DBE15 /* ltc_ecc_projective_add_point.c */; };
+		1595966A23691D6F007DBE15 /* ecc_make_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595944523691D6E007DBE15 /* ecc_make_key.c */; };
+		1595966B23691D6F007DBE15 /* ecc_ansi_x963_import.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595944623691D6E007DBE15 /* ecc_ansi_x963_import.c */; };
+		1595966C23691D6F007DBE15 /* ltc_ecc_map.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595944723691D6E007DBE15 /* ltc_ecc_map.c */; };
+		1595966D23691D6F007DBE15 /* ecc_get_size.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595944823691D6E007DBE15 /* ecc_get_size.c */; };
+		1595966E23691D6F007DBE15 /* ecc_import_pkcs8.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595944923691D6E007DBE15 /* ecc_import_pkcs8.c */; };
+		1595966F23691D6F007DBE15 /* ecc_set_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595944A23691D6E007DBE15 /* ecc_set_key.c */; };
+		1595967023691D6F007DBE15 /* ecc.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595944B23691D6E007DBE15 /* ecc.c */; };
+		1595967123691D6F007DBE15 /* ecc_get_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595944C23691D6E007DBE15 /* ecc_get_key.c */; };
+		1595967223691D6F007DBE15 /* ecc_export.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595944D23691D6E007DBE15 /* ecc_export.c */; };
+		1595967323691D6F007DBE15 /* ecc_import_openssl.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595944E23691D6E007DBE15 /* ecc_import_openssl.c */; };
+		1595967423691D6F007DBE15 /* ecc_free.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595944F23691D6E007DBE15 /* ecc_free.c */; };
+		1595967523691D6F007DBE15 /* ecc_find_curve.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595945023691D6E007DBE15 /* ecc_find_curve.c */; };
+		1595967623691D6F007DBE15 /* ecc_import.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595945123691D6E007DBE15 /* ecc_import.c */; };
+		1595967723691D6F007DBE15 /* ecc_get_oid_str.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595945223691D6E007DBE15 /* ecc_get_oid_str.c */; };
+		1595967823691D6F007DBE15 /* ecc_decrypt_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595945323691D6E007DBE15 /* ecc_decrypt_key.c */; };
+		1595967923691D6F007DBE15 /* ltc_ecc_is_point.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595945423691D6E007DBE15 /* ltc_ecc_is_point.c */; };
+		1595967A23691D6F007DBE15 /* ecc_shared_secret.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595945523691D6E007DBE15 /* ecc_shared_secret.c */; };
+		1595967B23691D6F007DBE15 /* ltc_ecc_projective_dbl_point.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595945623691D6E007DBE15 /* ltc_ecc_projective_dbl_point.c */; };
+		1595967C23691D6F007DBE15 /* ecc_sizes.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595945723691D6E007DBE15 /* ecc_sizes.c */; };
+		1595967D23691D6F007DBE15 /* ltc_ecc_mul2add.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595945823691D6E007DBE15 /* ltc_ecc_mul2add.c */; };
+		1595967E23691D6F007DBE15 /* ltc_ecc_points.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595945923691D6E007DBE15 /* ltc_ecc_points.c */; };
+		1595967F23691D6F007DBE15 /* ltc_ecc_mulmod.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595945A23691D6E007DBE15 /* ltc_ecc_mulmod.c */; };
+		1595968023691D6F007DBE15 /* ecc_verify_hash.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595945B23691D6E007DBE15 /* ecc_verify_hash.c */; };
+		1595968123691D6F007DBE15 /* ltc_ecc_is_point_at_infinity.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595945C23691D6E007DBE15 /* ltc_ecc_is_point_at_infinity.c */; };
+		1595968223691D6F007DBE15 /* ltc_ecc_import_point.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595945D23691D6E007DBE15 /* ltc_ecc_import_point.c */; };
+		1595968323691D6F007DBE15 /* ltc_ecc_mulmod_timing.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595945E23691D6E007DBE15 /* ltc_ecc_mulmod_timing.c */; };
+		1595968423691D6F007DBE15 /* ecc_ansi_x963_export.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595945F23691D6E007DBE15 /* ecc_ansi_x963_export.c */; };
+		1595968523691D6F007DBE15 /* ecc_ssh_ecdsa_encode_name.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595946023691D6E007DBE15 /* ecc_ssh_ecdsa_encode_name.c */; };
+		1595968623691D6F007DBE15 /* ecc_sign_hash.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595946123691D6E007DBE15 /* ecc_sign_hash.c */; };
+		1595968723691D6F007DBE15 /* ecc_encrypt_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595946223691D6E007DBE15 /* ecc_encrypt_key.c */; };
+		1595968823691D6F007DBE15 /* ecc_set_curve_internal.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595946323691D6E007DBE15 /* ecc_set_curve_internal.c */; };
+		1595968923691D6F007DBE15 /* ltc_ecc_verify_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595946423691D6E007DBE15 /* ltc_ecc_verify_key.c */; };
+		1595968A23691D6F007DBE15 /* ltc_ecc_export_point.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595946523691D6E007DBE15 /* ltc_ecc_export_point.c */; };
+		1595968B23691D6F007DBE15 /* pkcs_1_os2ip.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595946723691D6E007DBE15 /* pkcs_1_os2ip.c */; };
+		1595968C23691D6F007DBE15 /* pkcs_1_pss_decode.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595946823691D6E007DBE15 /* pkcs_1_pss_decode.c */; };
+		1595968D23691D6F007DBE15 /* pkcs_1_pss_encode.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595946923691D6E007DBE15 /* pkcs_1_pss_encode.c */; };
+		1595968E23691D6F007DBE15 /* pkcs_1_mgf1.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595946A23691D6E007DBE15 /* pkcs_1_mgf1.c */; };
+		1595968F23691D6F007DBE15 /* pkcs_1_oaep_decode.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595946B23691D6E007DBE15 /* pkcs_1_oaep_decode.c */; };
+		1595969023691D6F007DBE15 /* pkcs_1_v1_5_decode.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595946C23691D6E007DBE15 /* pkcs_1_v1_5_decode.c */; };
+		1595969123691D6F007DBE15 /* pkcs_1_v1_5_encode.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595946D23691D6E007DBE15 /* pkcs_1_v1_5_encode.c */; };
+		1595969223691D6F007DBE15 /* pkcs_1_oaep_encode.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595946E23691D6E007DBE15 /* pkcs_1_oaep_encode.c */; };
+		1595969323691D6F007DBE15 /* pkcs_1_i2osp.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595946F23691D6E007DBE15 /* pkcs_1_i2osp.c */; };
+		1595969423691D6F007DBE15 /* x25519_make_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595947123691D6E007DBE15 /* x25519_make_key.c */; };
+		1595969523691D6F007DBE15 /* x25519_import_pkcs8.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595947223691D6E007DBE15 /* x25519_import_pkcs8.c */; };
+		1595969623691D6F007DBE15 /* x25519_export.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595947323691D6E007DBE15 /* x25519_export.c */; };
+		1595969723691D6F007DBE15 /* x25519_shared_secret.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595947423691D6E007DBE15 /* x25519_shared_secret.c */; };
+		1595969823691D6F007DBE15 /* x25519_import.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595947523691D6E007DBE15 /* x25519_import.c */; };
+		1595969923691D6F007DBE15 /* x25519_import_raw.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595947623691D6E007DBE15 /* x25519_import_raw.c */; };
+		1595969A23691D6F007DBE15 /* x25519_import_x509.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595947723691D6E007DBE15 /* x25519_import_x509.c */; };
+		1595969B23691D6F007DBE15 /* md4.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595947923691D6E007DBE15 /* md4.c */; };
+		1595969C23691D6F007DBE15 /* sha512_224.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595947B23691D6E007DBE15 /* sha512_224.c */; };
+		1595969D23691D6F007DBE15 /* sha512_256.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595947C23691D6E007DBE15 /* sha512_256.c */; };
+		1595969E23691D6F007DBE15 /* sha224.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595947D23691D6E007DBE15 /* sha224.c */; };
+		1595969F23691D6F007DBE15 /* sha256.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595947E23691D6E007DBE15 /* sha256.c */; };
+		159596A023691D6F007DBE15 /* sha512.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595947F23691D6E007DBE15 /* sha512.c */; };
+		159596A123691D6F007DBE15 /* sha384.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595948023691D6E007DBE15 /* sha384.c */; };
+		159596A223691D6F007DBE15 /* whirltab.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595948223691D6E007DBE15 /* whirltab.c */; };
+		159596A323691D6F007DBE15 /* whirl.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595948323691D6E007DBE15 /* whirl.c */; };
+		159596A423691D6F007DBE15 /* sha1.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595948423691D6E007DBE15 /* sha1.c */; };
+		159596A523691D6F007DBE15 /* rmd128.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595948523691D6E007DBE15 /* rmd128.c */; };
+		159596A623691D6F007DBE15 /* sha3_test.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595948623691D6E007DBE15 /* sha3_test.c */; };
+		159596A723691D6F007DBE15 /* chc.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595948823691D6E007DBE15 /* chc.c */; };
+		159596A823691D6F007DBE15 /* rmd256.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595948923691D6E007DBE15 /* rmd256.c */; };
+		159596A923691D6F007DBE15 /* md2.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595948A23691D6E007DBE15 /* md2.c */; };
+		159596AA23691D6F007DBE15 /* blake2b.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595948B23691D6E007DBE15 /* blake2b.c */; };
+		159596AB23691D6F007DBE15 /* md5.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595948C23691D6E007DBE15 /* md5.c */; };
+		159596AC23691D6F007DBE15 /* tiger.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595948D23691D6E007DBE15 /* tiger.c */; };
+		159596AD23691D6F007DBE15 /* blake2s.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595948E23691D6E007DBE15 /* blake2s.c */; };
+		159596AE23691D6F007DBE15 /* sha3.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595948F23691D6E007DBE15 /* sha3.c */; };
+		159596AF23691D6F007DBE15 /* hash_memory_multi.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595949123691D6E007DBE15 /* hash_memory_multi.c */; };
+		159596B023691D6F007DBE15 /* hash_file.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595949223691D6E007DBE15 /* hash_file.c */; };
+		159596B123691D6F007DBE15 /* hash_filehandle.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595949323691D6E007DBE15 /* hash_filehandle.c */; };
+		159596B223691D6F007DBE15 /* hash_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595949423691D6E007DBE15 /* hash_memory.c */; };
+		159596B323691D6F007DBE15 /* rmd160.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595949523691D6E007DBE15 /* rmd160.c */; };
+		159596B423691D6F007DBE15 /* rmd320.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595949623691D6E007DBE15 /* rmd320.c */; };
+		159596B523691D6F007DBE15 /* xts_init.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595949923691D6E007DBE15 /* xts_init.c */; };
+		159596B623691D6F007DBE15 /* xts_mult_x.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595949A23691D6E007DBE15 /* xts_mult_x.c */; };
+		159596B723691D6F007DBE15 /* xts_decrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595949B23691D6E007DBE15 /* xts_decrypt.c */; };
+		159596B823691D6F007DBE15 /* xts_encrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595949C23691D6E007DBE15 /* xts_encrypt.c */; };
+		159596B923691D6F007DBE15 /* xts_done.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595949D23691D6E007DBE15 /* xts_done.c */; };
+		159596BA23691D6F007DBE15 /* xts_test.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595949E23691D6E007DBE15 /* xts_test.c */; };
+		159596BB23691D6F007DBE15 /* ctr_encrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594A023691D6E007DBE15 /* ctr_encrypt.c */; };
+		159596BC23691D6F007DBE15 /* ctr_setiv.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594A123691D6E007DBE15 /* ctr_setiv.c */; };
+		159596BD23691D6F007DBE15 /* ctr_start.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594A223691D6E007DBE15 /* ctr_start.c */; };
+		159596BE23691D6F007DBE15 /* ctr_decrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594A323691D6E007DBE15 /* ctr_decrypt.c */; };
+		159596BF23691D6F007DBE15 /* ctr_getiv.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594A423691D6E007DBE15 /* ctr_getiv.c */; };
+		159596C023691D6F007DBE15 /* ctr_test.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594A523691D6E007DBE15 /* ctr_test.c */; };
+		159596C123691D6F007DBE15 /* ctr_done.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594A623691D6E007DBE15 /* ctr_done.c */; };
+		159596C223691D6F007DBE15 /* ofb_getiv.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594A823691D6E007DBE15 /* ofb_getiv.c */; };
+		159596C323691D6F007DBE15 /* ofb_encrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594A923691D6E007DBE15 /* ofb_encrypt.c */; };
+		159596C423691D6F007DBE15 /* ofb_done.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594AA23691D6E007DBE15 /* ofb_done.c */; };
+		159596C523691D6F007DBE15 /* ofb_start.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594AB23691D6E007DBE15 /* ofb_start.c */; };
+		159596C623691D6F007DBE15 /* ofb_setiv.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594AC23691D6E007DBE15 /* ofb_setiv.c */; };
+		159596C723691D6F007DBE15 /* ofb_decrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594AD23691D6E007DBE15 /* ofb_decrypt.c */; };
+		159596C823691D6F007DBE15 /* cbc_setiv.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594AF23691D6E007DBE15 /* cbc_setiv.c */; };
+		159596C923691D6F007DBE15 /* cbc_decrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594B023691D6E007DBE15 /* cbc_decrypt.c */; };
+		159596CA23691D6F007DBE15 /* cbc_done.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594B123691D6E007DBE15 /* cbc_done.c */; };
+		159596CB23691D6F007DBE15 /* cbc_getiv.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594B223691D6E007DBE15 /* cbc_getiv.c */; };
+		159596CC23691D6F007DBE15 /* cbc_start.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594B323691D6E007DBE15 /* cbc_start.c */; };
+		159596CD23691D6F007DBE15 /* cbc_encrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594B423691D6E007DBE15 /* cbc_encrypt.c */; };
+		159596CE23691D6F007DBE15 /* lrw_encrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594B623691D6E007DBE15 /* lrw_encrypt.c */; };
+		159596CF23691D6F007DBE15 /* lrw_test.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594B723691D6E007DBE15 /* lrw_test.c */; };
+		159596D023691D6F007DBE15 /* lrw_process.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594B823691D6E007DBE15 /* lrw_process.c */; };
+		159596D123691D6F007DBE15 /* lrw_setiv.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594B923691D6E007DBE15 /* lrw_setiv.c */; };
+		159596D223691D6F007DBE15 /* lrw_done.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594BA23691D6E007DBE15 /* lrw_done.c */; };
+		159596D323691D6F007DBE15 /* lrw_start.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594BB23691D6E007DBE15 /* lrw_start.c */; };
+		159596D423691D6F007DBE15 /* lrw_getiv.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594BC23691D6E007DBE15 /* lrw_getiv.c */; };
+		159596D523691D6F007DBE15 /* lrw_decrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594BD23691D6E007DBE15 /* lrw_decrypt.c */; };
+		159596D623691D6F007DBE15 /* f8_start.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594BF23691D6E007DBE15 /* f8_start.c */; };
+		159596D723691D6F007DBE15 /* f8_decrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594C023691D6E007DBE15 /* f8_decrypt.c */; };
+		159596D823691D6F007DBE15 /* f8_getiv.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594C123691D6E007DBE15 /* f8_getiv.c */; };
+		159596D923691D6F007DBE15 /* f8_done.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594C223691D6E007DBE15 /* f8_done.c */; };
+		159596DA23691D6F007DBE15 /* f8_test_mode.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594C323691D6E007DBE15 /* f8_test_mode.c */; };
+		159596DB23691D6F007DBE15 /* f8_encrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594C423691D6E007DBE15 /* f8_encrypt.c */; };
+		159596DC23691D6F007DBE15 /* f8_setiv.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594C523691D6E007DBE15 /* f8_setiv.c */; };
+		159596DD23691D6F007DBE15 /* cfb_done.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594C723691D6E007DBE15 /* cfb_done.c */; };
+		159596DE23691D6F007DBE15 /* cfb_encrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594C823691D6E007DBE15 /* cfb_encrypt.c */; };
+		159596DF23691D6F007DBE15 /* cfb_start.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594C923691D6E007DBE15 /* cfb_start.c */; };
+		159596E023691D6F007DBE15 /* cfb_getiv.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594CA23691D6E007DBE15 /* cfb_getiv.c */; };
+		159596E123691D6F007DBE15 /* cfb_setiv.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594CB23691D6E007DBE15 /* cfb_setiv.c */; };
+		159596E223691D6F007DBE15 /* cfb_decrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594CC23691D6E007DBE15 /* cfb_decrypt.c */; };
+		159596E323691D6F007DBE15 /* ecb_encrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594CE23691D6E007DBE15 /* ecb_encrypt.c */; };
+		159596E423691D6F007DBE15 /* ecb_done.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594CF23691D6E007DBE15 /* ecb_done.c */; };
+		159596E523691D6F007DBE15 /* ecb_decrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594D023691D6E007DBE15 /* ecb_decrypt.c */; };
+		159596E623691D6F007DBE15 /* ecb_start.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594D123691D6E007DBE15 /* ecb_start.c */; };
+		159596E723691D6F007DBE15 /* chacha20.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594D323691D6E007DBE15 /* chacha20.c */; };
+		159596E823691D6F007DBE15 /* rc4.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594D423691D6E007DBE15 /* rc4.c */; };
+		159596E923691D6F007DBE15 /* rng_get_bytes.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594D523691D6E007DBE15 /* rng_get_bytes.c */; };
+		159596EA23691D6F007DBE15 /* fortuna.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594D623691D6E007DBE15 /* fortuna.c */; };
+		159596EB23691D6F007DBE15 /* rng_make_prng.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594D723691D6E007DBE15 /* rng_make_prng.c */; };
+		159596EC23691D6F007DBE15 /* sober128.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594D823691D6E007DBE15 /* sober128.c */; };
+		159596ED23691D6F007DBE15 /* sprng.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594D923691D6E007DBE15 /* sprng.c */; };
+		159596EE23691D6F007DBE15 /* yarrow.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594DA23691D6E007DBE15 /* yarrow.c */; };
+		159596EF23691D6F007DBE15 /* eax_decrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594DD23691D6E007DBE15 /* eax_decrypt.c */; };
+		159596F023691D6F007DBE15 /* eax_decrypt_verify_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594DE23691D6E007DBE15 /* eax_decrypt_verify_memory.c */; };
+		159596F123691D6F007DBE15 /* eax_init.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594DF23691D6E007DBE15 /* eax_init.c */; };
+		159596F223691D6F007DBE15 /* eax_encrypt_authenticate_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594E023691D6E007DBE15 /* eax_encrypt_authenticate_memory.c */; };
+		159596F323691D6F007DBE15 /* eax_addheader.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594E123691D6E007DBE15 /* eax_addheader.c */; };
+		159596F423691D6F007DBE15 /* eax_encrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594E223691D6E007DBE15 /* eax_encrypt.c */; };
+		159596F523691D6F007DBE15 /* eax_done.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594E323691D6E007DBE15 /* eax_done.c */; };
+		159596F623691D6F007DBE15 /* eax_test.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594E423691D6E007DBE15 /* eax_test.c */; };
+		159596F723691D6F007DBE15 /* gcm_init.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594E623691D6E007DBE15 /* gcm_init.c */; };
+		159596F823691D6F007DBE15 /* gcm_process.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594E723691D6E007DBE15 /* gcm_process.c */; };
+		159596F923691D6F007DBE15 /* gcm_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594E823691D6E007DBE15 /* gcm_memory.c */; };
+		159596FA23691D6F007DBE15 /* gcm_reset.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594E923691D6E007DBE15 /* gcm_reset.c */; };
+		159596FB23691D6F007DBE15 /* gcm_done.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594EA23691D6E007DBE15 /* gcm_done.c */; };
+		159596FC23691D6F007DBE15 /* gcm_test.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594EB23691D6E007DBE15 /* gcm_test.c */; };
+		159596FD23691D6F007DBE15 /* gcm_mult_h.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594EC23691D6E007DBE15 /* gcm_mult_h.c */; };
+		159596FE23691D6F007DBE15 /* gcm_add_iv.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594ED23691D6E007DBE15 /* gcm_add_iv.c */; };
+		159596FF23691D6F007DBE15 /* gcm_add_aad.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594EE23691D6E007DBE15 /* gcm_add_aad.c */; };
+		1595970023691D6F007DBE15 /* gcm_gf_mult.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594EF23691D6E007DBE15 /* gcm_gf_mult.c */; };
+		1595970123691D6F007DBE15 /* ccm_done.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594F123691D6E007DBE15 /* ccm_done.c */; };
+		1595970223691D6F007DBE15 /* ccm_add_aad.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594F223691D6E007DBE15 /* ccm_add_aad.c */; };
+		1595970323691D6F007DBE15 /* ccm_test.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594F323691D6E007DBE15 /* ccm_test.c */; };
+		1595970423691D6F007DBE15 /* ccm_add_nonce.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594F423691D6E007DBE15 /* ccm_add_nonce.c */; };
+		1595970523691D6F007DBE15 /* ccm_process.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594F523691D6E007DBE15 /* ccm_process.c */; };
+		1595970623691D6F007DBE15 /* ccm_reset.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594F623691D6E007DBE15 /* ccm_reset.c */; };
+		1595970723691D6F007DBE15 /* ccm_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594F723691D6E007DBE15 /* ccm_memory.c */; };
+		1595970823691D6F007DBE15 /* ccm_init.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594F823691D6E007DBE15 /* ccm_init.c */; };
+		1595970923691D6F007DBE15 /* chacha20poly1305_test.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594FA23691D6E007DBE15 /* chacha20poly1305_test.c */; };
+		1595970A23691D6F007DBE15 /* chacha20poly1305_done.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594FB23691D6E007DBE15 /* chacha20poly1305_done.c */; };
+		1595970B23691D6F007DBE15 /* chacha20poly1305_add_aad.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594FC23691D6E007DBE15 /* chacha20poly1305_add_aad.c */; };
+		1595970C23691D6F007DBE15 /* chacha20poly1305_setiv_rfc7905.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594FD23691D6E007DBE15 /* chacha20poly1305_setiv_rfc7905.c */; };
+		1595970D23691D6F007DBE15 /* chacha20poly1305_decrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594FE23691D6E007DBE15 /* chacha20poly1305_decrypt.c */; };
+		1595970E23691D6F007DBE15 /* chacha20poly1305_encrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 159594FF23691D6E007DBE15 /* chacha20poly1305_encrypt.c */; };
+		1595970F23691D6F007DBE15 /* chacha20poly1305_setiv.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595950023691D6E007DBE15 /* chacha20poly1305_setiv.c */; };
+		1595971023691D6F007DBE15 /* chacha20poly1305_init.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595950123691D6E007DBE15 /* chacha20poly1305_init.c */; };
+		1595971123691D6F007DBE15 /* chacha20poly1305_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595950223691D6E007DBE15 /* chacha20poly1305_memory.c */; };
+		1595971223691D6F007DBE15 /* ocb_ntz.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595950423691D6E007DBE15 /* ocb_ntz.c */; };
+		1595971323691D6F007DBE15 /* ocb_encrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595950523691D6E007DBE15 /* ocb_encrypt.c */; };
+		1595971423691D6F007DBE15 /* ocb_shift_xor.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595950623691D6E007DBE15 /* ocb_shift_xor.c */; };
+		1595971523691D6F007DBE15 /* ocb_init.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595950723691D6E007DBE15 /* ocb_init.c */; };
+		1595971623691D6F007DBE15 /* ocb_encrypt_authenticate_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595950823691D6E007DBE15 /* ocb_encrypt_authenticate_memory.c */; };
+		1595971723691D6F007DBE15 /* s_ocb_done.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595950923691D6E007DBE15 /* s_ocb_done.c */; };
+		1595971823691D6F007DBE15 /* ocb_done_encrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595950A23691D6E007DBE15 /* ocb_done_encrypt.c */; };
+		1595971923691D6F007DBE15 /* ocb_test.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595950B23691D6E007DBE15 /* ocb_test.c */; };
+		1595971A23691D6F007DBE15 /* ocb_done_decrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595950C23691D6E007DBE15 /* ocb_done_decrypt.c */; };
+		1595971B23691D6F007DBE15 /* ocb_decrypt_verify_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595950D23691D6E007DBE15 /* ocb_decrypt_verify_memory.c */; };
+		1595971C23691D6F007DBE15 /* ocb_decrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595950E23691D6E007DBE15 /* ocb_decrypt.c */; };
+		1595971D23691D6F007DBE15 /* ocb3_int_ntz.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595951023691D6E007DBE15 /* ocb3_int_ntz.c */; };
+		1595971E23691D6F007DBE15 /* ocb3_encrypt_authenticate_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595951123691D6E007DBE15 /* ocb3_encrypt_authenticate_memory.c */; };
+		1595971F23691D6F007DBE15 /* ocb3_add_aad.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595951223691D6E007DBE15 /* ocb3_add_aad.c */; };
+		1595972023691D6F007DBE15 /* ocb3_encrypt_last.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595951323691D6E007DBE15 /* ocb3_encrypt_last.c */; };
+		1595972123691D6F007DBE15 /* ocb3_int_xor_blocks.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595951423691D6E007DBE15 /* ocb3_int_xor_blocks.c */; };
+		1595972223691D6F007DBE15 /* ocb3_decrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595951523691D6E007DBE15 /* ocb3_decrypt.c */; };
+		1595972323691D6F007DBE15 /* ocb3_done.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595951623691D6E007DBE15 /* ocb3_done.c */; };
+		1595972423691D6F007DBE15 /* ocb3_test.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595951723691D6E007DBE15 /* ocb3_test.c */; };
+		1595972523691D6F007DBE15 /* ocb3_decrypt_verify_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595951823691D6E007DBE15 /* ocb3_decrypt_verify_memory.c */; };
+		1595972623691D6F007DBE15 /* ocb3_encrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595951923691D6E007DBE15 /* ocb3_encrypt.c */; };
+		1595972723691D6F007DBE15 /* ocb3_decrypt_last.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595951A23691D6E007DBE15 /* ocb3_decrypt_last.c */; };
+		1595972823691D6F007DBE15 /* ocb3_init.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595951B23691D6E007DBE15 /* ocb3_init.c */; };
+		1595972923691D6F007DBE15 /* rc4_stream.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595951E23691D6E007DBE15 /* rc4_stream.c */; };
+		1595972A23691D6F007DBE15 /* rc4_test.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595951F23691D6E007DBE15 /* rc4_test.c */; };
+		1595972B23691D6F007DBE15 /* rc4_stream_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595952023691D6E007DBE15 /* rc4_stream_memory.c */; };
+		1595972C23691D6F007DBE15 /* chacha_ivctr32.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595952223691D6E007DBE15 /* chacha_ivctr32.c */; };
+		1595972D23691D6F007DBE15 /* chacha_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595952323691D6E007DBE15 /* chacha_memory.c */; };
+		1595972E23691D6F007DBE15 /* chacha_crypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595952423691D6E007DBE15 /* chacha_crypt.c */; };
+		1595972F23691D6F007DBE15 /* chacha_keystream.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595952523691D6E007DBE15 /* chacha_keystream.c */; };
+		1595973023691D6F007DBE15 /* chacha_test.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595952623691D6E007DBE15 /* chacha_test.c */; };
+		1595973123691D6F007DBE15 /* chacha_done.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595952723691D6E007DBE15 /* chacha_done.c */; };
+		1595973223691D6F007DBE15 /* chacha_ivctr64.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595952823691D6E007DBE15 /* chacha_ivctr64.c */; };
+		1595973323691D6F007DBE15 /* chacha_setup.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595952923691D6E007DBE15 /* chacha_setup.c */; };
+		1595973423691D6F007DBE15 /* sober128_stream_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595952B23691D6E007DBE15 /* sober128_stream_memory.c */; };
+		1595973523691D6F007DBE15 /* sober128tab.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595952C23691D6E007DBE15 /* sober128tab.c */; };
+		1595973623691D6F007DBE15 /* sober128_test.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595952D23691D6E007DBE15 /* sober128_test.c */; };
+		1595973723691D6F007DBE15 /* sober128_stream.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595952E23691D6E007DBE15 /* sober128_stream.c */; };
+		1595973823691D6F007DBE15 /* salsa20_setup.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595953023691D6E007DBE15 /* salsa20_setup.c */; };
+		1595973923691D6F007DBE15 /* xsalsa20_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595953123691D6E007DBE15 /* xsalsa20_memory.c */; };
+		1595973A23691D6F007DBE15 /* salsa20_done.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595953223691D6E007DBE15 /* salsa20_done.c */; };
+		1595973B23691D6F007DBE15 /* salsa20_test.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595953323691D6E007DBE15 /* salsa20_test.c */; };
+		1595973C23691D6F007DBE15 /* salsa20_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595953423691D6E007DBE15 /* salsa20_memory.c */; };
+		1595973D23691D6F007DBE15 /* salsa20_keystream.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595953523691D6E007DBE15 /* salsa20_keystream.c */; };
+		1595973E23691D6F007DBE15 /* salsa20_crypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595953623691D6E007DBE15 /* salsa20_crypt.c */; };
+		1595973F23691D6F007DBE15 /* xsalsa20_test.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595953723691D6E007DBE15 /* xsalsa20_test.c */; };
+		1595974023691D6F007DBE15 /* salsa20_ivctr64.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595953823691D6E007DBE15 /* salsa20_ivctr64.c */; };
+		1595974123691D6F007DBE15 /* xsalsa20_setup.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595953923691D6E007DBE15 /* xsalsa20_setup.c */; };
+		1595974223691D6F007DBE15 /* rabbit_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595953B23691D6E007DBE15 /* rabbit_memory.c */; };
+		1595974323691D6F007DBE15 /* rabbit.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595953C23691D6E007DBE15 /* rabbit.c */; };
+		1595974423691D6F007DBE15 /* sosemanuk_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595953E23691D6E007DBE15 /* sosemanuk_memory.c */; };
+		1595974523691D6F007DBE15 /* sosemanuk_test.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595953F23691D6E007DBE15 /* sosemanuk_test.c */; };
+		1595974623691D6F007DBE15 /* sosemanuk.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595954023691D6E007DBE15 /* sosemanuk.c */; };
+		1595974723691D6F007DBE15 /* radix_to_bin.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595954223691D6E007DBE15 /* radix_to_bin.c */; };
+		1595974823691D6F007DBE15 /* tfm_desc.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595954323691D6E007DBE15 /* tfm_desc.c */; };
+		1595974923691D6F007DBE15 /* rand_bn.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595954423691D6E007DBE15 /* rand_bn.c */; };
+		1595974A23691D6F007DBE15 /* ltc_ecc_fp_mulmod.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595954623691D6E007DBE15 /* ltc_ecc_fp_mulmod.c */; };
+		1595974B23691D6F007DBE15 /* multi.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595954723691D6E007DBE15 /* multi.c */; };
+		1595974C23691D6F007DBE15 /* ltm_desc.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595954823691D6E007DBE15 /* ltm_desc.c */; };
+		1595974D23691D6F007DBE15 /* gmp_desc.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595954923691D6E007DBE15 /* gmp_desc.c */; };
+		1595974E23691D6F007DBE15 /* rand_prime.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595954A23691D6E007DBE15 /* rand_prime.c */; };
+		1595974F23691D6F007DBE15 /* pmac_init.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595954D23691D6F007DBE15 /* pmac_init.c */; };
+		1595975023691D6F007DBE15 /* pmac_shift_xor.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595954E23691D6F007DBE15 /* pmac_shift_xor.c */; };
+		1595975123691D6F007DBE15 /* pmac_ntz.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595954F23691D6F007DBE15 /* pmac_ntz.c */; };
+		1595975223691D6F007DBE15 /* pmac_done.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595955023691D6F007DBE15 /* pmac_done.c */; };
+		1595975323691D6F007DBE15 /* pmac_file.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595955123691D6F007DBE15 /* pmac_file.c */; };
+		1595975423691D6F007DBE15 /* pmac_test.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595955223691D6F007DBE15 /* pmac_test.c */; };
+		1595975523691D6F007DBE15 /* pmac_memory_multi.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595955323691D6F007DBE15 /* pmac_memory_multi.c */; };
+		1595975623691D6F007DBE15 /* pmac_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595955423691D6F007DBE15 /* pmac_memory.c */; };
+		1595975723691D6F007DBE15 /* pmac_process.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595955523691D6F007DBE15 /* pmac_process.c */; };
+		1595975823691D6F007DBE15 /* hmac_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595955723691D6F007DBE15 /* hmac_memory.c */; };
+		1595975923691D6F007DBE15 /* hmac_init.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595955823691D6F007DBE15 /* hmac_init.c */; };
+		1595975A23691D6F007DBE15 /* hmac_done.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595955923691D6F007DBE15 /* hmac_done.c */; };
+		1595975B23691D6F007DBE15 /* hmac_test.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595955A23691D6F007DBE15 /* hmac_test.c */; };
+		1595975C23691D6F007DBE15 /* hmac_file.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595955B23691D6F007DBE15 /* hmac_file.c */; };
+		1595975D23691D6F007DBE15 /* hmac_memory_multi.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595955C23691D6F007DBE15 /* hmac_memory_multi.c */; };
+		1595975E23691D6F007DBE15 /* hmac_process.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595955D23691D6F007DBE15 /* hmac_process.c */; };
+		1595975F23691D6F007DBE15 /* blake2bmac_file.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595955F23691D6F007DBE15 /* blake2bmac_file.c */; };
+		1595976023691D6F007DBE15 /* blake2smac_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595956023691D6F007DBE15 /* blake2smac_memory.c */; };
+		1595976123691D6F007DBE15 /* blake2bmac_test.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595956123691D6F007DBE15 /* blake2bmac_test.c */; };
+		1595976223691D6F007DBE15 /* blake2bmac_memory_multi.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595956223691D6F007DBE15 /* blake2bmac_memory_multi.c */; };
+		1595976323691D6F007DBE15 /* blake2smac.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595956323691D6F007DBE15 /* blake2smac.c */; };
+		1595976423691D6F007DBE15 /* blake2smac_test.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595956423691D6F007DBE15 /* blake2smac_test.c */; };
+		1595976523691D6F007DBE15 /* blake2smac_file.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595956523691D6F007DBE15 /* blake2smac_file.c */; };
+		1595976623691D6F007DBE15 /* blake2smac_memory_multi.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595956623691D6F007DBE15 /* blake2smac_memory_multi.c */; };
+		1595976723691D6F007DBE15 /* blake2bmac_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595956723691D6F007DBE15 /* blake2bmac_memory.c */; };
+		1595976823691D6F007DBE15 /* blake2bmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595956823691D6F007DBE15 /* blake2bmac.c */; };
+		1595976923691D6F007DBE15 /* poly1305_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595956A23691D6F007DBE15 /* poly1305_memory.c */; };
+		1595976A23691D6F007DBE15 /* poly1305_test.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595956B23691D6F007DBE15 /* poly1305_test.c */; };
+		1595976B23691D6F007DBE15 /* poly1305_file.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595956C23691D6F007DBE15 /* poly1305_file.c */; };
+		1595976C23691D6F007DBE15 /* poly1305.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595956D23691D6F007DBE15 /* poly1305.c */; };
+		1595976D23691D6F007DBE15 /* poly1305_memory_multi.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595956E23691D6F007DBE15 /* poly1305_memory_multi.c */; };
+		1595976E23691D6F007DBE15 /* xcbc_init.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595957023691D6F007DBE15 /* xcbc_init.c */; };
+		1595976F23691D6F007DBE15 /* xcbc_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595957123691D6F007DBE15 /* xcbc_memory.c */; };
+		1595977023691D6F007DBE15 /* xcbc_process.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595957223691D6F007DBE15 /* xcbc_process.c */; };
+		1595977123691D6F007DBE15 /* xcbc_file.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595957323691D6F007DBE15 /* xcbc_file.c */; };
+		1595977223691D6F007DBE15 /* xcbc_test.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595957423691D6F007DBE15 /* xcbc_test.c */; };
+		1595977323691D6F007DBE15 /* xcbc_memory_multi.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595957523691D6F007DBE15 /* xcbc_memory_multi.c */; };
+		1595977423691D6F007DBE15 /* xcbc_done.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595957623691D6F007DBE15 /* xcbc_done.c */; };
+		1595977523691D6F007DBE15 /* f9_memory_multi.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595957823691D6F007DBE15 /* f9_memory_multi.c */; };
+		1595977623691D6F007DBE15 /* f9_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595957923691D6F007DBE15 /* f9_memory.c */; };
+		1595977723691D6F007DBE15 /* f9_init.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595957A23691D6F007DBE15 /* f9_init.c */; };
+		1595977823691D6F007DBE15 /* f9_process.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595957B23691D6F007DBE15 /* f9_process.c */; };
+		1595977923691D6F007DBE15 /* f9_done.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595957C23691D6F007DBE15 /* f9_done.c */; };
+		1595977A23691D6F007DBE15 /* f9_file.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595957D23691D6F007DBE15 /* f9_file.c */; };
+		1595977B23691D6F007DBE15 /* f9_test.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595957E23691D6F007DBE15 /* f9_test.c */; };
+		1595977C23691D6F007DBE15 /* pelican.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595958023691D6F007DBE15 /* pelican.c */; };
+		1595977D23691D6F007DBE15 /* pelican_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595958123691D6F007DBE15 /* pelican_memory.c */; };
+		1595977E23691D6F007DBE15 /* pelican_test.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595958223691D6F007DBE15 /* pelican_test.c */; };
+		1595977F23691D6F007DBE15 /* omac_init.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595958423691D6F007DBE15 /* omac_init.c */; };
+		1595978023691D6F007DBE15 /* omac_file.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595958523691D6F007DBE15 /* omac_file.c */; };
+		1595978123691D6F007DBE15 /* omac_test.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595958623691D6F007DBE15 /* omac_test.c */; };
+		1595978223691D6F007DBE15 /* omac_process.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595958723691D6F007DBE15 /* omac_process.c */; };
+		1595978323691D6F007DBE15 /* omac_memory_multi.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595958823691D6F007DBE15 /* omac_memory_multi.c */; };
+		1595978423691D6F007DBE15 /* omac_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595958923691D6F007DBE15 /* omac_memory.c */; };
+		1595978523691D6F007DBE15 /* omac_done.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595958A23691D6F007DBE15 /* omac_done.c */; };
+		1595978623691D6F007DBE15 /* tomcrypt_pkcs.h in Headers */ = {isa = PBXBuildFile; fileRef = 1595958C23691D6F007DBE15 /* tomcrypt_pkcs.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1595978723691D6F007DBE15 /* tomcrypt_hash.h in Headers */ = {isa = PBXBuildFile; fileRef = 1595958D23691D6F007DBE15 /* tomcrypt_hash.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1595978823691D6F007DBE15 /* tomcrypt_private.h in Headers */ = {isa = PBXBuildFile; fileRef = 1595958E23691D6F007DBE15 /* tomcrypt_private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1595978923691D6F007DBE15 /* tomcrypt_macros.h in Headers */ = {isa = PBXBuildFile; fileRef = 1595958F23691D6F007DBE15 /* tomcrypt_macros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1595978A23691D6F007DBE15 /* tomcrypt_math.h in Headers */ = {isa = PBXBuildFile; fileRef = 1595959023691D6F007DBE15 /* tomcrypt_math.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1595978B23691D70007DBE15 /* tomcrypt_misc.h in Headers */ = {isa = PBXBuildFile; fileRef = 1595959123691D6F007DBE15 /* tomcrypt_misc.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1595978C23691D70007DBE15 /* tomcrypt.h in Headers */ = {isa = PBXBuildFile; fileRef = 1595959223691D6F007DBE15 /* tomcrypt.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1595978D23691D70007DBE15 /* tomcrypt_cipher.h in Headers */ = {isa = PBXBuildFile; fileRef = 1595959323691D6F007DBE15 /* tomcrypt_cipher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1595978E23691D70007DBE15 /* tomcrypt_pk.h in Headers */ = {isa = PBXBuildFile; fileRef = 1595959423691D6F007DBE15 /* tomcrypt_pk.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1595978F23691D70007DBE15 /* tomcrypt_cfg.h in Headers */ = {isa = PBXBuildFile; fileRef = 1595959523691D6F007DBE15 /* tomcrypt_cfg.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1595979023691D70007DBE15 /* tomcrypt_mac.h in Headers */ = {isa = PBXBuildFile; fileRef = 1595959623691D6F007DBE15 /* tomcrypt_mac.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1595979123691D70007DBE15 /* tomcrypt_prng.h in Headers */ = {isa = PBXBuildFile; fileRef = 1595959723691D6F007DBE15 /* tomcrypt_prng.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1595979223691D70007DBE15 /* tomcrypt_custom.h in Headers */ = {isa = PBXBuildFile; fileRef = 1595959823691D6F007DBE15 /* tomcrypt_custom.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1595979323691D70007DBE15 /* tomcrypt_argchk.h in Headers */ = {isa = PBXBuildFile; fileRef = 1595959923691D6F007DBE15 /* tomcrypt_argchk.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1595979423691D70007DBE15 /* noekeon.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595959B23691D6F007DBE15 /* noekeon.c */; };
+		1595979523691D70007DBE15 /* camellia.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595959C23691D6F007DBE15 /* camellia.c */; };
+		1595979623691D70007DBE15 /* safer.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595959E23691D6F007DBE15 /* safer.c */; };
+		1595979723691D70007DBE15 /* saferp.c in Sources */ = {isa = PBXBuildFile; fileRef = 1595959F23691D6F007DBE15 /* saferp.c */; };
+		1595979823691D70007DBE15 /* safer_tab.c in Sources */ = {isa = PBXBuildFile; fileRef = 159595A023691D6F007DBE15 /* safer_tab.c */; };
+		1595979923691D70007DBE15 /* tea.c in Sources */ = {isa = PBXBuildFile; fileRef = 159595A123691D6F007DBE15 /* tea.c */; };
+		1595979A23691D70007DBE15 /* kseed.c in Sources */ = {isa = PBXBuildFile; fileRef = 159595A223691D6F007DBE15 /* kseed.c */; };
+		1595979B23691D70007DBE15 /* des.c in Sources */ = {isa = PBXBuildFile; fileRef = 159595A323691D6F007DBE15 /* des.c */; };
+		1595979C23691D70007DBE15 /* khazad.c in Sources */ = {isa = PBXBuildFile; fileRef = 159595A423691D6F007DBE15 /* khazad.c */; };
+		1595979D23691D70007DBE15 /* idea.c in Sources */ = {isa = PBXBuildFile; fileRef = 159595A523691D6F007DBE15 /* idea.c */; };
+		1595979E23691D70007DBE15 /* blowfish.c in Sources */ = {isa = PBXBuildFile; fileRef = 159595A623691D6F007DBE15 /* blowfish.c */; };
+		1595979F23691D70007DBE15 /* kasumi.c in Sources */ = {isa = PBXBuildFile; fileRef = 159595A723691D6F007DBE15 /* kasumi.c */; };
+		159597A023691D70007DBE15 /* anubis.c in Sources */ = {isa = PBXBuildFile; fileRef = 159595A823691D6F007DBE15 /* anubis.c */; };
+		159597A123691D70007DBE15 /* rc2.c in Sources */ = {isa = PBXBuildFile; fileRef = 159595A923691D6F007DBE15 /* rc2.c */; };
+		159597A223691D70007DBE15 /* rc6.c in Sources */ = {isa = PBXBuildFile; fileRef = 159595AA23691D6F007DBE15 /* rc6.c */; };
+		159597A323691D70007DBE15 /* skipjack.c in Sources */ = {isa = PBXBuildFile; fileRef = 159595AB23691D6F007DBE15 /* skipjack.c */; };
+		159597A423691D70007DBE15 /* cast5.c in Sources */ = {isa = PBXBuildFile; fileRef = 159595AC23691D6F007DBE15 /* cast5.c */; };
+		159597A523691D70007DBE15 /* serpent.c in Sources */ = {isa = PBXBuildFile; fileRef = 159595AD23691D6F007DBE15 /* serpent.c */; };
+		159597A623691D70007DBE15 /* xtea.c in Sources */ = {isa = PBXBuildFile; fileRef = 159595AE23691D6F007DBE15 /* xtea.c */; };
+		159597A723691D70007DBE15 /* multi2.c in Sources */ = {isa = PBXBuildFile; fileRef = 159595AF23691D6F007DBE15 /* multi2.c */; };
+		159597A823691D70007DBE15 /* twofish.c in Sources */ = {isa = PBXBuildFile; fileRef = 159595B123691D6F007DBE15 /* twofish.c */; };
+		159597A923691D70007DBE15 /* twofish_tab.c in Sources */ = {isa = PBXBuildFile; fileRef = 159595B223691D6F007DBE15 /* twofish_tab.c */; };
+		159597AA23691D70007DBE15 /* rc5.c in Sources */ = {isa = PBXBuildFile; fileRef = 159595B323691D6F007DBE15 /* rc5.c */; };
+		159597AB23691D70007DBE15 /* aes.c in Sources */ = {isa = PBXBuildFile; fileRef = 159595B523691D6F007DBE15 /* aes.c */; };
+		159597AC23691D70007DBE15 /* aes_tab.c in Sources */ = {isa = PBXBuildFile; fileRef = 159595B623691D6F007DBE15 /* aes_tab.c */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		1595935D23691B13007DBE15 /* TomCrypt.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TomCrypt.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1595936123691B13007DBE15 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		1595936A23691D6D007DBE15 /* compare_testvector.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = compare_testvector.c; sourceTree = "<group>"; };
+		1595936B23691D6D007DBE15 /* error_to_string.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = error_to_string.c; sourceTree = "<group>"; };
+		1595936C23691D6D007DBE15 /* copy_or_zeromem.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = copy_or_zeromem.c; sourceTree = "<group>"; };
+		1595936E23691D6D007DBE15 /* pkcs12_utf8_to_utf16.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pkcs12_utf8_to_utf16.c; sourceTree = "<group>"; };
+		1595936F23691D6D007DBE15 /* pkcs12_kdf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pkcs12_kdf.c; sourceTree = "<group>"; };
+		1595937123691D6D007DBE15 /* pbes1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pbes1.c; sourceTree = "<group>"; };
+		1595937223691D6D007DBE15 /* pbes2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pbes2.c; sourceTree = "<group>"; };
+		1595937323691D6D007DBE15 /* pbes.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pbes.c; sourceTree = "<group>"; };
+		1595937523691D6D007DBE15 /* crypt_unregister_prng.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_unregister_prng.c; sourceTree = "<group>"; };
+		1595937623691D6D007DBE15 /* crypt_unregister_cipher.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_unregister_cipher.c; sourceTree = "<group>"; };
+		1595937723691D6D007DBE15 /* crypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt.c; sourceTree = "<group>"; };
+		1595937823691D6D007DBE15 /* crypt_find_cipher_any.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_find_cipher_any.c; sourceTree = "<group>"; };
+		1595937923691D6D007DBE15 /* crypt_prng_descriptor.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_prng_descriptor.c; sourceTree = "<group>"; };
+		1595937A23691D6D007DBE15 /* crypt_constants.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_constants.c; sourceTree = "<group>"; };
+		1595937B23691D6D007DBE15 /* crypt_prng_is_valid.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_prng_is_valid.c; sourceTree = "<group>"; };
+		1595937C23691D6D007DBE15 /* crypt_prng_rng_descriptor.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_prng_rng_descriptor.c; sourceTree = "<group>"; };
+		1595937D23691D6D007DBE15 /* crypt_cipher_is_valid.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_cipher_is_valid.c; sourceTree = "<group>"; };
+		1595937E23691D6D007DBE15 /* crypt_find_hash_oid.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_find_hash_oid.c; sourceTree = "<group>"; };
+		1595937F23691D6D007DBE15 /* crypt_hash_descriptor.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_hash_descriptor.c; sourceTree = "<group>"; };
+		1595938023691D6D007DBE15 /* crypt_register_all_ciphers.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_register_all_ciphers.c; sourceTree = "<group>"; };
+		1595938123691D6D007DBE15 /* crypt_register_prng.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_register_prng.c; sourceTree = "<group>"; };
+		1595938223691D6D007DBE15 /* crypt_register_cipher.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_register_cipher.c; sourceTree = "<group>"; };
+		1595938323691D6D007DBE15 /* crypt_find_hash.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_find_hash.c; sourceTree = "<group>"; };
+		1595938423691D6D007DBE15 /* crypt_inits.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_inits.c; sourceTree = "<group>"; };
+		1595938523691D6D007DBE15 /* crypt_cipher_descriptor.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_cipher_descriptor.c; sourceTree = "<group>"; };
+		1595938623691D6D007DBE15 /* crypt_register_all_hashes.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_register_all_hashes.c; sourceTree = "<group>"; };
+		1595938723691D6D007DBE15 /* crypt_find_cipher.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_find_cipher.c; sourceTree = "<group>"; };
+		1595938823691D6D007DBE15 /* crypt_find_hash_id.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_find_hash_id.c; sourceTree = "<group>"; };
+		1595938923691D6D007DBE15 /* crypt_ltc_mp_descriptor.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_ltc_mp_descriptor.c; sourceTree = "<group>"; };
+		1595938A23691D6D007DBE15 /* crypt_find_cipher_id.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_find_cipher_id.c; sourceTree = "<group>"; };
+		1595938B23691D6D007DBE15 /* crypt_register_hash.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_register_hash.c; sourceTree = "<group>"; };
+		1595938C23691D6D007DBE15 /* crypt_hash_is_valid.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_hash_is_valid.c; sourceTree = "<group>"; };
+		1595938D23691D6D007DBE15 /* crypt_find_prng.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_find_prng.c; sourceTree = "<group>"; };
+		1595938E23691D6D007DBE15 /* crypt_argchk.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_argchk.c; sourceTree = "<group>"; };
+		1595938F23691D6D007DBE15 /* crypt_sizes.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_sizes.c; sourceTree = "<group>"; };
+		1595939023691D6D007DBE15 /* crypt_find_hash_any.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_find_hash_any.c; sourceTree = "<group>"; };
+		1595939123691D6D007DBE15 /* crypt_register_all_prngs.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_register_all_prngs.c; sourceTree = "<group>"; };
+		1595939223691D6D007DBE15 /* crypt_fsa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_fsa.c; sourceTree = "<group>"; };
+		1595939323691D6D007DBE15 /* crypt_unregister_hash.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_unregister_hash.c; sourceTree = "<group>"; };
+		1595939523691D6D007DBE15 /* bcrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = bcrypt.c; sourceTree = "<group>"; };
+		1595939723691D6D007DBE15 /* base64_decode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = base64_decode.c; sourceTree = "<group>"; };
+		1595939823691D6D007DBE15 /* base64_encode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = base64_encode.c; sourceTree = "<group>"; };
+		1595939A23691D6D007DBE15 /* pkcs_5_1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pkcs_5_1.c; sourceTree = "<group>"; };
+		1595939B23691D6D007DBE15 /* pkcs_5_2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pkcs_5_2.c; sourceTree = "<group>"; };
+		1595939C23691D6D007DBE15 /* pkcs_5_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pkcs_5_test.c; sourceTree = "<group>"; };
+		1595939D23691D6D007DBE15 /* crc32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crc32.c; sourceTree = "<group>"; };
+		1595939E23691D6D007DBE15 /* burn_stack.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = burn_stack.c; sourceTree = "<group>"; };
+		159593A023691D6D007DBE15 /* hkdf_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hkdf_test.c; sourceTree = "<group>"; };
+		159593A123691D6D007DBE15 /* hkdf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hkdf.c; sourceTree = "<group>"; };
+		159593A323691D6D007DBE15 /* ssh_decode_sequence_multi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ssh_decode_sequence_multi.c; sourceTree = "<group>"; };
+		159593A423691D6D007DBE15 /* ssh_encode_sequence_multi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ssh_encode_sequence_multi.c; sourceTree = "<group>"; };
+		159593A623691D6D007DBE15 /* base16_encode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = base16_encode.c; sourceTree = "<group>"; };
+		159593A723691D6D007DBE15 /* base16_decode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = base16_decode.c; sourceTree = "<group>"; };
+		159593A923691D6D007DBE15 /* padding_pad.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = padding_pad.c; sourceTree = "<group>"; };
+		159593AA23691D6D007DBE15 /* padding_depad.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = padding_depad.c; sourceTree = "<group>"; };
+		159593AC23691D6D007DBE15 /* base32_decode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = base32_decode.c; sourceTree = "<group>"; };
+		159593AD23691D6D007DBE15 /* base32_encode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = base32_encode.c; sourceTree = "<group>"; };
+		159593AE23691D6D007DBE15 /* zeromem.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = zeromem.c; sourceTree = "<group>"; };
+		159593AF23691D6D007DBE15 /* mem_neq.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = mem_neq.c; sourceTree = "<group>"; };
+		159593B023691D6D007DBE15 /* adler32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = adler32.c; sourceTree = "<group>"; };
+		159593B523691D6D007DBE15 /* der_decode_octet_string.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_decode_octet_string.c; sourceTree = "<group>"; };
+		159593B623691D6D007DBE15 /* der_encode_octet_string.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_encode_octet_string.c; sourceTree = "<group>"; };
+		159593B723691D6D007DBE15 /* der_length_octet_string.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_length_octet_string.c; sourceTree = "<group>"; };
+		159593B923691D6D007DBE15 /* der_length_bit_string.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_length_bit_string.c; sourceTree = "<group>"; };
+		159593BA23691D6D007DBE15 /* der_encode_raw_bit_string.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_encode_raw_bit_string.c; sourceTree = "<group>"; };
+		159593BB23691D6D007DBE15 /* der_decode_raw_bit_string.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_decode_raw_bit_string.c; sourceTree = "<group>"; };
+		159593BC23691D6D007DBE15 /* der_encode_bit_string.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_encode_bit_string.c; sourceTree = "<group>"; };
+		159593BD23691D6D007DBE15 /* der_decode_bit_string.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_decode_bit_string.c; sourceTree = "<group>"; };
+		159593BF23691D6D007DBE15 /* der_encode_object_identifier.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_encode_object_identifier.c; sourceTree = "<group>"; };
+		159593C023691D6D007DBE15 /* der_decode_object_identifier.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_decode_object_identifier.c; sourceTree = "<group>"; };
+		159593C123691D6D007DBE15 /* der_length_object_identifier.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_length_object_identifier.c; sourceTree = "<group>"; };
+		159593C323691D6D007DBE15 /* der_encode_utf8_string.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_encode_utf8_string.c; sourceTree = "<group>"; };
+		159593C423691D6D007DBE15 /* der_decode_utf8_string.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_decode_utf8_string.c; sourceTree = "<group>"; };
+		159593C523691D6D007DBE15 /* der_length_utf8_string.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_length_utf8_string.c; sourceTree = "<group>"; };
+		159593C723691D6D007DBE15 /* der_encode_asn1_identifier.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_encode_asn1_identifier.c; sourceTree = "<group>"; };
+		159593C823691D6D007DBE15 /* der_length_asn1_identifier.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_length_asn1_identifier.c; sourceTree = "<group>"; };
+		159593C923691D6D007DBE15 /* der_encode_asn1_length.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_encode_asn1_length.c; sourceTree = "<group>"; };
+		159593CA23691D6D007DBE15 /* der_decode_asn1_identifier.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_decode_asn1_identifier.c; sourceTree = "<group>"; };
+		159593CB23691D6D007DBE15 /* der_length_asn1_length.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_length_asn1_length.c; sourceTree = "<group>"; };
+		159593CC23691D6D007DBE15 /* der_decode_asn1_length.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_decode_asn1_length.c; sourceTree = "<group>"; };
+		159593CD23691D6D007DBE15 /* der_asn1_maps.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_asn1_maps.c; sourceTree = "<group>"; };
+		159593CF23691D6D007DBE15 /* der_decode_generalizedtime.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_decode_generalizedtime.c; sourceTree = "<group>"; };
+		159593D023691D6D007DBE15 /* der_encode_generalizedtime.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_encode_generalizedtime.c; sourceTree = "<group>"; };
+		159593D123691D6D007DBE15 /* der_length_generalizedtime.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_length_generalizedtime.c; sourceTree = "<group>"; };
+		159593D323691D6D007DBE15 /* der_length_short_integer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_length_short_integer.c; sourceTree = "<group>"; };
+		159593D423691D6D007DBE15 /* der_encode_short_integer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_encode_short_integer.c; sourceTree = "<group>"; };
+		159593D523691D6D007DBE15 /* der_decode_short_integer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_decode_short_integer.c; sourceTree = "<group>"; };
+		159593D723691D6D007DBE15 /* der_decode_choice.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_decode_choice.c; sourceTree = "<group>"; };
+		159593D923691D6D007DBE15 /* der_length_ia5_string.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_length_ia5_string.c; sourceTree = "<group>"; };
+		159593DA23691D6D007DBE15 /* der_encode_ia5_string.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_encode_ia5_string.c; sourceTree = "<group>"; };
+		159593DB23691D6D007DBE15 /* der_decode_ia5_string.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_decode_ia5_string.c; sourceTree = "<group>"; };
+		159593DD23691D6D007DBE15 /* der_decode_teletex_string.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_decode_teletex_string.c; sourceTree = "<group>"; };
+		159593DE23691D6D007DBE15 /* der_length_teletex_string.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_length_teletex_string.c; sourceTree = "<group>"; };
+		159593E023691D6D007DBE15 /* der_decode_boolean.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_decode_boolean.c; sourceTree = "<group>"; };
+		159593E123691D6D007DBE15 /* der_length_boolean.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_length_boolean.c; sourceTree = "<group>"; };
+		159593E223691D6D007DBE15 /* der_encode_boolean.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_encode_boolean.c; sourceTree = "<group>"; };
+		159593E423691D6D007DBE15 /* der_length_integer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_length_integer.c; sourceTree = "<group>"; };
+		159593E523691D6D007DBE15 /* der_decode_integer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_decode_integer.c; sourceTree = "<group>"; };
+		159593E623691D6D007DBE15 /* der_encode_integer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_encode_integer.c; sourceTree = "<group>"; };
+		159593E823691D6D007DBE15 /* der_encode_custom_type.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_encode_custom_type.c; sourceTree = "<group>"; };
+		159593E923691D6D007DBE15 /* der_decode_custom_type.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_decode_custom_type.c; sourceTree = "<group>"; };
+		159593EA23691D6D007DBE15 /* der_length_custom_type.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_length_custom_type.c; sourceTree = "<group>"; };
+		159593EC23691D6D007DBE15 /* der_encode_setof.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_encode_setof.c; sourceTree = "<group>"; };
+		159593ED23691D6D007DBE15 /* der_encode_set.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_encode_set.c; sourceTree = "<group>"; };
+		159593EF23691D6E007DBE15 /* der_encode_sequence_ex.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_encode_sequence_ex.c; sourceTree = "<group>"; };
+		159593F023691D6E007DBE15 /* der_sequence_shrink.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_sequence_shrink.c; sourceTree = "<group>"; };
+		159593F123691D6E007DBE15 /* der_length_sequence.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_length_sequence.c; sourceTree = "<group>"; };
+		159593F223691D6E007DBE15 /* der_decode_sequence_ex.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_decode_sequence_ex.c; sourceTree = "<group>"; };
+		159593F323691D6E007DBE15 /* der_decode_sequence_multi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_decode_sequence_multi.c; sourceTree = "<group>"; };
+		159593F423691D6E007DBE15 /* der_decode_sequence_flexi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_decode_sequence_flexi.c; sourceTree = "<group>"; };
+		159593F523691D6E007DBE15 /* der_encode_sequence_multi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_encode_sequence_multi.c; sourceTree = "<group>"; };
+		159593F623691D6E007DBE15 /* der_sequence_free.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_sequence_free.c; sourceTree = "<group>"; };
+		159593F823691D6E007DBE15 /* der_encode_printable_string.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_encode_printable_string.c; sourceTree = "<group>"; };
+		159593F923691D6E007DBE15 /* der_length_printable_string.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_length_printable_string.c; sourceTree = "<group>"; };
+		159593FA23691D6E007DBE15 /* der_decode_printable_string.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_decode_printable_string.c; sourceTree = "<group>"; };
+		159593FC23691D6E007DBE15 /* der_encode_utctime.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_encode_utctime.c; sourceTree = "<group>"; };
+		159593FD23691D6E007DBE15 /* der_length_utctime.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_length_utctime.c; sourceTree = "<group>"; };
+		159593FE23691D6E007DBE15 /* der_decode_utctime.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = der_decode_utctime.c; sourceTree = "<group>"; };
+		1595940023691D6E007DBE15 /* x509_encode_subject_public_key_info.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x509_encode_subject_public_key_info.c; sourceTree = "<group>"; };
+		1595940123691D6E007DBE15 /* x509_decode_public_key_from_certificate.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x509_decode_public_key_from_certificate.c; sourceTree = "<group>"; };
+		1595940223691D6E007DBE15 /* x509_decode_subject_public_key_info.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x509_decode_subject_public_key_info.c; sourceTree = "<group>"; };
+		1595940423691D6E007DBE15 /* pk_get_oid.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pk_get_oid.c; sourceTree = "<group>"; };
+		1595940523691D6E007DBE15 /* pk_oid_str.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pk_oid_str.c; sourceTree = "<group>"; };
+		1595940623691D6E007DBE15 /* pk_oid_cmp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pk_oid_cmp.c; sourceTree = "<group>"; };
+		1595940823691D6E007DBE15 /* pkcs8_decode_flexi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pkcs8_decode_flexi.c; sourceTree = "<group>"; };
+		1595940A23691D6E007DBE15 /* dh_import.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dh_import.c; sourceTree = "<group>"; };
+		1595940B23691D6E007DBE15 /* dh_set.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dh_set.c; sourceTree = "<group>"; };
+		1595940C23691D6E007DBE15 /* dh_shared_secret.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dh_shared_secret.c; sourceTree = "<group>"; };
+		1595940D23691D6E007DBE15 /* dh_export_key.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dh_export_key.c; sourceTree = "<group>"; };
+		1595940E23691D6E007DBE15 /* dh_set_pg_dhparam.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dh_set_pg_dhparam.c; sourceTree = "<group>"; };
+		1595940F23691D6E007DBE15 /* dh_check_pubkey.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dh_check_pubkey.c; sourceTree = "<group>"; };
+		1595941023691D6E007DBE15 /* dh_free.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dh_free.c; sourceTree = "<group>"; };
+		1595941123691D6E007DBE15 /* dh_generate_key.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dh_generate_key.c; sourceTree = "<group>"; };
+		1595941223691D6E007DBE15 /* dh.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dh.c; sourceTree = "<group>"; };
+		1595941323691D6E007DBE15 /* dh_export.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dh_export.c; sourceTree = "<group>"; };
+		1595941523691D6E007DBE15 /* rsa_verify_hash.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rsa_verify_hash.c; sourceTree = "<group>"; };
+		1595941623691D6E007DBE15 /* rsa_import_pkcs8.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rsa_import_pkcs8.c; sourceTree = "<group>"; };
+		1595941723691D6E007DBE15 /* rsa_exptmod.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rsa_exptmod.c; sourceTree = "<group>"; };
+		1595941823691D6E007DBE15 /* rsa_decrypt_key.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rsa_decrypt_key.c; sourceTree = "<group>"; };
+		1595941923691D6E007DBE15 /* rsa_encrypt_key.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rsa_encrypt_key.c; sourceTree = "<group>"; };
+		1595941A23691D6E007DBE15 /* rsa_import.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rsa_import.c; sourceTree = "<group>"; };
+		1595941B23691D6E007DBE15 /* rsa_sign_hash.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rsa_sign_hash.c; sourceTree = "<group>"; };
+		1595941C23691D6E007DBE15 /* rsa_set.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rsa_set.c; sourceTree = "<group>"; };
+		1595941D23691D6E007DBE15 /* rsa_import_x509.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rsa_import_x509.c; sourceTree = "<group>"; };
+		1595941E23691D6E007DBE15 /* rsa_make_key.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rsa_make_key.c; sourceTree = "<group>"; };
+		1595941F23691D6E007DBE15 /* rsa_export.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rsa_export.c; sourceTree = "<group>"; };
+		1595942023691D6E007DBE15 /* rsa_sign_saltlen_get.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rsa_sign_saltlen_get.c; sourceTree = "<group>"; };
+		1595942123691D6E007DBE15 /* rsa_key.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rsa_key.c; sourceTree = "<group>"; };
+		1595942223691D6E007DBE15 /* rsa_get_size.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rsa_get_size.c; sourceTree = "<group>"; };
+		1595942423691D6E007DBE15 /* dsa_make_key.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dsa_make_key.c; sourceTree = "<group>"; };
+		1595942523691D6E007DBE15 /* dsa_verify_key.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dsa_verify_key.c; sourceTree = "<group>"; };
+		1595942623691D6E007DBE15 /* dsa_set.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dsa_set.c; sourceTree = "<group>"; };
+		1595942723691D6E007DBE15 /* dsa_sign_hash.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dsa_sign_hash.c; sourceTree = "<group>"; };
+		1595942823691D6E007DBE15 /* dsa_shared_secret.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dsa_shared_secret.c; sourceTree = "<group>"; };
+		1595942923691D6E007DBE15 /* dsa_generate_pqg.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dsa_generate_pqg.c; sourceTree = "<group>"; };
+		1595942A23691D6E007DBE15 /* dsa_import.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dsa_import.c; sourceTree = "<group>"; };
+		1595942B23691D6E007DBE15 /* dsa_decrypt_key.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dsa_decrypt_key.c; sourceTree = "<group>"; };
+		1595942C23691D6E007DBE15 /* dsa_set_pqg_dsaparam.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dsa_set_pqg_dsaparam.c; sourceTree = "<group>"; };
+		1595942D23691D6E007DBE15 /* dsa_export.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dsa_export.c; sourceTree = "<group>"; };
+		1595942E23691D6E007DBE15 /* dsa_verify_hash.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dsa_verify_hash.c; sourceTree = "<group>"; };
+		1595942F23691D6E007DBE15 /* dsa_generate_key.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dsa_generate_key.c; sourceTree = "<group>"; };
+		1595943023691D6E007DBE15 /* dsa_free.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dsa_free.c; sourceTree = "<group>"; };
+		1595943123691D6E007DBE15 /* dsa_encrypt_key.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dsa_encrypt_key.c; sourceTree = "<group>"; };
+		1595943323691D6E007DBE15 /* ec25519_export.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ec25519_export.c; sourceTree = "<group>"; };
+		1595943423691D6E007DBE15 /* ec25519_import_pkcs8.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ec25519_import_pkcs8.c; sourceTree = "<group>"; };
+		1595943523691D6E007DBE15 /* tweetnacl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tweetnacl.c; sourceTree = "<group>"; };
+		1595943723691D6E007DBE15 /* ed25519_export.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ed25519_export.c; sourceTree = "<group>"; };
+		1595943823691D6E007DBE15 /* ed25519_import_pkcs8.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ed25519_import_pkcs8.c; sourceTree = "<group>"; };
+		1595943923691D6E007DBE15 /* ed25519_import_raw.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ed25519_import_raw.c; sourceTree = "<group>"; };
+		1595943A23691D6E007DBE15 /* ed25519_import_x509.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ed25519_import_x509.c; sourceTree = "<group>"; };
+		1595943B23691D6E007DBE15 /* ed25519_sign.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ed25519_sign.c; sourceTree = "<group>"; };
+		1595943C23691D6E007DBE15 /* ed25519_make_key.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ed25519_make_key.c; sourceTree = "<group>"; };
+		1595943D23691D6E007DBE15 /* ed25519_verify.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ed25519_verify.c; sourceTree = "<group>"; };
+		1595943E23691D6E007DBE15 /* ed25519_import.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ed25519_import.c; sourceTree = "<group>"; };
+		1595944023691D6E007DBE15 /* ecc_import_x509.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecc_import_x509.c; sourceTree = "<group>"; };
+		1595944123691D6E007DBE15 /* ecc_set_curve.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecc_set_curve.c; sourceTree = "<group>"; };
+		1595944223691D6E007DBE15 /* ecc_recover_key.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecc_recover_key.c; sourceTree = "<group>"; };
+		1595944323691D6E007DBE15 /* ecc_export_openssl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecc_export_openssl.c; sourceTree = "<group>"; };
+		1595944423691D6E007DBE15 /* ltc_ecc_projective_add_point.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ltc_ecc_projective_add_point.c; sourceTree = "<group>"; };
+		1595944523691D6E007DBE15 /* ecc_make_key.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecc_make_key.c; sourceTree = "<group>"; };
+		1595944623691D6E007DBE15 /* ecc_ansi_x963_import.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecc_ansi_x963_import.c; sourceTree = "<group>"; };
+		1595944723691D6E007DBE15 /* ltc_ecc_map.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ltc_ecc_map.c; sourceTree = "<group>"; };
+		1595944823691D6E007DBE15 /* ecc_get_size.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecc_get_size.c; sourceTree = "<group>"; };
+		1595944923691D6E007DBE15 /* ecc_import_pkcs8.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecc_import_pkcs8.c; sourceTree = "<group>"; };
+		1595944A23691D6E007DBE15 /* ecc_set_key.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecc_set_key.c; sourceTree = "<group>"; };
+		1595944B23691D6E007DBE15 /* ecc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecc.c; sourceTree = "<group>"; };
+		1595944C23691D6E007DBE15 /* ecc_get_key.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecc_get_key.c; sourceTree = "<group>"; };
+		1595944D23691D6E007DBE15 /* ecc_export.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecc_export.c; sourceTree = "<group>"; };
+		1595944E23691D6E007DBE15 /* ecc_import_openssl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecc_import_openssl.c; sourceTree = "<group>"; };
+		1595944F23691D6E007DBE15 /* ecc_free.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecc_free.c; sourceTree = "<group>"; };
+		1595945023691D6E007DBE15 /* ecc_find_curve.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecc_find_curve.c; sourceTree = "<group>"; };
+		1595945123691D6E007DBE15 /* ecc_import.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecc_import.c; sourceTree = "<group>"; };
+		1595945223691D6E007DBE15 /* ecc_get_oid_str.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecc_get_oid_str.c; sourceTree = "<group>"; };
+		1595945323691D6E007DBE15 /* ecc_decrypt_key.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecc_decrypt_key.c; sourceTree = "<group>"; };
+		1595945423691D6E007DBE15 /* ltc_ecc_is_point.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ltc_ecc_is_point.c; sourceTree = "<group>"; };
+		1595945523691D6E007DBE15 /* ecc_shared_secret.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecc_shared_secret.c; sourceTree = "<group>"; };
+		1595945623691D6E007DBE15 /* ltc_ecc_projective_dbl_point.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ltc_ecc_projective_dbl_point.c; sourceTree = "<group>"; };
+		1595945723691D6E007DBE15 /* ecc_sizes.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecc_sizes.c; sourceTree = "<group>"; };
+		1595945823691D6E007DBE15 /* ltc_ecc_mul2add.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ltc_ecc_mul2add.c; sourceTree = "<group>"; };
+		1595945923691D6E007DBE15 /* ltc_ecc_points.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ltc_ecc_points.c; sourceTree = "<group>"; };
+		1595945A23691D6E007DBE15 /* ltc_ecc_mulmod.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ltc_ecc_mulmod.c; sourceTree = "<group>"; };
+		1595945B23691D6E007DBE15 /* ecc_verify_hash.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecc_verify_hash.c; sourceTree = "<group>"; };
+		1595945C23691D6E007DBE15 /* ltc_ecc_is_point_at_infinity.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ltc_ecc_is_point_at_infinity.c; sourceTree = "<group>"; };
+		1595945D23691D6E007DBE15 /* ltc_ecc_import_point.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ltc_ecc_import_point.c; sourceTree = "<group>"; };
+		1595945E23691D6E007DBE15 /* ltc_ecc_mulmod_timing.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ltc_ecc_mulmod_timing.c; sourceTree = "<group>"; };
+		1595945F23691D6E007DBE15 /* ecc_ansi_x963_export.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecc_ansi_x963_export.c; sourceTree = "<group>"; };
+		1595946023691D6E007DBE15 /* ecc_ssh_ecdsa_encode_name.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecc_ssh_ecdsa_encode_name.c; sourceTree = "<group>"; };
+		1595946123691D6E007DBE15 /* ecc_sign_hash.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecc_sign_hash.c; sourceTree = "<group>"; };
+		1595946223691D6E007DBE15 /* ecc_encrypt_key.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecc_encrypt_key.c; sourceTree = "<group>"; };
+		1595946323691D6E007DBE15 /* ecc_set_curve_internal.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecc_set_curve_internal.c; sourceTree = "<group>"; };
+		1595946423691D6E007DBE15 /* ltc_ecc_verify_key.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ltc_ecc_verify_key.c; sourceTree = "<group>"; };
+		1595946523691D6E007DBE15 /* ltc_ecc_export_point.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ltc_ecc_export_point.c; sourceTree = "<group>"; };
+		1595946723691D6E007DBE15 /* pkcs_1_os2ip.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pkcs_1_os2ip.c; sourceTree = "<group>"; };
+		1595946823691D6E007DBE15 /* pkcs_1_pss_decode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pkcs_1_pss_decode.c; sourceTree = "<group>"; };
+		1595946923691D6E007DBE15 /* pkcs_1_pss_encode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pkcs_1_pss_encode.c; sourceTree = "<group>"; };
+		1595946A23691D6E007DBE15 /* pkcs_1_mgf1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pkcs_1_mgf1.c; sourceTree = "<group>"; };
+		1595946B23691D6E007DBE15 /* pkcs_1_oaep_decode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pkcs_1_oaep_decode.c; sourceTree = "<group>"; };
+		1595946C23691D6E007DBE15 /* pkcs_1_v1_5_decode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pkcs_1_v1_5_decode.c; sourceTree = "<group>"; };
+		1595946D23691D6E007DBE15 /* pkcs_1_v1_5_encode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pkcs_1_v1_5_encode.c; sourceTree = "<group>"; };
+		1595946E23691D6E007DBE15 /* pkcs_1_oaep_encode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pkcs_1_oaep_encode.c; sourceTree = "<group>"; };
+		1595946F23691D6E007DBE15 /* pkcs_1_i2osp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pkcs_1_i2osp.c; sourceTree = "<group>"; };
+		1595947123691D6E007DBE15 /* x25519_make_key.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x25519_make_key.c; sourceTree = "<group>"; };
+		1595947223691D6E007DBE15 /* x25519_import_pkcs8.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x25519_import_pkcs8.c; sourceTree = "<group>"; };
+		1595947323691D6E007DBE15 /* x25519_export.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x25519_export.c; sourceTree = "<group>"; };
+		1595947423691D6E007DBE15 /* x25519_shared_secret.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x25519_shared_secret.c; sourceTree = "<group>"; };
+		1595947523691D6E007DBE15 /* x25519_import.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x25519_import.c; sourceTree = "<group>"; };
+		1595947623691D6E007DBE15 /* x25519_import_raw.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x25519_import_raw.c; sourceTree = "<group>"; };
+		1595947723691D6E007DBE15 /* x25519_import_x509.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x25519_import_x509.c; sourceTree = "<group>"; };
+		1595947923691D6E007DBE15 /* md4.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = md4.c; sourceTree = "<group>"; };
+		1595947B23691D6E007DBE15 /* sha512_224.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sha512_224.c; sourceTree = "<group>"; };
+		1595947C23691D6E007DBE15 /* sha512_256.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sha512_256.c; sourceTree = "<group>"; };
+		1595947D23691D6E007DBE15 /* sha224.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sha224.c; sourceTree = "<group>"; };
+		1595947E23691D6E007DBE15 /* sha256.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sha256.c; sourceTree = "<group>"; };
+		1595947F23691D6E007DBE15 /* sha512.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sha512.c; sourceTree = "<group>"; };
+		1595948023691D6E007DBE15 /* sha384.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sha384.c; sourceTree = "<group>"; };
+		1595948223691D6E007DBE15 /* whirltab.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = whirltab.c; sourceTree = "<group>"; };
+		1595948323691D6E007DBE15 /* whirl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = whirl.c; sourceTree = "<group>"; };
+		1595948423691D6E007DBE15 /* sha1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sha1.c; sourceTree = "<group>"; };
+		1595948523691D6E007DBE15 /* rmd128.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rmd128.c; sourceTree = "<group>"; };
+		1595948623691D6E007DBE15 /* sha3_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sha3_test.c; sourceTree = "<group>"; };
+		1595948823691D6E007DBE15 /* chc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = chc.c; sourceTree = "<group>"; };
+		1595948923691D6E007DBE15 /* rmd256.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rmd256.c; sourceTree = "<group>"; };
+		1595948A23691D6E007DBE15 /* md2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = md2.c; sourceTree = "<group>"; };
+		1595948B23691D6E007DBE15 /* blake2b.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = blake2b.c; sourceTree = "<group>"; };
+		1595948C23691D6E007DBE15 /* md5.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = md5.c; sourceTree = "<group>"; };
+		1595948D23691D6E007DBE15 /* tiger.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tiger.c; sourceTree = "<group>"; };
+		1595948E23691D6E007DBE15 /* blake2s.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = blake2s.c; sourceTree = "<group>"; };
+		1595948F23691D6E007DBE15 /* sha3.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sha3.c; sourceTree = "<group>"; };
+		1595949123691D6E007DBE15 /* hash_memory_multi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hash_memory_multi.c; sourceTree = "<group>"; };
+		1595949223691D6E007DBE15 /* hash_file.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hash_file.c; sourceTree = "<group>"; };
+		1595949323691D6E007DBE15 /* hash_filehandle.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hash_filehandle.c; sourceTree = "<group>"; };
+		1595949423691D6E007DBE15 /* hash_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hash_memory.c; sourceTree = "<group>"; };
+		1595949523691D6E007DBE15 /* rmd160.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rmd160.c; sourceTree = "<group>"; };
+		1595949623691D6E007DBE15 /* rmd320.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rmd320.c; sourceTree = "<group>"; };
+		1595949923691D6E007DBE15 /* xts_init.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = xts_init.c; sourceTree = "<group>"; };
+		1595949A23691D6E007DBE15 /* xts_mult_x.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = xts_mult_x.c; sourceTree = "<group>"; };
+		1595949B23691D6E007DBE15 /* xts_decrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = xts_decrypt.c; sourceTree = "<group>"; };
+		1595949C23691D6E007DBE15 /* xts_encrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = xts_encrypt.c; sourceTree = "<group>"; };
+		1595949D23691D6E007DBE15 /* xts_done.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = xts_done.c; sourceTree = "<group>"; };
+		1595949E23691D6E007DBE15 /* xts_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = xts_test.c; sourceTree = "<group>"; };
+		159594A023691D6E007DBE15 /* ctr_encrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ctr_encrypt.c; sourceTree = "<group>"; };
+		159594A123691D6E007DBE15 /* ctr_setiv.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ctr_setiv.c; sourceTree = "<group>"; };
+		159594A223691D6E007DBE15 /* ctr_start.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ctr_start.c; sourceTree = "<group>"; };
+		159594A323691D6E007DBE15 /* ctr_decrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ctr_decrypt.c; sourceTree = "<group>"; };
+		159594A423691D6E007DBE15 /* ctr_getiv.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ctr_getiv.c; sourceTree = "<group>"; };
+		159594A523691D6E007DBE15 /* ctr_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ctr_test.c; sourceTree = "<group>"; };
+		159594A623691D6E007DBE15 /* ctr_done.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ctr_done.c; sourceTree = "<group>"; };
+		159594A823691D6E007DBE15 /* ofb_getiv.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ofb_getiv.c; sourceTree = "<group>"; };
+		159594A923691D6E007DBE15 /* ofb_encrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ofb_encrypt.c; sourceTree = "<group>"; };
+		159594AA23691D6E007DBE15 /* ofb_done.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ofb_done.c; sourceTree = "<group>"; };
+		159594AB23691D6E007DBE15 /* ofb_start.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ofb_start.c; sourceTree = "<group>"; };
+		159594AC23691D6E007DBE15 /* ofb_setiv.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ofb_setiv.c; sourceTree = "<group>"; };
+		159594AD23691D6E007DBE15 /* ofb_decrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ofb_decrypt.c; sourceTree = "<group>"; };
+		159594AF23691D6E007DBE15 /* cbc_setiv.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cbc_setiv.c; sourceTree = "<group>"; };
+		159594B023691D6E007DBE15 /* cbc_decrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cbc_decrypt.c; sourceTree = "<group>"; };
+		159594B123691D6E007DBE15 /* cbc_done.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cbc_done.c; sourceTree = "<group>"; };
+		159594B223691D6E007DBE15 /* cbc_getiv.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cbc_getiv.c; sourceTree = "<group>"; };
+		159594B323691D6E007DBE15 /* cbc_start.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cbc_start.c; sourceTree = "<group>"; };
+		159594B423691D6E007DBE15 /* cbc_encrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cbc_encrypt.c; sourceTree = "<group>"; };
+		159594B623691D6E007DBE15 /* lrw_encrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lrw_encrypt.c; sourceTree = "<group>"; };
+		159594B723691D6E007DBE15 /* lrw_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lrw_test.c; sourceTree = "<group>"; };
+		159594B823691D6E007DBE15 /* lrw_process.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lrw_process.c; sourceTree = "<group>"; };
+		159594B923691D6E007DBE15 /* lrw_setiv.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lrw_setiv.c; sourceTree = "<group>"; };
+		159594BA23691D6E007DBE15 /* lrw_done.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lrw_done.c; sourceTree = "<group>"; };
+		159594BB23691D6E007DBE15 /* lrw_start.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lrw_start.c; sourceTree = "<group>"; };
+		159594BC23691D6E007DBE15 /* lrw_getiv.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lrw_getiv.c; sourceTree = "<group>"; };
+		159594BD23691D6E007DBE15 /* lrw_decrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lrw_decrypt.c; sourceTree = "<group>"; };
+		159594BF23691D6E007DBE15 /* f8_start.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = f8_start.c; sourceTree = "<group>"; };
+		159594C023691D6E007DBE15 /* f8_decrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = f8_decrypt.c; sourceTree = "<group>"; };
+		159594C123691D6E007DBE15 /* f8_getiv.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = f8_getiv.c; sourceTree = "<group>"; };
+		159594C223691D6E007DBE15 /* f8_done.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = f8_done.c; sourceTree = "<group>"; };
+		159594C323691D6E007DBE15 /* f8_test_mode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = f8_test_mode.c; sourceTree = "<group>"; };
+		159594C423691D6E007DBE15 /* f8_encrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = f8_encrypt.c; sourceTree = "<group>"; };
+		159594C523691D6E007DBE15 /* f8_setiv.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = f8_setiv.c; sourceTree = "<group>"; };
+		159594C723691D6E007DBE15 /* cfb_done.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cfb_done.c; sourceTree = "<group>"; };
+		159594C823691D6E007DBE15 /* cfb_encrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cfb_encrypt.c; sourceTree = "<group>"; };
+		159594C923691D6E007DBE15 /* cfb_start.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cfb_start.c; sourceTree = "<group>"; };
+		159594CA23691D6E007DBE15 /* cfb_getiv.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cfb_getiv.c; sourceTree = "<group>"; };
+		159594CB23691D6E007DBE15 /* cfb_setiv.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cfb_setiv.c; sourceTree = "<group>"; };
+		159594CC23691D6E007DBE15 /* cfb_decrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cfb_decrypt.c; sourceTree = "<group>"; };
+		159594CE23691D6E007DBE15 /* ecb_encrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecb_encrypt.c; sourceTree = "<group>"; };
+		159594CF23691D6E007DBE15 /* ecb_done.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecb_done.c; sourceTree = "<group>"; };
+		159594D023691D6E007DBE15 /* ecb_decrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecb_decrypt.c; sourceTree = "<group>"; };
+		159594D123691D6E007DBE15 /* ecb_start.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecb_start.c; sourceTree = "<group>"; };
+		159594D323691D6E007DBE15 /* chacha20.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = chacha20.c; sourceTree = "<group>"; };
+		159594D423691D6E007DBE15 /* rc4.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rc4.c; sourceTree = "<group>"; };
+		159594D523691D6E007DBE15 /* rng_get_bytes.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rng_get_bytes.c; sourceTree = "<group>"; };
+		159594D623691D6E007DBE15 /* fortuna.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = fortuna.c; sourceTree = "<group>"; };
+		159594D723691D6E007DBE15 /* rng_make_prng.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rng_make_prng.c; sourceTree = "<group>"; };
+		159594D823691D6E007DBE15 /* sober128.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sober128.c; sourceTree = "<group>"; };
+		159594D923691D6E007DBE15 /* sprng.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sprng.c; sourceTree = "<group>"; };
+		159594DA23691D6E007DBE15 /* yarrow.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = yarrow.c; sourceTree = "<group>"; };
+		159594DD23691D6E007DBE15 /* eax_decrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = eax_decrypt.c; sourceTree = "<group>"; };
+		159594DE23691D6E007DBE15 /* eax_decrypt_verify_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = eax_decrypt_verify_memory.c; sourceTree = "<group>"; };
+		159594DF23691D6E007DBE15 /* eax_init.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = eax_init.c; sourceTree = "<group>"; };
+		159594E023691D6E007DBE15 /* eax_encrypt_authenticate_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = eax_encrypt_authenticate_memory.c; sourceTree = "<group>"; };
+		159594E123691D6E007DBE15 /* eax_addheader.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = eax_addheader.c; sourceTree = "<group>"; };
+		159594E223691D6E007DBE15 /* eax_encrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = eax_encrypt.c; sourceTree = "<group>"; };
+		159594E323691D6E007DBE15 /* eax_done.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = eax_done.c; sourceTree = "<group>"; };
+		159594E423691D6E007DBE15 /* eax_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = eax_test.c; sourceTree = "<group>"; };
+		159594E623691D6E007DBE15 /* gcm_init.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = gcm_init.c; sourceTree = "<group>"; };
+		159594E723691D6E007DBE15 /* gcm_process.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = gcm_process.c; sourceTree = "<group>"; };
+		159594E823691D6E007DBE15 /* gcm_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = gcm_memory.c; sourceTree = "<group>"; };
+		159594E923691D6E007DBE15 /* gcm_reset.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = gcm_reset.c; sourceTree = "<group>"; };
+		159594EA23691D6E007DBE15 /* gcm_done.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = gcm_done.c; sourceTree = "<group>"; };
+		159594EB23691D6E007DBE15 /* gcm_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = gcm_test.c; sourceTree = "<group>"; };
+		159594EC23691D6E007DBE15 /* gcm_mult_h.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = gcm_mult_h.c; sourceTree = "<group>"; };
+		159594ED23691D6E007DBE15 /* gcm_add_iv.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = gcm_add_iv.c; sourceTree = "<group>"; };
+		159594EE23691D6E007DBE15 /* gcm_add_aad.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = gcm_add_aad.c; sourceTree = "<group>"; };
+		159594EF23691D6E007DBE15 /* gcm_gf_mult.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = gcm_gf_mult.c; sourceTree = "<group>"; };
+		159594F123691D6E007DBE15 /* ccm_done.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ccm_done.c; sourceTree = "<group>"; };
+		159594F223691D6E007DBE15 /* ccm_add_aad.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ccm_add_aad.c; sourceTree = "<group>"; };
+		159594F323691D6E007DBE15 /* ccm_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ccm_test.c; sourceTree = "<group>"; };
+		159594F423691D6E007DBE15 /* ccm_add_nonce.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ccm_add_nonce.c; sourceTree = "<group>"; };
+		159594F523691D6E007DBE15 /* ccm_process.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ccm_process.c; sourceTree = "<group>"; };
+		159594F623691D6E007DBE15 /* ccm_reset.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ccm_reset.c; sourceTree = "<group>"; };
+		159594F723691D6E007DBE15 /* ccm_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ccm_memory.c; sourceTree = "<group>"; };
+		159594F823691D6E007DBE15 /* ccm_init.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ccm_init.c; sourceTree = "<group>"; };
+		159594FA23691D6E007DBE15 /* chacha20poly1305_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = chacha20poly1305_test.c; sourceTree = "<group>"; };
+		159594FB23691D6E007DBE15 /* chacha20poly1305_done.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = chacha20poly1305_done.c; sourceTree = "<group>"; };
+		159594FC23691D6E007DBE15 /* chacha20poly1305_add_aad.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = chacha20poly1305_add_aad.c; sourceTree = "<group>"; };
+		159594FD23691D6E007DBE15 /* chacha20poly1305_setiv_rfc7905.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = chacha20poly1305_setiv_rfc7905.c; sourceTree = "<group>"; };
+		159594FE23691D6E007DBE15 /* chacha20poly1305_decrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = chacha20poly1305_decrypt.c; sourceTree = "<group>"; };
+		159594FF23691D6E007DBE15 /* chacha20poly1305_encrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = chacha20poly1305_encrypt.c; sourceTree = "<group>"; };
+		1595950023691D6E007DBE15 /* chacha20poly1305_setiv.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = chacha20poly1305_setiv.c; sourceTree = "<group>"; };
+		1595950123691D6E007DBE15 /* chacha20poly1305_init.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = chacha20poly1305_init.c; sourceTree = "<group>"; };
+		1595950223691D6E007DBE15 /* chacha20poly1305_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = chacha20poly1305_memory.c; sourceTree = "<group>"; };
+		1595950423691D6E007DBE15 /* ocb_ntz.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ocb_ntz.c; sourceTree = "<group>"; };
+		1595950523691D6E007DBE15 /* ocb_encrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ocb_encrypt.c; sourceTree = "<group>"; };
+		1595950623691D6E007DBE15 /* ocb_shift_xor.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ocb_shift_xor.c; sourceTree = "<group>"; };
+		1595950723691D6E007DBE15 /* ocb_init.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ocb_init.c; sourceTree = "<group>"; };
+		1595950823691D6E007DBE15 /* ocb_encrypt_authenticate_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ocb_encrypt_authenticate_memory.c; sourceTree = "<group>"; };
+		1595950923691D6E007DBE15 /* s_ocb_done.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = s_ocb_done.c; sourceTree = "<group>"; };
+		1595950A23691D6E007DBE15 /* ocb_done_encrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ocb_done_encrypt.c; sourceTree = "<group>"; };
+		1595950B23691D6E007DBE15 /* ocb_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ocb_test.c; sourceTree = "<group>"; };
+		1595950C23691D6E007DBE15 /* ocb_done_decrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ocb_done_decrypt.c; sourceTree = "<group>"; };
+		1595950D23691D6E007DBE15 /* ocb_decrypt_verify_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ocb_decrypt_verify_memory.c; sourceTree = "<group>"; };
+		1595950E23691D6E007DBE15 /* ocb_decrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ocb_decrypt.c; sourceTree = "<group>"; };
+		1595951023691D6E007DBE15 /* ocb3_int_ntz.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ocb3_int_ntz.c; sourceTree = "<group>"; };
+		1595951123691D6E007DBE15 /* ocb3_encrypt_authenticate_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ocb3_encrypt_authenticate_memory.c; sourceTree = "<group>"; };
+		1595951223691D6E007DBE15 /* ocb3_add_aad.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ocb3_add_aad.c; sourceTree = "<group>"; };
+		1595951323691D6E007DBE15 /* ocb3_encrypt_last.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ocb3_encrypt_last.c; sourceTree = "<group>"; };
+		1595951423691D6E007DBE15 /* ocb3_int_xor_blocks.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ocb3_int_xor_blocks.c; sourceTree = "<group>"; };
+		1595951523691D6E007DBE15 /* ocb3_decrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ocb3_decrypt.c; sourceTree = "<group>"; };
+		1595951623691D6E007DBE15 /* ocb3_done.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ocb3_done.c; sourceTree = "<group>"; };
+		1595951723691D6E007DBE15 /* ocb3_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ocb3_test.c; sourceTree = "<group>"; };
+		1595951823691D6E007DBE15 /* ocb3_decrypt_verify_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ocb3_decrypt_verify_memory.c; sourceTree = "<group>"; };
+		1595951923691D6E007DBE15 /* ocb3_encrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ocb3_encrypt.c; sourceTree = "<group>"; };
+		1595951A23691D6E007DBE15 /* ocb3_decrypt_last.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ocb3_decrypt_last.c; sourceTree = "<group>"; };
+		1595951B23691D6E007DBE15 /* ocb3_init.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ocb3_init.c; sourceTree = "<group>"; };
+		1595951E23691D6E007DBE15 /* rc4_stream.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rc4_stream.c; sourceTree = "<group>"; };
+		1595951F23691D6E007DBE15 /* rc4_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rc4_test.c; sourceTree = "<group>"; };
+		1595952023691D6E007DBE15 /* rc4_stream_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rc4_stream_memory.c; sourceTree = "<group>"; };
+		1595952223691D6E007DBE15 /* chacha_ivctr32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = chacha_ivctr32.c; sourceTree = "<group>"; };
+		1595952323691D6E007DBE15 /* chacha_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = chacha_memory.c; sourceTree = "<group>"; };
+		1595952423691D6E007DBE15 /* chacha_crypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = chacha_crypt.c; sourceTree = "<group>"; };
+		1595952523691D6E007DBE15 /* chacha_keystream.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = chacha_keystream.c; sourceTree = "<group>"; };
+		1595952623691D6E007DBE15 /* chacha_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = chacha_test.c; sourceTree = "<group>"; };
+		1595952723691D6E007DBE15 /* chacha_done.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = chacha_done.c; sourceTree = "<group>"; };
+		1595952823691D6E007DBE15 /* chacha_ivctr64.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = chacha_ivctr64.c; sourceTree = "<group>"; };
+		1595952923691D6E007DBE15 /* chacha_setup.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = chacha_setup.c; sourceTree = "<group>"; };
+		1595952B23691D6E007DBE15 /* sober128_stream_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sober128_stream_memory.c; sourceTree = "<group>"; };
+		1595952C23691D6E007DBE15 /* sober128tab.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sober128tab.c; sourceTree = "<group>"; };
+		1595952D23691D6E007DBE15 /* sober128_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sober128_test.c; sourceTree = "<group>"; };
+		1595952E23691D6E007DBE15 /* sober128_stream.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sober128_stream.c; sourceTree = "<group>"; };
+		1595953023691D6E007DBE15 /* salsa20_setup.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = salsa20_setup.c; sourceTree = "<group>"; };
+		1595953123691D6E007DBE15 /* xsalsa20_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = xsalsa20_memory.c; sourceTree = "<group>"; };
+		1595953223691D6E007DBE15 /* salsa20_done.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = salsa20_done.c; sourceTree = "<group>"; };
+		1595953323691D6E007DBE15 /* salsa20_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = salsa20_test.c; sourceTree = "<group>"; };
+		1595953423691D6E007DBE15 /* salsa20_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = salsa20_memory.c; sourceTree = "<group>"; };
+		1595953523691D6E007DBE15 /* salsa20_keystream.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = salsa20_keystream.c; sourceTree = "<group>"; };
+		1595953623691D6E007DBE15 /* salsa20_crypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = salsa20_crypt.c; sourceTree = "<group>"; };
+		1595953723691D6E007DBE15 /* xsalsa20_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = xsalsa20_test.c; sourceTree = "<group>"; };
+		1595953823691D6E007DBE15 /* salsa20_ivctr64.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = salsa20_ivctr64.c; sourceTree = "<group>"; };
+		1595953923691D6E007DBE15 /* xsalsa20_setup.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = xsalsa20_setup.c; sourceTree = "<group>"; };
+		1595953B23691D6E007DBE15 /* rabbit_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rabbit_memory.c; sourceTree = "<group>"; };
+		1595953C23691D6E007DBE15 /* rabbit.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rabbit.c; sourceTree = "<group>"; };
+		1595953E23691D6E007DBE15 /* sosemanuk_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sosemanuk_memory.c; sourceTree = "<group>"; };
+		1595953F23691D6E007DBE15 /* sosemanuk_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sosemanuk_test.c; sourceTree = "<group>"; };
+		1595954023691D6E007DBE15 /* sosemanuk.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sosemanuk.c; sourceTree = "<group>"; };
+		1595954223691D6E007DBE15 /* radix_to_bin.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = radix_to_bin.c; sourceTree = "<group>"; };
+		1595954323691D6E007DBE15 /* tfm_desc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tfm_desc.c; sourceTree = "<group>"; };
+		1595954423691D6E007DBE15 /* rand_bn.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rand_bn.c; sourceTree = "<group>"; };
+		1595954623691D6E007DBE15 /* ltc_ecc_fp_mulmod.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ltc_ecc_fp_mulmod.c; sourceTree = "<group>"; };
+		1595954723691D6E007DBE15 /* multi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = multi.c; sourceTree = "<group>"; };
+		1595954823691D6E007DBE15 /* ltm_desc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ltm_desc.c; sourceTree = "<group>"; };
+		1595954923691D6E007DBE15 /* gmp_desc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = gmp_desc.c; sourceTree = "<group>"; };
+		1595954A23691D6E007DBE15 /* rand_prime.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rand_prime.c; sourceTree = "<group>"; };
+		1595954D23691D6F007DBE15 /* pmac_init.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pmac_init.c; sourceTree = "<group>"; };
+		1595954E23691D6F007DBE15 /* pmac_shift_xor.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pmac_shift_xor.c; sourceTree = "<group>"; };
+		1595954F23691D6F007DBE15 /* pmac_ntz.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pmac_ntz.c; sourceTree = "<group>"; };
+		1595955023691D6F007DBE15 /* pmac_done.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pmac_done.c; sourceTree = "<group>"; };
+		1595955123691D6F007DBE15 /* pmac_file.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pmac_file.c; sourceTree = "<group>"; };
+		1595955223691D6F007DBE15 /* pmac_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pmac_test.c; sourceTree = "<group>"; };
+		1595955323691D6F007DBE15 /* pmac_memory_multi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pmac_memory_multi.c; sourceTree = "<group>"; };
+		1595955423691D6F007DBE15 /* pmac_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pmac_memory.c; sourceTree = "<group>"; };
+		1595955523691D6F007DBE15 /* pmac_process.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pmac_process.c; sourceTree = "<group>"; };
+		1595955723691D6F007DBE15 /* hmac_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hmac_memory.c; sourceTree = "<group>"; };
+		1595955823691D6F007DBE15 /* hmac_init.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hmac_init.c; sourceTree = "<group>"; };
+		1595955923691D6F007DBE15 /* hmac_done.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hmac_done.c; sourceTree = "<group>"; };
+		1595955A23691D6F007DBE15 /* hmac_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hmac_test.c; sourceTree = "<group>"; };
+		1595955B23691D6F007DBE15 /* hmac_file.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hmac_file.c; sourceTree = "<group>"; };
+		1595955C23691D6F007DBE15 /* hmac_memory_multi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hmac_memory_multi.c; sourceTree = "<group>"; };
+		1595955D23691D6F007DBE15 /* hmac_process.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hmac_process.c; sourceTree = "<group>"; };
+		1595955F23691D6F007DBE15 /* blake2bmac_file.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = blake2bmac_file.c; sourceTree = "<group>"; };
+		1595956023691D6F007DBE15 /* blake2smac_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = blake2smac_memory.c; sourceTree = "<group>"; };
+		1595956123691D6F007DBE15 /* blake2bmac_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = blake2bmac_test.c; sourceTree = "<group>"; };
+		1595956223691D6F007DBE15 /* blake2bmac_memory_multi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = blake2bmac_memory_multi.c; sourceTree = "<group>"; };
+		1595956323691D6F007DBE15 /* blake2smac.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = blake2smac.c; sourceTree = "<group>"; };
+		1595956423691D6F007DBE15 /* blake2smac_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = blake2smac_test.c; sourceTree = "<group>"; };
+		1595956523691D6F007DBE15 /* blake2smac_file.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = blake2smac_file.c; sourceTree = "<group>"; };
+		1595956623691D6F007DBE15 /* blake2smac_memory_multi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = blake2smac_memory_multi.c; sourceTree = "<group>"; };
+		1595956723691D6F007DBE15 /* blake2bmac_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = blake2bmac_memory.c; sourceTree = "<group>"; };
+		1595956823691D6F007DBE15 /* blake2bmac.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = blake2bmac.c; sourceTree = "<group>"; };
+		1595956A23691D6F007DBE15 /* poly1305_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = poly1305_memory.c; sourceTree = "<group>"; };
+		1595956B23691D6F007DBE15 /* poly1305_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = poly1305_test.c; sourceTree = "<group>"; };
+		1595956C23691D6F007DBE15 /* poly1305_file.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = poly1305_file.c; sourceTree = "<group>"; };
+		1595956D23691D6F007DBE15 /* poly1305.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = poly1305.c; sourceTree = "<group>"; };
+		1595956E23691D6F007DBE15 /* poly1305_memory_multi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = poly1305_memory_multi.c; sourceTree = "<group>"; };
+		1595957023691D6F007DBE15 /* xcbc_init.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = xcbc_init.c; sourceTree = "<group>"; };
+		1595957123691D6F007DBE15 /* xcbc_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = xcbc_memory.c; sourceTree = "<group>"; };
+		1595957223691D6F007DBE15 /* xcbc_process.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = xcbc_process.c; sourceTree = "<group>"; };
+		1595957323691D6F007DBE15 /* xcbc_file.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = xcbc_file.c; sourceTree = "<group>"; };
+		1595957423691D6F007DBE15 /* xcbc_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = xcbc_test.c; sourceTree = "<group>"; };
+		1595957523691D6F007DBE15 /* xcbc_memory_multi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = xcbc_memory_multi.c; sourceTree = "<group>"; };
+		1595957623691D6F007DBE15 /* xcbc_done.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = xcbc_done.c; sourceTree = "<group>"; };
+		1595957823691D6F007DBE15 /* f9_memory_multi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = f9_memory_multi.c; sourceTree = "<group>"; };
+		1595957923691D6F007DBE15 /* f9_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = f9_memory.c; sourceTree = "<group>"; };
+		1595957A23691D6F007DBE15 /* f9_init.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = f9_init.c; sourceTree = "<group>"; };
+		1595957B23691D6F007DBE15 /* f9_process.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = f9_process.c; sourceTree = "<group>"; };
+		1595957C23691D6F007DBE15 /* f9_done.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = f9_done.c; sourceTree = "<group>"; };
+		1595957D23691D6F007DBE15 /* f9_file.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = f9_file.c; sourceTree = "<group>"; };
+		1595957E23691D6F007DBE15 /* f9_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = f9_test.c; sourceTree = "<group>"; };
+		1595958023691D6F007DBE15 /* pelican.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pelican.c; sourceTree = "<group>"; };
+		1595958123691D6F007DBE15 /* pelican_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pelican_memory.c; sourceTree = "<group>"; };
+		1595958223691D6F007DBE15 /* pelican_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pelican_test.c; sourceTree = "<group>"; };
+		1595958423691D6F007DBE15 /* omac_init.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = omac_init.c; sourceTree = "<group>"; };
+		1595958523691D6F007DBE15 /* omac_file.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = omac_file.c; sourceTree = "<group>"; };
+		1595958623691D6F007DBE15 /* omac_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = omac_test.c; sourceTree = "<group>"; };
+		1595958723691D6F007DBE15 /* omac_process.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = omac_process.c; sourceTree = "<group>"; };
+		1595958823691D6F007DBE15 /* omac_memory_multi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = omac_memory_multi.c; sourceTree = "<group>"; };
+		1595958923691D6F007DBE15 /* omac_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = omac_memory.c; sourceTree = "<group>"; };
+		1595958A23691D6F007DBE15 /* omac_done.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = omac_done.c; sourceTree = "<group>"; };
+		1595958C23691D6F007DBE15 /* tomcrypt_pkcs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tomcrypt_pkcs.h; sourceTree = "<group>"; };
+		1595958D23691D6F007DBE15 /* tomcrypt_hash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tomcrypt_hash.h; sourceTree = "<group>"; };
+		1595958E23691D6F007DBE15 /* tomcrypt_private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tomcrypt_private.h; sourceTree = "<group>"; };
+		1595958F23691D6F007DBE15 /* tomcrypt_macros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tomcrypt_macros.h; sourceTree = "<group>"; };
+		1595959023691D6F007DBE15 /* tomcrypt_math.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tomcrypt_math.h; sourceTree = "<group>"; };
+		1595959123691D6F007DBE15 /* tomcrypt_misc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tomcrypt_misc.h; sourceTree = "<group>"; };
+		1595959223691D6F007DBE15 /* tomcrypt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tomcrypt.h; sourceTree = "<group>"; };
+		1595959323691D6F007DBE15 /* tomcrypt_cipher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tomcrypt_cipher.h; sourceTree = "<group>"; };
+		1595959423691D6F007DBE15 /* tomcrypt_pk.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tomcrypt_pk.h; sourceTree = "<group>"; };
+		1595959523691D6F007DBE15 /* tomcrypt_cfg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tomcrypt_cfg.h; sourceTree = "<group>"; };
+		1595959623691D6F007DBE15 /* tomcrypt_mac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tomcrypt_mac.h; sourceTree = "<group>"; };
+		1595959723691D6F007DBE15 /* tomcrypt_prng.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tomcrypt_prng.h; sourceTree = "<group>"; };
+		1595959823691D6F007DBE15 /* tomcrypt_custom.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tomcrypt_custom.h; sourceTree = "<group>"; };
+		1595959923691D6F007DBE15 /* tomcrypt_argchk.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tomcrypt_argchk.h; sourceTree = "<group>"; };
+		1595959B23691D6F007DBE15 /* noekeon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = noekeon.c; sourceTree = "<group>"; };
+		1595959C23691D6F007DBE15 /* camellia.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = camellia.c; sourceTree = "<group>"; };
+		1595959E23691D6F007DBE15 /* safer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = safer.c; sourceTree = "<group>"; };
+		1595959F23691D6F007DBE15 /* saferp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = saferp.c; sourceTree = "<group>"; };
+		159595A023691D6F007DBE15 /* safer_tab.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = safer_tab.c; sourceTree = "<group>"; };
+		159595A123691D6F007DBE15 /* tea.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tea.c; sourceTree = "<group>"; };
+		159595A223691D6F007DBE15 /* kseed.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = kseed.c; sourceTree = "<group>"; };
+		159595A323691D6F007DBE15 /* des.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = des.c; sourceTree = "<group>"; };
+		159595A423691D6F007DBE15 /* khazad.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = khazad.c; sourceTree = "<group>"; };
+		159595A523691D6F007DBE15 /* idea.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = idea.c; sourceTree = "<group>"; };
+		159595A623691D6F007DBE15 /* blowfish.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = blowfish.c; sourceTree = "<group>"; };
+		159595A723691D6F007DBE15 /* kasumi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = kasumi.c; sourceTree = "<group>"; };
+		159595A823691D6F007DBE15 /* anubis.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = anubis.c; sourceTree = "<group>"; };
+		159595A923691D6F007DBE15 /* rc2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rc2.c; sourceTree = "<group>"; };
+		159595AA23691D6F007DBE15 /* rc6.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rc6.c; sourceTree = "<group>"; };
+		159595AB23691D6F007DBE15 /* skipjack.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = skipjack.c; sourceTree = "<group>"; };
+		159595AC23691D6F007DBE15 /* cast5.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cast5.c; sourceTree = "<group>"; };
+		159595AD23691D6F007DBE15 /* serpent.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = serpent.c; sourceTree = "<group>"; };
+		159595AE23691D6F007DBE15 /* xtea.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = xtea.c; sourceTree = "<group>"; };
+		159595AF23691D6F007DBE15 /* multi2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = multi2.c; sourceTree = "<group>"; };
+		159595B123691D6F007DBE15 /* twofish.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = twofish.c; sourceTree = "<group>"; };
+		159595B223691D6F007DBE15 /* twofish_tab.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = twofish_tab.c; sourceTree = "<group>"; };
+		159595B323691D6F007DBE15 /* rc5.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rc5.c; sourceTree = "<group>"; };
+		159595B523691D6F007DBE15 /* aes.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = aes.c; sourceTree = "<group>"; };
+		159595B623691D6F007DBE15 /* aes_tab.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = aes_tab.c; sourceTree = "<group>"; };
+		159597AD23691EAA007DBE15 /* TomCrypt-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TomCrypt-Prefix.pch"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		1595935A23691B13007DBE15 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		1595935323691B13007DBE15 = {
+			isa = PBXGroup;
+			children = (
+				1595935F23691B13007DBE15 /* TomCrypt */,
+				1595935E23691B13007DBE15 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		1595935E23691B13007DBE15 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				1595935D23691B13007DBE15 /* TomCrypt.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		1595935F23691B13007DBE15 /* TomCrypt */ = {
+			isa = PBXGroup;
+			children = (
+				1595936823691D6D007DBE15 /* src */,
+				159597AD23691EAA007DBE15 /* TomCrypt-Prefix.pch */,
+				1595936123691B13007DBE15 /* Info.plist */,
+			);
+			path = TomCrypt;
+			sourceTree = "<group>";
+		};
+		1595936823691D6D007DBE15 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				1595936923691D6D007DBE15 /* misc */,
+				159593B123691D6D007DBE15 /* pk */,
+				1595947823691D6E007DBE15 /* hashes */,
+				1595949723691D6E007DBE15 /* modes */,
+				159594D223691D6E007DBE15 /* prngs */,
+				159594DB23691D6E007DBE15 /* encauth */,
+				1595951C23691D6E007DBE15 /* stream */,
+				1595954123691D6E007DBE15 /* math */,
+				1595954B23691D6F007DBE15 /* mac */,
+				1595958B23691D6F007DBE15 /* headers */,
+				1595959A23691D6F007DBE15 /* ciphers */,
+			);
+			name = src;
+			path = ../../src;
+			sourceTree = "<group>";
+		};
+		1595936923691D6D007DBE15 /* misc */ = {
+			isa = PBXGroup;
+			children = (
+				1595936A23691D6D007DBE15 /* compare_testvector.c */,
+				1595936B23691D6D007DBE15 /* error_to_string.c */,
+				1595936C23691D6D007DBE15 /* copy_or_zeromem.c */,
+				1595936D23691D6D007DBE15 /* pkcs12 */,
+				1595937023691D6D007DBE15 /* pbes */,
+				1595937423691D6D007DBE15 /* crypt */,
+				1595939423691D6D007DBE15 /* bcrypt */,
+				1595939623691D6D007DBE15 /* base64 */,
+				1595939923691D6D007DBE15 /* pkcs5 */,
+				1595939D23691D6D007DBE15 /* crc32.c */,
+				1595939E23691D6D007DBE15 /* burn_stack.c */,
+				1595939F23691D6D007DBE15 /* hkdf */,
+				159593A223691D6D007DBE15 /* ssh */,
+				159593A523691D6D007DBE15 /* base16 */,
+				159593A823691D6D007DBE15 /* padding */,
+				159593AB23691D6D007DBE15 /* base32 */,
+				159593AE23691D6D007DBE15 /* zeromem.c */,
+				159593AF23691D6D007DBE15 /* mem_neq.c */,
+				159593B023691D6D007DBE15 /* adler32.c */,
+			);
+			path = misc;
+			sourceTree = "<group>";
+		};
+		1595936D23691D6D007DBE15 /* pkcs12 */ = {
+			isa = PBXGroup;
+			children = (
+				1595936E23691D6D007DBE15 /* pkcs12_utf8_to_utf16.c */,
+				1595936F23691D6D007DBE15 /* pkcs12_kdf.c */,
+			);
+			path = pkcs12;
+			sourceTree = "<group>";
+		};
+		1595937023691D6D007DBE15 /* pbes */ = {
+			isa = PBXGroup;
+			children = (
+				1595937123691D6D007DBE15 /* pbes1.c */,
+				1595937223691D6D007DBE15 /* pbes2.c */,
+				1595937323691D6D007DBE15 /* pbes.c */,
+			);
+			path = pbes;
+			sourceTree = "<group>";
+		};
+		1595937423691D6D007DBE15 /* crypt */ = {
+			isa = PBXGroup;
+			children = (
+				1595937523691D6D007DBE15 /* crypt_unregister_prng.c */,
+				1595937623691D6D007DBE15 /* crypt_unregister_cipher.c */,
+				1595937723691D6D007DBE15 /* crypt.c */,
+				1595937823691D6D007DBE15 /* crypt_find_cipher_any.c */,
+				1595937923691D6D007DBE15 /* crypt_prng_descriptor.c */,
+				1595937A23691D6D007DBE15 /* crypt_constants.c */,
+				1595937B23691D6D007DBE15 /* crypt_prng_is_valid.c */,
+				1595937C23691D6D007DBE15 /* crypt_prng_rng_descriptor.c */,
+				1595937D23691D6D007DBE15 /* crypt_cipher_is_valid.c */,
+				1595937E23691D6D007DBE15 /* crypt_find_hash_oid.c */,
+				1595937F23691D6D007DBE15 /* crypt_hash_descriptor.c */,
+				1595938023691D6D007DBE15 /* crypt_register_all_ciphers.c */,
+				1595938123691D6D007DBE15 /* crypt_register_prng.c */,
+				1595938223691D6D007DBE15 /* crypt_register_cipher.c */,
+				1595938323691D6D007DBE15 /* crypt_find_hash.c */,
+				1595938423691D6D007DBE15 /* crypt_inits.c */,
+				1595938523691D6D007DBE15 /* crypt_cipher_descriptor.c */,
+				1595938623691D6D007DBE15 /* crypt_register_all_hashes.c */,
+				1595938723691D6D007DBE15 /* crypt_find_cipher.c */,
+				1595938823691D6D007DBE15 /* crypt_find_hash_id.c */,
+				1595938923691D6D007DBE15 /* crypt_ltc_mp_descriptor.c */,
+				1595938A23691D6D007DBE15 /* crypt_find_cipher_id.c */,
+				1595938B23691D6D007DBE15 /* crypt_register_hash.c */,
+				1595938C23691D6D007DBE15 /* crypt_hash_is_valid.c */,
+				1595938D23691D6D007DBE15 /* crypt_find_prng.c */,
+				1595938E23691D6D007DBE15 /* crypt_argchk.c */,
+				1595938F23691D6D007DBE15 /* crypt_sizes.c */,
+				1595939023691D6D007DBE15 /* crypt_find_hash_any.c */,
+				1595939123691D6D007DBE15 /* crypt_register_all_prngs.c */,
+				1595939223691D6D007DBE15 /* crypt_fsa.c */,
+				1595939323691D6D007DBE15 /* crypt_unregister_hash.c */,
+			);
+			path = crypt;
+			sourceTree = "<group>";
+		};
+		1595939423691D6D007DBE15 /* bcrypt */ = {
+			isa = PBXGroup;
+			children = (
+				1595939523691D6D007DBE15 /* bcrypt.c */,
+			);
+			path = bcrypt;
+			sourceTree = "<group>";
+		};
+		1595939623691D6D007DBE15 /* base64 */ = {
+			isa = PBXGroup;
+			children = (
+				1595939723691D6D007DBE15 /* base64_decode.c */,
+				1595939823691D6D007DBE15 /* base64_encode.c */,
+			);
+			path = base64;
+			sourceTree = "<group>";
+		};
+		1595939923691D6D007DBE15 /* pkcs5 */ = {
+			isa = PBXGroup;
+			children = (
+				1595939A23691D6D007DBE15 /* pkcs_5_1.c */,
+				1595939B23691D6D007DBE15 /* pkcs_5_2.c */,
+				1595939C23691D6D007DBE15 /* pkcs_5_test.c */,
+			);
+			path = pkcs5;
+			sourceTree = "<group>";
+		};
+		1595939F23691D6D007DBE15 /* hkdf */ = {
+			isa = PBXGroup;
+			children = (
+				159593A023691D6D007DBE15 /* hkdf_test.c */,
+				159593A123691D6D007DBE15 /* hkdf.c */,
+			);
+			path = hkdf;
+			sourceTree = "<group>";
+		};
+		159593A223691D6D007DBE15 /* ssh */ = {
+			isa = PBXGroup;
+			children = (
+				159593A323691D6D007DBE15 /* ssh_decode_sequence_multi.c */,
+				159593A423691D6D007DBE15 /* ssh_encode_sequence_multi.c */,
+			);
+			path = ssh;
+			sourceTree = "<group>";
+		};
+		159593A523691D6D007DBE15 /* base16 */ = {
+			isa = PBXGroup;
+			children = (
+				159593A623691D6D007DBE15 /* base16_encode.c */,
+				159593A723691D6D007DBE15 /* base16_decode.c */,
+			);
+			path = base16;
+			sourceTree = "<group>";
+		};
+		159593A823691D6D007DBE15 /* padding */ = {
+			isa = PBXGroup;
+			children = (
+				159593A923691D6D007DBE15 /* padding_pad.c */,
+				159593AA23691D6D007DBE15 /* padding_depad.c */,
+			);
+			path = padding;
+			sourceTree = "<group>";
+		};
+		159593AB23691D6D007DBE15 /* base32 */ = {
+			isa = PBXGroup;
+			children = (
+				159593AC23691D6D007DBE15 /* base32_decode.c */,
+				159593AD23691D6D007DBE15 /* base32_encode.c */,
+			);
+			path = base32;
+			sourceTree = "<group>";
+		};
+		159593B123691D6D007DBE15 /* pk */ = {
+			isa = PBXGroup;
+			children = (
+				159593B223691D6D007DBE15 /* asn1 */,
+				1595940923691D6E007DBE15 /* dh */,
+				1595941423691D6E007DBE15 /* rsa */,
+				1595942323691D6E007DBE15 /* dsa */,
+				1595943223691D6E007DBE15 /* ec25519 */,
+				1595943623691D6E007DBE15 /* ed25519 */,
+				1595943F23691D6E007DBE15 /* ecc */,
+				1595946623691D6E007DBE15 /* pkcs1 */,
+				1595947023691D6E007DBE15 /* x25519 */,
+			);
+			path = pk;
+			sourceTree = "<group>";
+		};
+		159593B223691D6D007DBE15 /* asn1 */ = {
+			isa = PBXGroup;
+			children = (
+				159593B323691D6D007DBE15 /* der */,
+				159593FF23691D6E007DBE15 /* x509 */,
+				1595940323691D6E007DBE15 /* oid */,
+				1595940723691D6E007DBE15 /* pkcs8 */,
+			);
+			path = asn1;
+			sourceTree = "<group>";
+		};
+		159593B323691D6D007DBE15 /* der */ = {
+			isa = PBXGroup;
+			children = (
+				159593B423691D6D007DBE15 /* octet */,
+				159593B823691D6D007DBE15 /* bit */,
+				159593BE23691D6D007DBE15 /* object_identifier */,
+				159593C223691D6D007DBE15 /* utf8 */,
+				159593C623691D6D007DBE15 /* general */,
+				159593CE23691D6D007DBE15 /* generalizedtime */,
+				159593D223691D6D007DBE15 /* short_integer */,
+				159593D623691D6D007DBE15 /* choice */,
+				159593D823691D6D007DBE15 /* ia5 */,
+				159593DC23691D6D007DBE15 /* teletex_string */,
+				159593DF23691D6D007DBE15 /* boolean */,
+				159593E323691D6D007DBE15 /* integer */,
+				159593E723691D6D007DBE15 /* custom_type */,
+				159593EB23691D6D007DBE15 /* set */,
+				159593EE23691D6D007DBE15 /* sequence */,
+				159593F723691D6E007DBE15 /* printable_string */,
+				159593FB23691D6E007DBE15 /* utctime */,
+			);
+			path = der;
+			sourceTree = "<group>";
+		};
+		159593B423691D6D007DBE15 /* octet */ = {
+			isa = PBXGroup;
+			children = (
+				159593B523691D6D007DBE15 /* der_decode_octet_string.c */,
+				159593B623691D6D007DBE15 /* der_encode_octet_string.c */,
+				159593B723691D6D007DBE15 /* der_length_octet_string.c */,
+			);
+			path = octet;
+			sourceTree = "<group>";
+		};
+		159593B823691D6D007DBE15 /* bit */ = {
+			isa = PBXGroup;
+			children = (
+				159593B923691D6D007DBE15 /* der_length_bit_string.c */,
+				159593BA23691D6D007DBE15 /* der_encode_raw_bit_string.c */,
+				159593BB23691D6D007DBE15 /* der_decode_raw_bit_string.c */,
+				159593BC23691D6D007DBE15 /* der_encode_bit_string.c */,
+				159593BD23691D6D007DBE15 /* der_decode_bit_string.c */,
+			);
+			path = bit;
+			sourceTree = "<group>";
+		};
+		159593BE23691D6D007DBE15 /* object_identifier */ = {
+			isa = PBXGroup;
+			children = (
+				159593BF23691D6D007DBE15 /* der_encode_object_identifier.c */,
+				159593C023691D6D007DBE15 /* der_decode_object_identifier.c */,
+				159593C123691D6D007DBE15 /* der_length_object_identifier.c */,
+			);
+			path = object_identifier;
+			sourceTree = "<group>";
+		};
+		159593C223691D6D007DBE15 /* utf8 */ = {
+			isa = PBXGroup;
+			children = (
+				159593C323691D6D007DBE15 /* der_encode_utf8_string.c */,
+				159593C423691D6D007DBE15 /* der_decode_utf8_string.c */,
+				159593C523691D6D007DBE15 /* der_length_utf8_string.c */,
+			);
+			path = utf8;
+			sourceTree = "<group>";
+		};
+		159593C623691D6D007DBE15 /* general */ = {
+			isa = PBXGroup;
+			children = (
+				159593C723691D6D007DBE15 /* der_encode_asn1_identifier.c */,
+				159593C823691D6D007DBE15 /* der_length_asn1_identifier.c */,
+				159593C923691D6D007DBE15 /* der_encode_asn1_length.c */,
+				159593CA23691D6D007DBE15 /* der_decode_asn1_identifier.c */,
+				159593CB23691D6D007DBE15 /* der_length_asn1_length.c */,
+				159593CC23691D6D007DBE15 /* der_decode_asn1_length.c */,
+				159593CD23691D6D007DBE15 /* der_asn1_maps.c */,
+			);
+			path = general;
+			sourceTree = "<group>";
+		};
+		159593CE23691D6D007DBE15 /* generalizedtime */ = {
+			isa = PBXGroup;
+			children = (
+				159593CF23691D6D007DBE15 /* der_decode_generalizedtime.c */,
+				159593D023691D6D007DBE15 /* der_encode_generalizedtime.c */,
+				159593D123691D6D007DBE15 /* der_length_generalizedtime.c */,
+			);
+			path = generalizedtime;
+			sourceTree = "<group>";
+		};
+		159593D223691D6D007DBE15 /* short_integer */ = {
+			isa = PBXGroup;
+			children = (
+				159593D323691D6D007DBE15 /* der_length_short_integer.c */,
+				159593D423691D6D007DBE15 /* der_encode_short_integer.c */,
+				159593D523691D6D007DBE15 /* der_decode_short_integer.c */,
+			);
+			path = short_integer;
+			sourceTree = "<group>";
+		};
+		159593D623691D6D007DBE15 /* choice */ = {
+			isa = PBXGroup;
+			children = (
+				159593D723691D6D007DBE15 /* der_decode_choice.c */,
+			);
+			path = choice;
+			sourceTree = "<group>";
+		};
+		159593D823691D6D007DBE15 /* ia5 */ = {
+			isa = PBXGroup;
+			children = (
+				159593D923691D6D007DBE15 /* der_length_ia5_string.c */,
+				159593DA23691D6D007DBE15 /* der_encode_ia5_string.c */,
+				159593DB23691D6D007DBE15 /* der_decode_ia5_string.c */,
+			);
+			path = ia5;
+			sourceTree = "<group>";
+		};
+		159593DC23691D6D007DBE15 /* teletex_string */ = {
+			isa = PBXGroup;
+			children = (
+				159593DD23691D6D007DBE15 /* der_decode_teletex_string.c */,
+				159593DE23691D6D007DBE15 /* der_length_teletex_string.c */,
+			);
+			path = teletex_string;
+			sourceTree = "<group>";
+		};
+		159593DF23691D6D007DBE15 /* boolean */ = {
+			isa = PBXGroup;
+			children = (
+				159593E023691D6D007DBE15 /* der_decode_boolean.c */,
+				159593E123691D6D007DBE15 /* der_length_boolean.c */,
+				159593E223691D6D007DBE15 /* der_encode_boolean.c */,
+			);
+			path = boolean;
+			sourceTree = "<group>";
+		};
+		159593E323691D6D007DBE15 /* integer */ = {
+			isa = PBXGroup;
+			children = (
+				159593E423691D6D007DBE15 /* der_length_integer.c */,
+				159593E523691D6D007DBE15 /* der_decode_integer.c */,
+				159593E623691D6D007DBE15 /* der_encode_integer.c */,
+			);
+			path = integer;
+			sourceTree = "<group>";
+		};
+		159593E723691D6D007DBE15 /* custom_type */ = {
+			isa = PBXGroup;
+			children = (
+				159593E823691D6D007DBE15 /* der_encode_custom_type.c */,
+				159593E923691D6D007DBE15 /* der_decode_custom_type.c */,
+				159593EA23691D6D007DBE15 /* der_length_custom_type.c */,
+			);
+			path = custom_type;
+			sourceTree = "<group>";
+		};
+		159593EB23691D6D007DBE15 /* set */ = {
+			isa = PBXGroup;
+			children = (
+				159593EC23691D6D007DBE15 /* der_encode_setof.c */,
+				159593ED23691D6D007DBE15 /* der_encode_set.c */,
+			);
+			path = set;
+			sourceTree = "<group>";
+		};
+		159593EE23691D6D007DBE15 /* sequence */ = {
+			isa = PBXGroup;
+			children = (
+				159593EF23691D6E007DBE15 /* der_encode_sequence_ex.c */,
+				159593F023691D6E007DBE15 /* der_sequence_shrink.c */,
+				159593F123691D6E007DBE15 /* der_length_sequence.c */,
+				159593F223691D6E007DBE15 /* der_decode_sequence_ex.c */,
+				159593F323691D6E007DBE15 /* der_decode_sequence_multi.c */,
+				159593F423691D6E007DBE15 /* der_decode_sequence_flexi.c */,
+				159593F523691D6E007DBE15 /* der_encode_sequence_multi.c */,
+				159593F623691D6E007DBE15 /* der_sequence_free.c */,
+			);
+			path = sequence;
+			sourceTree = "<group>";
+		};
+		159593F723691D6E007DBE15 /* printable_string */ = {
+			isa = PBXGroup;
+			children = (
+				159593F823691D6E007DBE15 /* der_encode_printable_string.c */,
+				159593F923691D6E007DBE15 /* der_length_printable_string.c */,
+				159593FA23691D6E007DBE15 /* der_decode_printable_string.c */,
+			);
+			path = printable_string;
+			sourceTree = "<group>";
+		};
+		159593FB23691D6E007DBE15 /* utctime */ = {
+			isa = PBXGroup;
+			children = (
+				159593FC23691D6E007DBE15 /* der_encode_utctime.c */,
+				159593FD23691D6E007DBE15 /* der_length_utctime.c */,
+				159593FE23691D6E007DBE15 /* der_decode_utctime.c */,
+			);
+			path = utctime;
+			sourceTree = "<group>";
+		};
+		159593FF23691D6E007DBE15 /* x509 */ = {
+			isa = PBXGroup;
+			children = (
+				1595940023691D6E007DBE15 /* x509_encode_subject_public_key_info.c */,
+				1595940123691D6E007DBE15 /* x509_decode_public_key_from_certificate.c */,
+				1595940223691D6E007DBE15 /* x509_decode_subject_public_key_info.c */,
+			);
+			path = x509;
+			sourceTree = "<group>";
+		};
+		1595940323691D6E007DBE15 /* oid */ = {
+			isa = PBXGroup;
+			children = (
+				1595940423691D6E007DBE15 /* pk_get_oid.c */,
+				1595940523691D6E007DBE15 /* pk_oid_str.c */,
+				1595940623691D6E007DBE15 /* pk_oid_cmp.c */,
+			);
+			path = oid;
+			sourceTree = "<group>";
+		};
+		1595940723691D6E007DBE15 /* pkcs8 */ = {
+			isa = PBXGroup;
+			children = (
+				1595940823691D6E007DBE15 /* pkcs8_decode_flexi.c */,
+			);
+			path = pkcs8;
+			sourceTree = "<group>";
+		};
+		1595940923691D6E007DBE15 /* dh */ = {
+			isa = PBXGroup;
+			children = (
+				1595940A23691D6E007DBE15 /* dh_import.c */,
+				1595940B23691D6E007DBE15 /* dh_set.c */,
+				1595940C23691D6E007DBE15 /* dh_shared_secret.c */,
+				1595940D23691D6E007DBE15 /* dh_export_key.c */,
+				1595940E23691D6E007DBE15 /* dh_set_pg_dhparam.c */,
+				1595940F23691D6E007DBE15 /* dh_check_pubkey.c */,
+				1595941023691D6E007DBE15 /* dh_free.c */,
+				1595941123691D6E007DBE15 /* dh_generate_key.c */,
+				1595941223691D6E007DBE15 /* dh.c */,
+				1595941323691D6E007DBE15 /* dh_export.c */,
+			);
+			path = dh;
+			sourceTree = "<group>";
+		};
+		1595941423691D6E007DBE15 /* rsa */ = {
+			isa = PBXGroup;
+			children = (
+				1595941523691D6E007DBE15 /* rsa_verify_hash.c */,
+				1595941623691D6E007DBE15 /* rsa_import_pkcs8.c */,
+				1595941723691D6E007DBE15 /* rsa_exptmod.c */,
+				1595941823691D6E007DBE15 /* rsa_decrypt_key.c */,
+				1595941923691D6E007DBE15 /* rsa_encrypt_key.c */,
+				1595941A23691D6E007DBE15 /* rsa_import.c */,
+				1595941B23691D6E007DBE15 /* rsa_sign_hash.c */,
+				1595941C23691D6E007DBE15 /* rsa_set.c */,
+				1595941D23691D6E007DBE15 /* rsa_import_x509.c */,
+				1595941E23691D6E007DBE15 /* rsa_make_key.c */,
+				1595941F23691D6E007DBE15 /* rsa_export.c */,
+				1595942023691D6E007DBE15 /* rsa_sign_saltlen_get.c */,
+				1595942123691D6E007DBE15 /* rsa_key.c */,
+				1595942223691D6E007DBE15 /* rsa_get_size.c */,
+			);
+			path = rsa;
+			sourceTree = "<group>";
+		};
+		1595942323691D6E007DBE15 /* dsa */ = {
+			isa = PBXGroup;
+			children = (
+				1595942423691D6E007DBE15 /* dsa_make_key.c */,
+				1595942523691D6E007DBE15 /* dsa_verify_key.c */,
+				1595942623691D6E007DBE15 /* dsa_set.c */,
+				1595942723691D6E007DBE15 /* dsa_sign_hash.c */,
+				1595942823691D6E007DBE15 /* dsa_shared_secret.c */,
+				1595942923691D6E007DBE15 /* dsa_generate_pqg.c */,
+				1595942A23691D6E007DBE15 /* dsa_import.c */,
+				1595942B23691D6E007DBE15 /* dsa_decrypt_key.c */,
+				1595942C23691D6E007DBE15 /* dsa_set_pqg_dsaparam.c */,
+				1595942D23691D6E007DBE15 /* dsa_export.c */,
+				1595942E23691D6E007DBE15 /* dsa_verify_hash.c */,
+				1595942F23691D6E007DBE15 /* dsa_generate_key.c */,
+				1595943023691D6E007DBE15 /* dsa_free.c */,
+				1595943123691D6E007DBE15 /* dsa_encrypt_key.c */,
+			);
+			path = dsa;
+			sourceTree = "<group>";
+		};
+		1595943223691D6E007DBE15 /* ec25519 */ = {
+			isa = PBXGroup;
+			children = (
+				1595943323691D6E007DBE15 /* ec25519_export.c */,
+				1595943423691D6E007DBE15 /* ec25519_import_pkcs8.c */,
+				1595943523691D6E007DBE15 /* tweetnacl.c */,
+			);
+			path = ec25519;
+			sourceTree = "<group>";
+		};
+		1595943623691D6E007DBE15 /* ed25519 */ = {
+			isa = PBXGroup;
+			children = (
+				1595943723691D6E007DBE15 /* ed25519_export.c */,
+				1595943823691D6E007DBE15 /* ed25519_import_pkcs8.c */,
+				1595943923691D6E007DBE15 /* ed25519_import_raw.c */,
+				1595943A23691D6E007DBE15 /* ed25519_import_x509.c */,
+				1595943B23691D6E007DBE15 /* ed25519_sign.c */,
+				1595943C23691D6E007DBE15 /* ed25519_make_key.c */,
+				1595943D23691D6E007DBE15 /* ed25519_verify.c */,
+				1595943E23691D6E007DBE15 /* ed25519_import.c */,
+			);
+			path = ed25519;
+			sourceTree = "<group>";
+		};
+		1595943F23691D6E007DBE15 /* ecc */ = {
+			isa = PBXGroup;
+			children = (
+				1595944023691D6E007DBE15 /* ecc_import_x509.c */,
+				1595944123691D6E007DBE15 /* ecc_set_curve.c */,
+				1595944223691D6E007DBE15 /* ecc_recover_key.c */,
+				1595944323691D6E007DBE15 /* ecc_export_openssl.c */,
+				1595944423691D6E007DBE15 /* ltc_ecc_projective_add_point.c */,
+				1595944523691D6E007DBE15 /* ecc_make_key.c */,
+				1595944623691D6E007DBE15 /* ecc_ansi_x963_import.c */,
+				1595944723691D6E007DBE15 /* ltc_ecc_map.c */,
+				1595944823691D6E007DBE15 /* ecc_get_size.c */,
+				1595944923691D6E007DBE15 /* ecc_import_pkcs8.c */,
+				1595944A23691D6E007DBE15 /* ecc_set_key.c */,
+				1595944B23691D6E007DBE15 /* ecc.c */,
+				1595944C23691D6E007DBE15 /* ecc_get_key.c */,
+				1595944D23691D6E007DBE15 /* ecc_export.c */,
+				1595944E23691D6E007DBE15 /* ecc_import_openssl.c */,
+				1595944F23691D6E007DBE15 /* ecc_free.c */,
+				1595945023691D6E007DBE15 /* ecc_find_curve.c */,
+				1595945123691D6E007DBE15 /* ecc_import.c */,
+				1595945223691D6E007DBE15 /* ecc_get_oid_str.c */,
+				1595945323691D6E007DBE15 /* ecc_decrypt_key.c */,
+				1595945423691D6E007DBE15 /* ltc_ecc_is_point.c */,
+				1595945523691D6E007DBE15 /* ecc_shared_secret.c */,
+				1595945623691D6E007DBE15 /* ltc_ecc_projective_dbl_point.c */,
+				1595945723691D6E007DBE15 /* ecc_sizes.c */,
+				1595945823691D6E007DBE15 /* ltc_ecc_mul2add.c */,
+				1595945923691D6E007DBE15 /* ltc_ecc_points.c */,
+				1595945A23691D6E007DBE15 /* ltc_ecc_mulmod.c */,
+				1595945B23691D6E007DBE15 /* ecc_verify_hash.c */,
+				1595945C23691D6E007DBE15 /* ltc_ecc_is_point_at_infinity.c */,
+				1595945D23691D6E007DBE15 /* ltc_ecc_import_point.c */,
+				1595945E23691D6E007DBE15 /* ltc_ecc_mulmod_timing.c */,
+				1595945F23691D6E007DBE15 /* ecc_ansi_x963_export.c */,
+				1595946023691D6E007DBE15 /* ecc_ssh_ecdsa_encode_name.c */,
+				1595946123691D6E007DBE15 /* ecc_sign_hash.c */,
+				1595946223691D6E007DBE15 /* ecc_encrypt_key.c */,
+				1595946323691D6E007DBE15 /* ecc_set_curve_internal.c */,
+				1595946423691D6E007DBE15 /* ltc_ecc_verify_key.c */,
+				1595946523691D6E007DBE15 /* ltc_ecc_export_point.c */,
+			);
+			path = ecc;
+			sourceTree = "<group>";
+		};
+		1595946623691D6E007DBE15 /* pkcs1 */ = {
+			isa = PBXGroup;
+			children = (
+				1595946723691D6E007DBE15 /* pkcs_1_os2ip.c */,
+				1595946823691D6E007DBE15 /* pkcs_1_pss_decode.c */,
+				1595946923691D6E007DBE15 /* pkcs_1_pss_encode.c */,
+				1595946A23691D6E007DBE15 /* pkcs_1_mgf1.c */,
+				1595946B23691D6E007DBE15 /* pkcs_1_oaep_decode.c */,
+				1595946C23691D6E007DBE15 /* pkcs_1_v1_5_decode.c */,
+				1595946D23691D6E007DBE15 /* pkcs_1_v1_5_encode.c */,
+				1595946E23691D6E007DBE15 /* pkcs_1_oaep_encode.c */,
+				1595946F23691D6E007DBE15 /* pkcs_1_i2osp.c */,
+			);
+			path = pkcs1;
+			sourceTree = "<group>";
+		};
+		1595947023691D6E007DBE15 /* x25519 */ = {
+			isa = PBXGroup;
+			children = (
+				1595947123691D6E007DBE15 /* x25519_make_key.c */,
+				1595947223691D6E007DBE15 /* x25519_import_pkcs8.c */,
+				1595947323691D6E007DBE15 /* x25519_export.c */,
+				1595947423691D6E007DBE15 /* x25519_shared_secret.c */,
+				1595947523691D6E007DBE15 /* x25519_import.c */,
+				1595947623691D6E007DBE15 /* x25519_import_raw.c */,
+				1595947723691D6E007DBE15 /* x25519_import_x509.c */,
+			);
+			path = x25519;
+			sourceTree = "<group>";
+		};
+		1595947823691D6E007DBE15 /* hashes */ = {
+			isa = PBXGroup;
+			children = (
+				1595947923691D6E007DBE15 /* md4.c */,
+				1595947A23691D6E007DBE15 /* sha2 */,
+				1595948123691D6E007DBE15 /* whirl */,
+				1595948423691D6E007DBE15 /* sha1.c */,
+				1595948523691D6E007DBE15 /* rmd128.c */,
+				1595948623691D6E007DBE15 /* sha3_test.c */,
+				1595948723691D6E007DBE15 /* chc */,
+				1595948923691D6E007DBE15 /* rmd256.c */,
+				1595948A23691D6E007DBE15 /* md2.c */,
+				1595948B23691D6E007DBE15 /* blake2b.c */,
+				1595948C23691D6E007DBE15 /* md5.c */,
+				1595948D23691D6E007DBE15 /* tiger.c */,
+				1595948E23691D6E007DBE15 /* blake2s.c */,
+				1595948F23691D6E007DBE15 /* sha3.c */,
+				1595949023691D6E007DBE15 /* helper */,
+				1595949523691D6E007DBE15 /* rmd160.c */,
+				1595949623691D6E007DBE15 /* rmd320.c */,
+			);
+			path = hashes;
+			sourceTree = "<group>";
+		};
+		1595947A23691D6E007DBE15 /* sha2 */ = {
+			isa = PBXGroup;
+			children = (
+				1595947B23691D6E007DBE15 /* sha512_224.c */,
+				1595947C23691D6E007DBE15 /* sha512_256.c */,
+				1595947D23691D6E007DBE15 /* sha224.c */,
+				1595947E23691D6E007DBE15 /* sha256.c */,
+				1595947F23691D6E007DBE15 /* sha512.c */,
+				1595948023691D6E007DBE15 /* sha384.c */,
+			);
+			path = sha2;
+			sourceTree = "<group>";
+		};
+		1595948123691D6E007DBE15 /* whirl */ = {
+			isa = PBXGroup;
+			children = (
+				1595948223691D6E007DBE15 /* whirltab.c */,
+				1595948323691D6E007DBE15 /* whirl.c */,
+			);
+			path = whirl;
+			sourceTree = "<group>";
+		};
+		1595948723691D6E007DBE15 /* chc */ = {
+			isa = PBXGroup;
+			children = (
+				1595948823691D6E007DBE15 /* chc.c */,
+			);
+			path = chc;
+			sourceTree = "<group>";
+		};
+		1595949023691D6E007DBE15 /* helper */ = {
+			isa = PBXGroup;
+			children = (
+				1595949123691D6E007DBE15 /* hash_memory_multi.c */,
+				1595949223691D6E007DBE15 /* hash_file.c */,
+				1595949323691D6E007DBE15 /* hash_filehandle.c */,
+				1595949423691D6E007DBE15 /* hash_memory.c */,
+			);
+			path = helper;
+			sourceTree = "<group>";
+		};
+		1595949723691D6E007DBE15 /* modes */ = {
+			isa = PBXGroup;
+			children = (
+				1595949823691D6E007DBE15 /* xts */,
+				1595949F23691D6E007DBE15 /* ctr */,
+				159594A723691D6E007DBE15 /* ofb */,
+				159594AE23691D6E007DBE15 /* cbc */,
+				159594B523691D6E007DBE15 /* lrw */,
+				159594BE23691D6E007DBE15 /* f8 */,
+				159594C623691D6E007DBE15 /* cfb */,
+				159594CD23691D6E007DBE15 /* ecb */,
+			);
+			path = modes;
+			sourceTree = "<group>";
+		};
+		1595949823691D6E007DBE15 /* xts */ = {
+			isa = PBXGroup;
+			children = (
+				1595949923691D6E007DBE15 /* xts_init.c */,
+				1595949A23691D6E007DBE15 /* xts_mult_x.c */,
+				1595949B23691D6E007DBE15 /* xts_decrypt.c */,
+				1595949C23691D6E007DBE15 /* xts_encrypt.c */,
+				1595949D23691D6E007DBE15 /* xts_done.c */,
+				1595949E23691D6E007DBE15 /* xts_test.c */,
+			);
+			path = xts;
+			sourceTree = "<group>";
+		};
+		1595949F23691D6E007DBE15 /* ctr */ = {
+			isa = PBXGroup;
+			children = (
+				159594A023691D6E007DBE15 /* ctr_encrypt.c */,
+				159594A123691D6E007DBE15 /* ctr_setiv.c */,
+				159594A223691D6E007DBE15 /* ctr_start.c */,
+				159594A323691D6E007DBE15 /* ctr_decrypt.c */,
+				159594A423691D6E007DBE15 /* ctr_getiv.c */,
+				159594A523691D6E007DBE15 /* ctr_test.c */,
+				159594A623691D6E007DBE15 /* ctr_done.c */,
+			);
+			path = ctr;
+			sourceTree = "<group>";
+		};
+		159594A723691D6E007DBE15 /* ofb */ = {
+			isa = PBXGroup;
+			children = (
+				159594A823691D6E007DBE15 /* ofb_getiv.c */,
+				159594A923691D6E007DBE15 /* ofb_encrypt.c */,
+				159594AA23691D6E007DBE15 /* ofb_done.c */,
+				159594AB23691D6E007DBE15 /* ofb_start.c */,
+				159594AC23691D6E007DBE15 /* ofb_setiv.c */,
+				159594AD23691D6E007DBE15 /* ofb_decrypt.c */,
+			);
+			path = ofb;
+			sourceTree = "<group>";
+		};
+		159594AE23691D6E007DBE15 /* cbc */ = {
+			isa = PBXGroup;
+			children = (
+				159594AF23691D6E007DBE15 /* cbc_setiv.c */,
+				159594B023691D6E007DBE15 /* cbc_decrypt.c */,
+				159594B123691D6E007DBE15 /* cbc_done.c */,
+				159594B223691D6E007DBE15 /* cbc_getiv.c */,
+				159594B323691D6E007DBE15 /* cbc_start.c */,
+				159594B423691D6E007DBE15 /* cbc_encrypt.c */,
+			);
+			path = cbc;
+			sourceTree = "<group>";
+		};
+		159594B523691D6E007DBE15 /* lrw */ = {
+			isa = PBXGroup;
+			children = (
+				159594B623691D6E007DBE15 /* lrw_encrypt.c */,
+				159594B723691D6E007DBE15 /* lrw_test.c */,
+				159594B823691D6E007DBE15 /* lrw_process.c */,
+				159594B923691D6E007DBE15 /* lrw_setiv.c */,
+				159594BA23691D6E007DBE15 /* lrw_done.c */,
+				159594BB23691D6E007DBE15 /* lrw_start.c */,
+				159594BC23691D6E007DBE15 /* lrw_getiv.c */,
+				159594BD23691D6E007DBE15 /* lrw_decrypt.c */,
+			);
+			path = lrw;
+			sourceTree = "<group>";
+		};
+		159594BE23691D6E007DBE15 /* f8 */ = {
+			isa = PBXGroup;
+			children = (
+				159594BF23691D6E007DBE15 /* f8_start.c */,
+				159594C023691D6E007DBE15 /* f8_decrypt.c */,
+				159594C123691D6E007DBE15 /* f8_getiv.c */,
+				159594C223691D6E007DBE15 /* f8_done.c */,
+				159594C323691D6E007DBE15 /* f8_test_mode.c */,
+				159594C423691D6E007DBE15 /* f8_encrypt.c */,
+				159594C523691D6E007DBE15 /* f8_setiv.c */,
+			);
+			path = f8;
+			sourceTree = "<group>";
+		};
+		159594C623691D6E007DBE15 /* cfb */ = {
+			isa = PBXGroup;
+			children = (
+				159594C723691D6E007DBE15 /* cfb_done.c */,
+				159594C823691D6E007DBE15 /* cfb_encrypt.c */,
+				159594C923691D6E007DBE15 /* cfb_start.c */,
+				159594CA23691D6E007DBE15 /* cfb_getiv.c */,
+				159594CB23691D6E007DBE15 /* cfb_setiv.c */,
+				159594CC23691D6E007DBE15 /* cfb_decrypt.c */,
+			);
+			path = cfb;
+			sourceTree = "<group>";
+		};
+		159594CD23691D6E007DBE15 /* ecb */ = {
+			isa = PBXGroup;
+			children = (
+				159594CE23691D6E007DBE15 /* ecb_encrypt.c */,
+				159594CF23691D6E007DBE15 /* ecb_done.c */,
+				159594D023691D6E007DBE15 /* ecb_decrypt.c */,
+				159594D123691D6E007DBE15 /* ecb_start.c */,
+			);
+			path = ecb;
+			sourceTree = "<group>";
+		};
+		159594D223691D6E007DBE15 /* prngs */ = {
+			isa = PBXGroup;
+			children = (
+				159594D323691D6E007DBE15 /* chacha20.c */,
+				159594D423691D6E007DBE15 /* rc4.c */,
+				159594D523691D6E007DBE15 /* rng_get_bytes.c */,
+				159594D623691D6E007DBE15 /* fortuna.c */,
+				159594D723691D6E007DBE15 /* rng_make_prng.c */,
+				159594D823691D6E007DBE15 /* sober128.c */,
+				159594D923691D6E007DBE15 /* sprng.c */,
+				159594DA23691D6E007DBE15 /* yarrow.c */,
+			);
+			path = prngs;
+			sourceTree = "<group>";
+		};
+		159594DB23691D6E007DBE15 /* encauth */ = {
+			isa = PBXGroup;
+			children = (
+				159594DC23691D6E007DBE15 /* eax */,
+				159594E523691D6E007DBE15 /* gcm */,
+				159594F023691D6E007DBE15 /* ccm */,
+				159594F923691D6E007DBE15 /* chachapoly */,
+				1595950323691D6E007DBE15 /* ocb */,
+				1595950F23691D6E007DBE15 /* ocb3 */,
+			);
+			path = encauth;
+			sourceTree = "<group>";
+		};
+		159594DC23691D6E007DBE15 /* eax */ = {
+			isa = PBXGroup;
+			children = (
+				159594DD23691D6E007DBE15 /* eax_decrypt.c */,
+				159594DE23691D6E007DBE15 /* eax_decrypt_verify_memory.c */,
+				159594DF23691D6E007DBE15 /* eax_init.c */,
+				159594E023691D6E007DBE15 /* eax_encrypt_authenticate_memory.c */,
+				159594E123691D6E007DBE15 /* eax_addheader.c */,
+				159594E223691D6E007DBE15 /* eax_encrypt.c */,
+				159594E323691D6E007DBE15 /* eax_done.c */,
+				159594E423691D6E007DBE15 /* eax_test.c */,
+			);
+			path = eax;
+			sourceTree = "<group>";
+		};
+		159594E523691D6E007DBE15 /* gcm */ = {
+			isa = PBXGroup;
+			children = (
+				159594E623691D6E007DBE15 /* gcm_init.c */,
+				159594E723691D6E007DBE15 /* gcm_process.c */,
+				159594E823691D6E007DBE15 /* gcm_memory.c */,
+				159594E923691D6E007DBE15 /* gcm_reset.c */,
+				159594EA23691D6E007DBE15 /* gcm_done.c */,
+				159594EB23691D6E007DBE15 /* gcm_test.c */,
+				159594EC23691D6E007DBE15 /* gcm_mult_h.c */,
+				159594ED23691D6E007DBE15 /* gcm_add_iv.c */,
+				159594EE23691D6E007DBE15 /* gcm_add_aad.c */,
+				159594EF23691D6E007DBE15 /* gcm_gf_mult.c */,
+			);
+			path = gcm;
+			sourceTree = "<group>";
+		};
+		159594F023691D6E007DBE15 /* ccm */ = {
+			isa = PBXGroup;
+			children = (
+				159594F123691D6E007DBE15 /* ccm_done.c */,
+				159594F223691D6E007DBE15 /* ccm_add_aad.c */,
+				159594F323691D6E007DBE15 /* ccm_test.c */,
+				159594F423691D6E007DBE15 /* ccm_add_nonce.c */,
+				159594F523691D6E007DBE15 /* ccm_process.c */,
+				159594F623691D6E007DBE15 /* ccm_reset.c */,
+				159594F723691D6E007DBE15 /* ccm_memory.c */,
+				159594F823691D6E007DBE15 /* ccm_init.c */,
+			);
+			path = ccm;
+			sourceTree = "<group>";
+		};
+		159594F923691D6E007DBE15 /* chachapoly */ = {
+			isa = PBXGroup;
+			children = (
+				159594FA23691D6E007DBE15 /* chacha20poly1305_test.c */,
+				159594FB23691D6E007DBE15 /* chacha20poly1305_done.c */,
+				159594FC23691D6E007DBE15 /* chacha20poly1305_add_aad.c */,
+				159594FD23691D6E007DBE15 /* chacha20poly1305_setiv_rfc7905.c */,
+				159594FE23691D6E007DBE15 /* chacha20poly1305_decrypt.c */,
+				159594FF23691D6E007DBE15 /* chacha20poly1305_encrypt.c */,
+				1595950023691D6E007DBE15 /* chacha20poly1305_setiv.c */,
+				1595950123691D6E007DBE15 /* chacha20poly1305_init.c */,
+				1595950223691D6E007DBE15 /* chacha20poly1305_memory.c */,
+			);
+			path = chachapoly;
+			sourceTree = "<group>";
+		};
+		1595950323691D6E007DBE15 /* ocb */ = {
+			isa = PBXGroup;
+			children = (
+				1595950423691D6E007DBE15 /* ocb_ntz.c */,
+				1595950523691D6E007DBE15 /* ocb_encrypt.c */,
+				1595950623691D6E007DBE15 /* ocb_shift_xor.c */,
+				1595950723691D6E007DBE15 /* ocb_init.c */,
+				1595950823691D6E007DBE15 /* ocb_encrypt_authenticate_memory.c */,
+				1595950923691D6E007DBE15 /* s_ocb_done.c */,
+				1595950A23691D6E007DBE15 /* ocb_done_encrypt.c */,
+				1595950B23691D6E007DBE15 /* ocb_test.c */,
+				1595950C23691D6E007DBE15 /* ocb_done_decrypt.c */,
+				1595950D23691D6E007DBE15 /* ocb_decrypt_verify_memory.c */,
+				1595950E23691D6E007DBE15 /* ocb_decrypt.c */,
+			);
+			path = ocb;
+			sourceTree = "<group>";
+		};
+		1595950F23691D6E007DBE15 /* ocb3 */ = {
+			isa = PBXGroup;
+			children = (
+				1595951023691D6E007DBE15 /* ocb3_int_ntz.c */,
+				1595951123691D6E007DBE15 /* ocb3_encrypt_authenticate_memory.c */,
+				1595951223691D6E007DBE15 /* ocb3_add_aad.c */,
+				1595951323691D6E007DBE15 /* ocb3_encrypt_last.c */,
+				1595951423691D6E007DBE15 /* ocb3_int_xor_blocks.c */,
+				1595951523691D6E007DBE15 /* ocb3_decrypt.c */,
+				1595951623691D6E007DBE15 /* ocb3_done.c */,
+				1595951723691D6E007DBE15 /* ocb3_test.c */,
+				1595951823691D6E007DBE15 /* ocb3_decrypt_verify_memory.c */,
+				1595951923691D6E007DBE15 /* ocb3_encrypt.c */,
+				1595951A23691D6E007DBE15 /* ocb3_decrypt_last.c */,
+				1595951B23691D6E007DBE15 /* ocb3_init.c */,
+			);
+			path = ocb3;
+			sourceTree = "<group>";
+		};
+		1595951C23691D6E007DBE15 /* stream */ = {
+			isa = PBXGroup;
+			children = (
+				1595951D23691D6E007DBE15 /* rc4 */,
+				1595952123691D6E007DBE15 /* chacha */,
+				1595952A23691D6E007DBE15 /* sober128 */,
+				1595952F23691D6E007DBE15 /* salsa20 */,
+				1595953A23691D6E007DBE15 /* rabbit */,
+				1595953D23691D6E007DBE15 /* sosemanuk */,
+			);
+			path = stream;
+			sourceTree = "<group>";
+		};
+		1595951D23691D6E007DBE15 /* rc4 */ = {
+			isa = PBXGroup;
+			children = (
+				1595951E23691D6E007DBE15 /* rc4_stream.c */,
+				1595951F23691D6E007DBE15 /* rc4_test.c */,
+				1595952023691D6E007DBE15 /* rc4_stream_memory.c */,
+			);
+			path = rc4;
+			sourceTree = "<group>";
+		};
+		1595952123691D6E007DBE15 /* chacha */ = {
+			isa = PBXGroup;
+			children = (
+				1595952223691D6E007DBE15 /* chacha_ivctr32.c */,
+				1595952323691D6E007DBE15 /* chacha_memory.c */,
+				1595952423691D6E007DBE15 /* chacha_crypt.c */,
+				1595952523691D6E007DBE15 /* chacha_keystream.c */,
+				1595952623691D6E007DBE15 /* chacha_test.c */,
+				1595952723691D6E007DBE15 /* chacha_done.c */,
+				1595952823691D6E007DBE15 /* chacha_ivctr64.c */,
+				1595952923691D6E007DBE15 /* chacha_setup.c */,
+			);
+			path = chacha;
+			sourceTree = "<group>";
+		};
+		1595952A23691D6E007DBE15 /* sober128 */ = {
+			isa = PBXGroup;
+			children = (
+				1595952B23691D6E007DBE15 /* sober128_stream_memory.c */,
+				1595952C23691D6E007DBE15 /* sober128tab.c */,
+				1595952D23691D6E007DBE15 /* sober128_test.c */,
+				1595952E23691D6E007DBE15 /* sober128_stream.c */,
+			);
+			path = sober128;
+			sourceTree = "<group>";
+		};
+		1595952F23691D6E007DBE15 /* salsa20 */ = {
+			isa = PBXGroup;
+			children = (
+				1595953023691D6E007DBE15 /* salsa20_setup.c */,
+				1595953123691D6E007DBE15 /* xsalsa20_memory.c */,
+				1595953223691D6E007DBE15 /* salsa20_done.c */,
+				1595953323691D6E007DBE15 /* salsa20_test.c */,
+				1595953423691D6E007DBE15 /* salsa20_memory.c */,
+				1595953523691D6E007DBE15 /* salsa20_keystream.c */,
+				1595953623691D6E007DBE15 /* salsa20_crypt.c */,
+				1595953723691D6E007DBE15 /* xsalsa20_test.c */,
+				1595953823691D6E007DBE15 /* salsa20_ivctr64.c */,
+				1595953923691D6E007DBE15 /* xsalsa20_setup.c */,
+			);
+			path = salsa20;
+			sourceTree = "<group>";
+		};
+		1595953A23691D6E007DBE15 /* rabbit */ = {
+			isa = PBXGroup;
+			children = (
+				1595953B23691D6E007DBE15 /* rabbit_memory.c */,
+				1595953C23691D6E007DBE15 /* rabbit.c */,
+			);
+			path = rabbit;
+			sourceTree = "<group>";
+		};
+		1595953D23691D6E007DBE15 /* sosemanuk */ = {
+			isa = PBXGroup;
+			children = (
+				1595953E23691D6E007DBE15 /* sosemanuk_memory.c */,
+				1595953F23691D6E007DBE15 /* sosemanuk_test.c */,
+				1595954023691D6E007DBE15 /* sosemanuk.c */,
+			);
+			path = sosemanuk;
+			sourceTree = "<group>";
+		};
+		1595954123691D6E007DBE15 /* math */ = {
+			isa = PBXGroup;
+			children = (
+				1595954223691D6E007DBE15 /* radix_to_bin.c */,
+				1595954323691D6E007DBE15 /* tfm_desc.c */,
+				1595954423691D6E007DBE15 /* rand_bn.c */,
+				1595954523691D6E007DBE15 /* fp */,
+				1595954723691D6E007DBE15 /* multi.c */,
+				1595954823691D6E007DBE15 /* ltm_desc.c */,
+				1595954923691D6E007DBE15 /* gmp_desc.c */,
+				1595954A23691D6E007DBE15 /* rand_prime.c */,
+			);
+			path = math;
+			sourceTree = "<group>";
+		};
+		1595954523691D6E007DBE15 /* fp */ = {
+			isa = PBXGroup;
+			children = (
+				1595954623691D6E007DBE15 /* ltc_ecc_fp_mulmod.c */,
+			);
+			path = fp;
+			sourceTree = "<group>";
+		};
+		1595954B23691D6F007DBE15 /* mac */ = {
+			isa = PBXGroup;
+			children = (
+				1595954C23691D6F007DBE15 /* pmac */,
+				1595955623691D6F007DBE15 /* hmac */,
+				1595955E23691D6F007DBE15 /* blake2 */,
+				1595956923691D6F007DBE15 /* poly1305 */,
+				1595956F23691D6F007DBE15 /* xcbc */,
+				1595957723691D6F007DBE15 /* f9 */,
+				1595957F23691D6F007DBE15 /* pelican */,
+				1595958323691D6F007DBE15 /* omac */,
+			);
+			path = mac;
+			sourceTree = "<group>";
+		};
+		1595954C23691D6F007DBE15 /* pmac */ = {
+			isa = PBXGroup;
+			children = (
+				1595954D23691D6F007DBE15 /* pmac_init.c */,
+				1595954E23691D6F007DBE15 /* pmac_shift_xor.c */,
+				1595954F23691D6F007DBE15 /* pmac_ntz.c */,
+				1595955023691D6F007DBE15 /* pmac_done.c */,
+				1595955123691D6F007DBE15 /* pmac_file.c */,
+				1595955223691D6F007DBE15 /* pmac_test.c */,
+				1595955323691D6F007DBE15 /* pmac_memory_multi.c */,
+				1595955423691D6F007DBE15 /* pmac_memory.c */,
+				1595955523691D6F007DBE15 /* pmac_process.c */,
+			);
+			path = pmac;
+			sourceTree = "<group>";
+		};
+		1595955623691D6F007DBE15 /* hmac */ = {
+			isa = PBXGroup;
+			children = (
+				1595955723691D6F007DBE15 /* hmac_memory.c */,
+				1595955823691D6F007DBE15 /* hmac_init.c */,
+				1595955923691D6F007DBE15 /* hmac_done.c */,
+				1595955A23691D6F007DBE15 /* hmac_test.c */,
+				1595955B23691D6F007DBE15 /* hmac_file.c */,
+				1595955C23691D6F007DBE15 /* hmac_memory_multi.c */,
+				1595955D23691D6F007DBE15 /* hmac_process.c */,
+			);
+			path = hmac;
+			sourceTree = "<group>";
+		};
+		1595955E23691D6F007DBE15 /* blake2 */ = {
+			isa = PBXGroup;
+			children = (
+				1595955F23691D6F007DBE15 /* blake2bmac_file.c */,
+				1595956023691D6F007DBE15 /* blake2smac_memory.c */,
+				1595956123691D6F007DBE15 /* blake2bmac_test.c */,
+				1595956223691D6F007DBE15 /* blake2bmac_memory_multi.c */,
+				1595956323691D6F007DBE15 /* blake2smac.c */,
+				1595956423691D6F007DBE15 /* blake2smac_test.c */,
+				1595956523691D6F007DBE15 /* blake2smac_file.c */,
+				1595956623691D6F007DBE15 /* blake2smac_memory_multi.c */,
+				1595956723691D6F007DBE15 /* blake2bmac_memory.c */,
+				1595956823691D6F007DBE15 /* blake2bmac.c */,
+			);
+			path = blake2;
+			sourceTree = "<group>";
+		};
+		1595956923691D6F007DBE15 /* poly1305 */ = {
+			isa = PBXGroup;
+			children = (
+				1595956A23691D6F007DBE15 /* poly1305_memory.c */,
+				1595956B23691D6F007DBE15 /* poly1305_test.c */,
+				1595956C23691D6F007DBE15 /* poly1305_file.c */,
+				1595956D23691D6F007DBE15 /* poly1305.c */,
+				1595956E23691D6F007DBE15 /* poly1305_memory_multi.c */,
+			);
+			path = poly1305;
+			sourceTree = "<group>";
+		};
+		1595956F23691D6F007DBE15 /* xcbc */ = {
+			isa = PBXGroup;
+			children = (
+				1595957023691D6F007DBE15 /* xcbc_init.c */,
+				1595957123691D6F007DBE15 /* xcbc_memory.c */,
+				1595957223691D6F007DBE15 /* xcbc_process.c */,
+				1595957323691D6F007DBE15 /* xcbc_file.c */,
+				1595957423691D6F007DBE15 /* xcbc_test.c */,
+				1595957523691D6F007DBE15 /* xcbc_memory_multi.c */,
+				1595957623691D6F007DBE15 /* xcbc_done.c */,
+			);
+			path = xcbc;
+			sourceTree = "<group>";
+		};
+		1595957723691D6F007DBE15 /* f9 */ = {
+			isa = PBXGroup;
+			children = (
+				1595957823691D6F007DBE15 /* f9_memory_multi.c */,
+				1595957923691D6F007DBE15 /* f9_memory.c */,
+				1595957A23691D6F007DBE15 /* f9_init.c */,
+				1595957B23691D6F007DBE15 /* f9_process.c */,
+				1595957C23691D6F007DBE15 /* f9_done.c */,
+				1595957D23691D6F007DBE15 /* f9_file.c */,
+				1595957E23691D6F007DBE15 /* f9_test.c */,
+			);
+			path = f9;
+			sourceTree = "<group>";
+		};
+		1595957F23691D6F007DBE15 /* pelican */ = {
+			isa = PBXGroup;
+			children = (
+				1595958023691D6F007DBE15 /* pelican.c */,
+				1595958123691D6F007DBE15 /* pelican_memory.c */,
+				1595958223691D6F007DBE15 /* pelican_test.c */,
+			);
+			path = pelican;
+			sourceTree = "<group>";
+		};
+		1595958323691D6F007DBE15 /* omac */ = {
+			isa = PBXGroup;
+			children = (
+				1595958423691D6F007DBE15 /* omac_init.c */,
+				1595958523691D6F007DBE15 /* omac_file.c */,
+				1595958623691D6F007DBE15 /* omac_test.c */,
+				1595958723691D6F007DBE15 /* omac_process.c */,
+				1595958823691D6F007DBE15 /* omac_memory_multi.c */,
+				1595958923691D6F007DBE15 /* omac_memory.c */,
+				1595958A23691D6F007DBE15 /* omac_done.c */,
+			);
+			path = omac;
+			sourceTree = "<group>";
+		};
+		1595958B23691D6F007DBE15 /* headers */ = {
+			isa = PBXGroup;
+			children = (
+				1595958C23691D6F007DBE15 /* tomcrypt_pkcs.h */,
+				1595958D23691D6F007DBE15 /* tomcrypt_hash.h */,
+				1595958E23691D6F007DBE15 /* tomcrypt_private.h */,
+				1595958F23691D6F007DBE15 /* tomcrypt_macros.h */,
+				1595959023691D6F007DBE15 /* tomcrypt_math.h */,
+				1595959123691D6F007DBE15 /* tomcrypt_misc.h */,
+				1595959223691D6F007DBE15 /* tomcrypt.h */,
+				1595959323691D6F007DBE15 /* tomcrypt_cipher.h */,
+				1595959423691D6F007DBE15 /* tomcrypt_pk.h */,
+				1595959523691D6F007DBE15 /* tomcrypt_cfg.h */,
+				1595959623691D6F007DBE15 /* tomcrypt_mac.h */,
+				1595959723691D6F007DBE15 /* tomcrypt_prng.h */,
+				1595959823691D6F007DBE15 /* tomcrypt_custom.h */,
+				1595959923691D6F007DBE15 /* tomcrypt_argchk.h */,
+			);
+			path = headers;
+			sourceTree = "<group>";
+		};
+		1595959A23691D6F007DBE15 /* ciphers */ = {
+			isa = PBXGroup;
+			children = (
+				1595959B23691D6F007DBE15 /* noekeon.c */,
+				1595959C23691D6F007DBE15 /* camellia.c */,
+				1595959D23691D6F007DBE15 /* safer */,
+				159595A123691D6F007DBE15 /* tea.c */,
+				159595A223691D6F007DBE15 /* kseed.c */,
+				159595A323691D6F007DBE15 /* des.c */,
+				159595A423691D6F007DBE15 /* khazad.c */,
+				159595A523691D6F007DBE15 /* idea.c */,
+				159595A623691D6F007DBE15 /* blowfish.c */,
+				159595A723691D6F007DBE15 /* kasumi.c */,
+				159595A823691D6F007DBE15 /* anubis.c */,
+				159595A923691D6F007DBE15 /* rc2.c */,
+				159595AA23691D6F007DBE15 /* rc6.c */,
+				159595AB23691D6F007DBE15 /* skipjack.c */,
+				159595AC23691D6F007DBE15 /* cast5.c */,
+				159595AD23691D6F007DBE15 /* serpent.c */,
+				159595AE23691D6F007DBE15 /* xtea.c */,
+				159595AF23691D6F007DBE15 /* multi2.c */,
+				159595B023691D6F007DBE15 /* twofish */,
+				159595B323691D6F007DBE15 /* rc5.c */,
+				159595B423691D6F007DBE15 /* aes */,
+			);
+			path = ciphers;
+			sourceTree = "<group>";
+		};
+		1595959D23691D6F007DBE15 /* safer */ = {
+			isa = PBXGroup;
+			children = (
+				1595959E23691D6F007DBE15 /* safer.c */,
+				1595959F23691D6F007DBE15 /* saferp.c */,
+				159595A023691D6F007DBE15 /* safer_tab.c */,
+			);
+			path = safer;
+			sourceTree = "<group>";
+		};
+		159595B023691D6F007DBE15 /* twofish */ = {
+			isa = PBXGroup;
+			children = (
+				159595B123691D6F007DBE15 /* twofish.c */,
+				159595B223691D6F007DBE15 /* twofish_tab.c */,
+			);
+			path = twofish;
+			sourceTree = "<group>";
+		};
+		159595B423691D6F007DBE15 /* aes */ = {
+			isa = PBXGroup;
+			children = (
+				159595B523691D6F007DBE15 /* aes.c */,
+				159595B623691D6F007DBE15 /* aes_tab.c */,
+			);
+			path = aes;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		1595935823691B13007DBE15 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1595978D23691D70007DBE15 /* tomcrypt_cipher.h in Headers */,
+				1595978A23691D6F007DBE15 /* tomcrypt_math.h in Headers */,
+				1595978C23691D70007DBE15 /* tomcrypt.h in Headers */,
+				1595978F23691D70007DBE15 /* tomcrypt_cfg.h in Headers */,
+				1595978723691D6F007DBE15 /* tomcrypt_hash.h in Headers */,
+				1595979023691D70007DBE15 /* tomcrypt_mac.h in Headers */,
+				1595978E23691D70007DBE15 /* tomcrypt_pk.h in Headers */,
+				1595978923691D6F007DBE15 /* tomcrypt_macros.h in Headers */,
+				1595979323691D70007DBE15 /* tomcrypt_argchk.h in Headers */,
+				1595978623691D6F007DBE15 /* tomcrypt_pkcs.h in Headers */,
+				1595978B23691D70007DBE15 /* tomcrypt_misc.h in Headers */,
+				1595979123691D70007DBE15 /* tomcrypt_prng.h in Headers */,
+				1595979223691D70007DBE15 /* tomcrypt_custom.h in Headers */,
+				1595978823691D6F007DBE15 /* tomcrypt_private.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		1595935C23691B13007DBE15 /* TomCrypt */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1595936523691B13007DBE15 /* Build configuration list for PBXNativeTarget "TomCrypt" */;
+			buildPhases = (
+				1595935823691B13007DBE15 /* Headers */,
+				1595935923691B13007DBE15 /* Sources */,
+				1595935A23691B13007DBE15 /* Frameworks */,
+				1595935B23691B13007DBE15 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TomCrypt;
+			productName = TomCrypt;
+			productReference = 1595935D23691B13007DBE15 /* TomCrypt.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		1595935423691B13007DBE15 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1110;
+				ORGANIZATIONNAME = libtom;
+				TargetAttributes = {
+					1595935C23691B13007DBE15 = {
+						CreatedOnToolsVersion = 11.1;
+					};
+				};
+			};
+			buildConfigurationList = 1595935723691B13007DBE15 /* Build configuration list for PBXProject "TomCrypt" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 1595935323691B13007DBE15;
+			productRefGroup = 1595935E23691B13007DBE15 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				1595935C23691B13007DBE15 /* TomCrypt */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		1595935B23691B13007DBE15 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		1595935923691B13007DBE15 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				159595CA23691D6F007DBE15 /* crypt_register_all_ciphers.c in Sources */,
+				1595960C23691D6F007DBE15 /* der_encode_short_integer.c in Sources */,
+				1595972123691D6F007DBE15 /* ocb3_int_xor_blocks.c in Sources */,
+				1595962B23691D6F007DBE15 /* der_length_utctime.c in Sources */,
+				159596E623691D6F007DBE15 /* ecb_start.c in Sources */,
+				1595968C23691D6F007DBE15 /* pkcs_1_pss_decode.c in Sources */,
+				159595F923691D6F007DBE15 /* der_encode_bit_string.c in Sources */,
+				159595EC23691D6F007DBE15 /* padding_pad.c in Sources */,
+				1595967F23691D6F007DBE15 /* ltc_ecc_mulmod.c in Sources */,
+				1595968D23691D6F007DBE15 /* pkcs_1_pss_encode.c in Sources */,
+				1595964423691D6F007DBE15 /* rsa_sign_hash.c in Sources */,
+				1595963C23691D6F007DBE15 /* dh.c in Sources */,
+				1595971B23691D6F007DBE15 /* ocb_decrypt_verify_memory.c in Sources */,
+				1595961E23691D6F007DBE15 /* der_encode_set.c in Sources */,
+				159595BD23691D6F007DBE15 /* pbes2.c in Sources */,
+				1595975823691D6F007DBE15 /* hmac_memory.c in Sources */,
+				159595ED23691D6F007DBE15 /* padding_depad.c in Sources */,
+				1595976623691D6F007DBE15 /* blake2smac_memory_multi.c in Sources */,
+				1595962223691D6F007DBE15 /* der_decode_sequence_ex.c in Sources */,
+				1595962823691D6F007DBE15 /* der_length_printable_string.c in Sources */,
+				1595973223691D6F007DBE15 /* chacha_ivctr64.c in Sources */,
+				159596B323691D6F007DBE15 /* rmd160.c in Sources */,
+				1595965A23691D6F007DBE15 /* ec25519_export.c in Sources */,
+				1595974523691D6F007DBE15 /* sosemanuk_test.c in Sources */,
+				159597AA23691D70007DBE15 /* rc5.c in Sources */,
+				159597A423691D70007DBE15 /* cast5.c in Sources */,
+				1595974E23691D6F007DBE15 /* rand_prime.c in Sources */,
+				1595969D23691D6F007DBE15 /* sha512_256.c in Sources */,
+				1595964A23691D6F007DBE15 /* rsa_key.c in Sources */,
+				1595973923691D6F007DBE15 /* xsalsa20_memory.c in Sources */,
+				1595977A23691D6F007DBE15 /* f9_file.c in Sources */,
+				159596C923691D6F007DBE15 /* cbc_decrypt.c in Sources */,
+				1595966023691D6F007DBE15 /* ed25519_import_x509.c in Sources */,
+				1595963523691D6F007DBE15 /* dh_set.c in Sources */,
+				1595968923691D6F007DBE15 /* ltc_ecc_verify_key.c in Sources */,
+				1595976323691D6F007DBE15 /* blake2smac.c in Sources */,
+				1595972623691D6F007DBE15 /* ocb3_encrypt.c in Sources */,
+				159596D523691D6F007DBE15 /* lrw_decrypt.c in Sources */,
+				1595962D23691D6F007DBE15 /* x509_encode_subject_public_key_info.c in Sources */,
+				159596A123691D6F007DBE15 /* sha384.c in Sources */,
+				1595972723691D6F007DBE15 /* ocb3_decrypt_last.c in Sources */,
+				159597AC23691D70007DBE15 /* aes_tab.c in Sources */,
+				1595964523691D6F007DBE15 /* rsa_set.c in Sources */,
+				159597A523691D70007DBE15 /* serpent.c in Sources */,
+				159596DC23691D6F007DBE15 /* f8_setiv.c in Sources */,
+				1595963B23691D6F007DBE15 /* dh_generate_key.c in Sources */,
+				159595C723691D6F007DBE15 /* crypt_cipher_is_valid.c in Sources */,
+				159595D023691D6F007DBE15 /* crypt_register_all_hashes.c in Sources */,
+				1595965023691D6F007DBE15 /* dsa_shared_secret.c in Sources */,
+				159596C423691D6F007DBE15 /* ofb_done.c in Sources */,
+				1595962F23691D6F007DBE15 /* x509_decode_subject_public_key_info.c in Sources */,
+				1595972523691D6F007DBE15 /* ocb3_decrypt_verify_memory.c in Sources */,
+				1595972E23691D6F007DBE15 /* chacha_crypt.c in Sources */,
+				1595975F23691D6F007DBE15 /* blake2bmac_file.c in Sources */,
+				159596A823691D6F007DBE15 /* rmd256.c in Sources */,
+				159596F023691D6F007DBE15 /* eax_decrypt_verify_memory.c in Sources */,
+				159595E523691D6F007DBE15 /* burn_stack.c in Sources */,
+				159596F923691D6F007DBE15 /* gcm_memory.c in Sources */,
+				1595969B23691D6F007DBE15 /* md4.c in Sources */,
+				1595972F23691D6F007DBE15 /* chacha_keystream.c in Sources */,
+				1595973423691D6F007DBE15 /* sober128_stream_memory.c in Sources */,
+				159596BE23691D6F007DBE15 /* ctr_decrypt.c in Sources */,
+				1595965723691D6F007DBE15 /* dsa_generate_key.c in Sources */,
+				1595963123691D6F007DBE15 /* pk_oid_str.c in Sources */,
+				159596C123691D6F007DBE15 /* ctr_done.c in Sources */,
+				1595967E23691D6F007DBE15 /* ltc_ecc_points.c in Sources */,
+				159596B123691D6F007DBE15 /* hash_filehandle.c in Sources */,
+				159596B023691D6F007DBE15 /* hash_file.c in Sources */,
+				1595975D23691D6F007DBE15 /* hmac_memory_multi.c in Sources */,
+				1595965B23691D6F007DBE15 /* ec25519_import_pkcs8.c in Sources */,
+				159596F323691D6F007DBE15 /* eax_addheader.c in Sources */,
+				1595968823691D6F007DBE15 /* ecc_set_curve_internal.c in Sources */,
+				1595972C23691D6F007DBE15 /* chacha_ivctr32.c in Sources */,
+				159597A223691D70007DBE15 /* rc6.c in Sources */,
+				159596FB23691D6F007DBE15 /* gcm_done.c in Sources */,
+				159595C523691D6F007DBE15 /* crypt_prng_is_valid.c in Sources */,
+				159596D223691D6F007DBE15 /* lrw_done.c in Sources */,
+				1595968F23691D6F007DBE15 /* pkcs_1_oaep_decode.c in Sources */,
+				1595979423691D70007DBE15 /* noekeon.c in Sources */,
+				1595969E23691D6F007DBE15 /* sha224.c in Sources */,
+				159595DE23691D6F007DBE15 /* bcrypt.c in Sources */,
+				159596E223691D6F007DBE15 /* cfb_decrypt.c in Sources */,
+				1595972323691D6F007DBE15 /* ocb3_done.c in Sources */,
+				1595969823691D6F007DBE15 /* x25519_import.c in Sources */,
+				1595970223691D6F007DBE15 /* ccm_add_aad.c in Sources */,
+				159596EB23691D6F007DBE15 /* rng_make_prng.c in Sources */,
+				1595973123691D6F007DBE15 /* chacha_done.c in Sources */,
+				1595973523691D6F007DBE15 /* sober128tab.c in Sources */,
+				1595964923691D6F007DBE15 /* rsa_sign_saltlen_get.c in Sources */,
+				1595962C23691D6F007DBE15 /* der_decode_utctime.c in Sources */,
+				1595975723691D6F007DBE15 /* pmac_process.c in Sources */,
+				159596BC23691D6F007DBE15 /* ctr_setiv.c in Sources */,
+				1595967523691D6F007DBE15 /* ecc_find_curve.c in Sources */,
+				159595D623691D6F007DBE15 /* crypt_hash_is_valid.c in Sources */,
+				1595963F23691D6F007DBE15 /* rsa_import_pkcs8.c in Sources */,
+				1595962323691D6F007DBE15 /* der_decode_sequence_multi.c in Sources */,
+				1595975E23691D6F007DBE15 /* hmac_process.c in Sources */,
+				1595974F23691D6F007DBE15 /* pmac_init.c in Sources */,
+				159596A523691D6F007DBE15 /* rmd128.c in Sources */,
+				1595962023691D6F007DBE15 /* der_sequence_shrink.c in Sources */,
+				1595968723691D6F007DBE15 /* ecc_encrypt_key.c in Sources */,
+				1595975623691D6F007DBE15 /* pmac_memory.c in Sources */,
+				159595D423691D6F007DBE15 /* crypt_find_cipher_id.c in Sources */,
+				159596A023691D6F007DBE15 /* sha512.c in Sources */,
+				159597A023691D70007DBE15 /* anubis.c in Sources */,
+				1595966523691D6F007DBE15 /* ecc_import_x509.c in Sources */,
+				1595974923691D6F007DBE15 /* rand_bn.c in Sources */,
+				1595960523691D6F007DBE15 /* der_length_asn1_length.c in Sources */,
+				1595960F23691D6F007DBE15 /* der_length_ia5_string.c in Sources */,
+				1595969F23691D6F007DBE15 /* sha256.c in Sources */,
+				1595971F23691D6F007DBE15 /* ocb3_add_aad.c in Sources */,
+				1595974123691D6F007DBE15 /* xsalsa20_setup.c in Sources */,
+				159596BB23691D6F007DBE15 /* ctr_encrypt.c in Sources */,
+				1595968423691D6F007DBE15 /* ecc_ansi_x963_export.c in Sources */,
+				1595960123691D6F007DBE15 /* der_encode_asn1_identifier.c in Sources */,
+				159596A623691D6F007DBE15 /* sha3_test.c in Sources */,
+				1595964823691D6F007DBE15 /* rsa_export.c in Sources */,
+				1595967423691D6F007DBE15 /* ecc_free.c in Sources */,
+				1595960923691D6F007DBE15 /* der_encode_generalizedtime.c in Sources */,
+				1595976523691D6F007DBE15 /* blake2smac_file.c in Sources */,
+				1595970F23691D6F007DBE15 /* chacha20poly1305_setiv.c in Sources */,
+				1595974223691D6F007DBE15 /* rabbit_memory.c in Sources */,
+				1595969023691D6F007DBE15 /* pkcs_1_v1_5_decode.c in Sources */,
+				159596D823691D6F007DBE15 /* f8_getiv.c in Sources */,
+				1595961D23691D6F007DBE15 /* der_encode_setof.c in Sources */,
+				1595977923691D6F007DBE15 /* f9_done.c in Sources */,
+				159596D423691D6F007DBE15 /* lrw_getiv.c in Sources */,
+				1595967323691D6F007DBE15 /* ecc_import_openssl.c in Sources */,
+				159595E323691D6F007DBE15 /* pkcs_5_test.c in Sources */,
+				159595FE23691D6F007DBE15 /* der_encode_utf8_string.c in Sources */,
+				1595965F23691D6F007DBE15 /* ed25519_import_raw.c in Sources */,
+				159595DC23691D6F007DBE15 /* crypt_fsa.c in Sources */,
+				1595966323691D6F007DBE15 /* ed25519_verify.c in Sources */,
+				1595961923691D6F007DBE15 /* der_encode_integer.c in Sources */,
+				159596AF23691D6F007DBE15 /* hash_memory_multi.c in Sources */,
+				1595974323691D6F007DBE15 /* rabbit.c in Sources */,
+				159596FA23691D6F007DBE15 /* gcm_reset.c in Sources */,
+				1595968123691D6F007DBE15 /* ltc_ecc_is_point_at_infinity.c in Sources */,
+				1595970623691D6F007DBE15 /* ccm_reset.c in Sources */,
+				1595973723691D6F007DBE15 /* sober128_stream.c in Sources */,
+				159595F523691D6F007DBE15 /* der_length_octet_string.c in Sources */,
+				1595964F23691D6F007DBE15 /* dsa_sign_hash.c in Sources */,
+				1595964623691D6F007DBE15 /* rsa_import_x509.c in Sources */,
+				159596E923691D6F007DBE15 /* rng_get_bytes.c in Sources */,
+				159595FB23691D6F007DBE15 /* der_encode_object_identifier.c in Sources */,
+				159596CE23691D6F007DBE15 /* lrw_encrypt.c in Sources */,
+				1595961223691D6F007DBE15 /* der_decode_teletex_string.c in Sources */,
+				1595964E23691D6F007DBE15 /* dsa_set.c in Sources */,
+				1595971D23691D6F007DBE15 /* ocb3_int_ntz.c in Sources */,
+				1595969A23691D6F007DBE15 /* x25519_import_x509.c in Sources */,
+				1595968623691D6F007DBE15 /* ecc_sign_hash.c in Sources */,
+				159596E823691D6F007DBE15 /* rc4.c in Sources */,
+				1595973E23691D6F007DBE15 /* salsa20_crypt.c in Sources */,
+				1595977E23691D6F007DBE15 /* pelican_test.c in Sources */,
+				1595963023691D6F007DBE15 /* pk_get_oid.c in Sources */,
+				1595972023691D6F007DBE15 /* ocb3_encrypt_last.c in Sources */,
+				159595BE23691D6F007DBE15 /* pbes.c in Sources */,
+				1595961723691D6F007DBE15 /* der_length_integer.c in Sources */,
+				159595DD23691D6F007DBE15 /* crypt_unregister_hash.c in Sources */,
+				1595967A23691D6F007DBE15 /* ecc_shared_secret.c in Sources */,
+				1595970423691D6F007DBE15 /* ccm_add_nonce.c in Sources */,
+				1595970523691D6F007DBE15 /* ccm_process.c in Sources */,
+				159595D323691D6F007DBE15 /* crypt_ltc_mp_descriptor.c in Sources */,
+				1595975B23691D6F007DBE15 /* hmac_test.c in Sources */,
+				1595963423691D6F007DBE15 /* dh_import.c in Sources */,
+				1595970123691D6F007DBE15 /* ccm_done.c in Sources */,
+				159596FE23691D6F007DBE15 /* gcm_add_iv.c in Sources */,
+				1595965523691D6F007DBE15 /* dsa_export.c in Sources */,
+				1595963623691D6F007DBE15 /* dh_shared_secret.c in Sources */,
+				159596FD23691D6F007DBE15 /* gcm_mult_h.c in Sources */,
+				1595967623691D6F007DBE15 /* ecc_import.c in Sources */,
+				159596A423691D6F007DBE15 /* sha1.c in Sources */,
+				159595C923691D6F007DBE15 /* crypt_hash_descriptor.c in Sources */,
+				1595966F23691D6F007DBE15 /* ecc_set_key.c in Sources */,
+				1595967223691D6F007DBE15 /* ecc_export.c in Sources */,
+				1595962A23691D6F007DBE15 /* der_encode_utctime.c in Sources */,
+				159596F823691D6F007DBE15 /* gcm_process.c in Sources */,
+				1595970923691D6F007DBE15 /* chacha20poly1305_test.c in Sources */,
+				159595F323691D6F007DBE15 /* der_decode_octet_string.c in Sources */,
+				1595974D23691D6F007DBE15 /* gmp_desc.c in Sources */,
+				1595979F23691D70007DBE15 /* kasumi.c in Sources */,
+				159595EA23691D6F007DBE15 /* base16_encode.c in Sources */,
+				1595966123691D6F007DBE15 /* ed25519_sign.c in Sources */,
+				1595973F23691D6F007DBE15 /* xsalsa20_test.c in Sources */,
+				1595973823691D6F007DBE15 /* salsa20_setup.c in Sources */,
+				159595EB23691D6F007DBE15 /* base16_decode.c in Sources */,
+				1595966B23691D6F007DBE15 /* ecc_ansi_x963_import.c in Sources */,
+				159596C223691D6F007DBE15 /* ofb_getiv.c in Sources */,
+				1595961C23691D6F007DBE15 /* der_length_custom_type.c in Sources */,
+				159596CC23691D6F007DBE15 /* cbc_start.c in Sources */,
+				159597A323691D70007DBE15 /* skipjack.c in Sources */,
+				1595969323691D6F007DBE15 /* pkcs_1_i2osp.c in Sources */,
+				1595960E23691D6F007DBE15 /* der_decode_choice.c in Sources */,
+				1595976823691D6F007DBE15 /* blake2bmac.c in Sources */,
+				1595969523691D6F007DBE15 /* x25519_import_pkcs8.c in Sources */,
+				1595968323691D6F007DBE15 /* ltc_ecc_mulmod_timing.c in Sources */,
+				1595979C23691D70007DBE15 /* khazad.c in Sources */,
+				159596A323691D6F007DBE15 /* whirl.c in Sources */,
+				1595976D23691D6F007DBE15 /* poly1305_memory_multi.c in Sources */,
+				1595960223691D6F007DBE15 /* der_length_asn1_identifier.c in Sources */,
+				1595979D23691D70007DBE15 /* idea.c in Sources */,
+				159597A123691D70007DBE15 /* rc2.c in Sources */,
+				1595971E23691D6F007DBE15 /* ocb3_encrypt_authenticate_memory.c in Sources */,
+				1595976023691D6F007DBE15 /* blake2smac_memory.c in Sources */,
+				159596BD23691D6F007DBE15 /* ctr_start.c in Sources */,
+				159595E823691D6F007DBE15 /* ssh_decode_sequence_multi.c in Sources */,
+				1595968A23691D6F007DBE15 /* ltc_ecc_export_point.c in Sources */,
+				1595977F23691D6F007DBE15 /* omac_init.c in Sources */,
+				1595972A23691D6F007DBE15 /* rc4_test.c in Sources */,
+				1595967023691D6F007DBE15 /* ecc.c in Sources */,
+				1595971723691D6F007DBE15 /* s_ocb_done.c in Sources */,
+				1595977023691D6F007DBE15 /* xcbc_process.c in Sources */,
+				1595968023691D6F007DBE15 /* ecc_verify_hash.c in Sources */,
+				159595CC23691D6F007DBE15 /* crypt_register_cipher.c in Sources */,
+				1595962523691D6F007DBE15 /* der_encode_sequence_multi.c in Sources */,
+				1595960823691D6F007DBE15 /* der_decode_generalizedtime.c in Sources */,
+				1595975423691D6F007DBE15 /* pmac_test.c in Sources */,
+				1595972D23691D6F007DBE15 /* chacha_memory.c in Sources */,
+				159595C823691D6F007DBE15 /* crypt_find_hash_oid.c in Sources */,
+				159595F623691D6F007DBE15 /* der_length_bit_string.c in Sources */,
+				159596D623691D6F007DBE15 /* f8_start.c in Sources */,
+				159595BB23691D6F007DBE15 /* pkcs12_kdf.c in Sources */,
+				1595961A23691D6F007DBE15 /* der_encode_custom_type.c in Sources */,
+				1595962723691D6F007DBE15 /* der_encode_printable_string.c in Sources */,
+				1595969923691D6F007DBE15 /* x25519_import_raw.c in Sources */,
+				1595962123691D6F007DBE15 /* der_length_sequence.c in Sources */,
+				1595963223691D6F007DBE15 /* pk_oid_cmp.c in Sources */,
+				1595961F23691D6F007DBE15 /* der_encode_sequence_ex.c in Sources */,
+				1595976B23691D6F007DBE15 /* poly1305_file.c in Sources */,
+				1595965D23691D6F007DBE15 /* ed25519_export.c in Sources */,
+				159596A223691D6F007DBE15 /* whirltab.c in Sources */,
+				1595965423691D6F007DBE15 /* dsa_set_pqg_dsaparam.c in Sources */,
+				159595E423691D6F007DBE15 /* crc32.c in Sources */,
+				1595978223691D6F007DBE15 /* omac_process.c in Sources */,
+				159595E023691D6F007DBE15 /* base64_encode.c in Sources */,
+				1595971A23691D6F007DBE15 /* ocb_done_decrypt.c in Sources */,
+				1595966D23691D6F007DBE15 /* ecc_get_size.c in Sources */,
+				1595974423691D6F007DBE15 /* sosemanuk_memory.c in Sources */,
+				1595961423691D6F007DBE15 /* der_decode_boolean.c in Sources */,
+				159596BF23691D6F007DBE15 /* ctr_getiv.c in Sources */,
+				1595960D23691D6F007DBE15 /* der_decode_short_integer.c in Sources */,
+				159596F723691D6F007DBE15 /* gcm_init.c in Sources */,
+				159595BA23691D6F007DBE15 /* pkcs12_utf8_to_utf16.c in Sources */,
+				1595964B23691D6F007DBE15 /* rsa_get_size.c in Sources */,
+				1595970D23691D6F007DBE15 /* chacha20poly1305_decrypt.c in Sources */,
+				1595977323691D6F007DBE15 /* xcbc_memory_multi.c in Sources */,
+				1595965323691D6F007DBE15 /* dsa_decrypt_key.c in Sources */,
+				159596AC23691D6F007DBE15 /* tiger.c in Sources */,
+				1595966C23691D6F007DBE15 /* ltc_ecc_map.c in Sources */,
+				1595963D23691D6F007DBE15 /* dh_export.c in Sources */,
+				1595971223691D6F007DBE15 /* ocb_ntz.c in Sources */,
+				1595975923691D6F007DBE15 /* hmac_init.c in Sources */,
+				159595B823691D6F007DBE15 /* error_to_string.c in Sources */,
+				1595961623691D6F007DBE15 /* der_encode_boolean.c in Sources */,
+				159596C823691D6F007DBE15 /* cbc_setiv.c in Sources */,
+				1595960323691D6F007DBE15 /* der_encode_asn1_length.c in Sources */,
+				159595D123691D6F007DBE15 /* crypt_find_cipher.c in Sources */,
+				159595CD23691D6F007DBE15 /* crypt_find_hash.c in Sources */,
+				1595976423691D6F007DBE15 /* blake2smac_test.c in Sources */,
+				1595975323691D6F007DBE15 /* pmac_file.c in Sources */,
+				159596D723691D6F007DBE15 /* f8_decrypt.c in Sources */,
+				159596D123691D6F007DBE15 /* lrw_setiv.c in Sources */,
+				1595969623691D6F007DBE15 /* x25519_export.c in Sources */,
+				159595E623691D6F007DBE15 /* hkdf_test.c in Sources */,
+				159597A823691D70007DBE15 /* twofish.c in Sources */,
+				1595971623691D6F007DBE15 /* ocb_encrypt_authenticate_memory.c in Sources */,
+				1595976123691D6F007DBE15 /* blake2bmac_test.c in Sources */,
+				1595971C23691D6F007DBE15 /* ocb_decrypt.c in Sources */,
+				159596E423691D6F007DBE15 /* ecb_done.c in Sources */,
+				159596DA23691D6F007DBE15 /* f8_test_mode.c in Sources */,
+				159596FC23691D6F007DBE15 /* gcm_test.c in Sources */,
+				1595970823691D6F007DBE15 /* ccm_init.c in Sources */,
+				1595973A23691D6F007DBE15 /* salsa20_done.c in Sources */,
+				159597AB23691D70007DBE15 /* aes.c in Sources */,
+				159595FC23691D6F007DBE15 /* der_decode_object_identifier.c in Sources */,
+				1595977823691D6F007DBE15 /* f9_process.c in Sources */,
+				1595960023691D6F007DBE15 /* der_length_utf8_string.c in Sources */,
+				1595976223691D6F007DBE15 /* blake2bmac_memory_multi.c in Sources */,
+				1595973023691D6F007DBE15 /* chacha_test.c in Sources */,
+				1595960623691D6F007DBE15 /* der_decode_asn1_length.c in Sources */,
+				1595976F23691D6F007DBE15 /* xcbc_memory.c in Sources */,
+				159596EF23691D6F007DBE15 /* eax_decrypt.c in Sources */,
+				159596B523691D6F007DBE15 /* xts_init.c in Sources */,
+				159595E723691D6F007DBE15 /* hkdf.c in Sources */,
+				159596C023691D6F007DBE15 /* ctr_test.c in Sources */,
+				1595964023691D6F007DBE15 /* rsa_exptmod.c in Sources */,
+				1595961823691D6F007DBE15 /* der_decode_integer.c in Sources */,
+				159596E323691D6F007DBE15 /* ecb_encrypt.c in Sources */,
+				1595972823691D6F007DBE15 /* ocb3_init.c in Sources */,
+				1595976A23691D6F007DBE15 /* poly1305_test.c in Sources */,
+				1595966623691D6F007DBE15 /* ecc_set_curve.c in Sources */,
+				159596C523691D6F007DBE15 /* ofb_start.c in Sources */,
+				1595975A23691D6F007DBE15 /* hmac_done.c in Sources */,
+				159596BA23691D6F007DBE15 /* xts_test.c in Sources */,
+				1595974C23691D6F007DBE15 /* ltm_desc.c in Sources */,
+				159596F223691D6F007DBE15 /* eax_encrypt_authenticate_memory.c in Sources */,
+				1595963A23691D6F007DBE15 /* dh_free.c in Sources */,
+				1595965223691D6F007DBE15 /* dsa_import.c in Sources */,
+				159595D223691D6F007DBE15 /* crypt_find_hash_id.c in Sources */,
+				159595F823691D6F007DBE15 /* der_decode_raw_bit_string.c in Sources */,
+				1595972223691D6F007DBE15 /* ocb3_decrypt.c in Sources */,
+				1595962923691D6F007DBE15 /* der_decode_printable_string.c in Sources */,
+				159595BF23691D6F007DBE15 /* crypt_unregister_prng.c in Sources */,
+				1595970E23691D6F007DBE15 /* chacha20poly1305_encrypt.c in Sources */,
+				1595963E23691D6F007DBE15 /* rsa_verify_hash.c in Sources */,
+				1595963323691D6F007DBE15 /* pkcs8_decode_flexi.c in Sources */,
+				1595974823691D6F007DBE15 /* tfm_desc.c in Sources */,
+				1595965923691D6F007DBE15 /* dsa_encrypt_key.c in Sources */,
+				1595960A23691D6F007DBE15 /* der_length_generalizedtime.c in Sources */,
+				1595970023691D6F007DBE15 /* gcm_gf_mult.c in Sources */,
+				159596AB23691D6F007DBE15 /* md5.c in Sources */,
+				1595977423691D6F007DBE15 /* xcbc_done.c in Sources */,
+				159596CB23691D6F007DBE15 /* cbc_getiv.c in Sources */,
+				159597A723691D70007DBE15 /* multi2.c in Sources */,
+				159596F123691D6F007DBE15 /* eax_init.c in Sources */,
+				159596E123691D6F007DBE15 /* cfb_setiv.c in Sources */,
+				159596B223691D6F007DBE15 /* hash_memory.c in Sources */,
+				1595979723691D70007DBE15 /* saferp.c in Sources */,
+				159596C323691D6F007DBE15 /* ofb_encrypt.c in Sources */,
+				1595966E23691D6F007DBE15 /* ecc_import_pkcs8.c in Sources */,
+				1595979623691D70007DBE15 /* safer.c in Sources */,
+				159595BC23691D6F007DBE15 /* pbes1.c in Sources */,
+				1595965E23691D6F007DBE15 /* ed25519_import_pkcs8.c in Sources */,
+				159596B423691D6F007DBE15 /* rmd320.c in Sources */,
+				1595974A23691D6F007DBE15 /* ltc_ecc_fp_mulmod.c in Sources */,
+				1595975C23691D6F007DBE15 /* hmac_file.c in Sources */,
+				1595979A23691D70007DBE15 /* kseed.c in Sources */,
+				1595972423691D6F007DBE15 /* ocb3_test.c in Sources */,
+				1595977D23691D6F007DBE15 /* pelican_memory.c in Sources */,
+				1595974B23691D6F007DBE15 /* multi.c in Sources */,
+				159595CE23691D6F007DBE15 /* crypt_inits.c in Sources */,
+				1595968E23691D6F007DBE15 /* pkcs_1_mgf1.c in Sources */,
+				1595978023691D6F007DBE15 /* omac_file.c in Sources */,
+				1595977623691D6F007DBE15 /* f9_memory.c in Sources */,
+				1595964323691D6F007DBE15 /* rsa_import.c in Sources */,
+				1595961523691D6F007DBE15 /* der_length_boolean.c in Sources */,
+				159595E223691D6F007DBE15 /* pkcs_5_2.c in Sources */,
+				159595C623691D6F007DBE15 /* crypt_prng_rng_descriptor.c in Sources */,
+				1595979B23691D70007DBE15 /* des.c in Sources */,
+				1595967823691D6F007DBE15 /* ecc_decrypt_key.c in Sources */,
+				1595969C23691D6F007DBE15 /* sha512_224.c in Sources */,
+				159596D923691D6F007DBE15 /* f8_done.c in Sources */,
+				1595972923691D6F007DBE15 /* rc4_stream.c in Sources */,
+				1595961123691D6F007DBE15 /* der_decode_ia5_string.c in Sources */,
+				1595968523691D6F007DBE15 /* ecc_ssh_ecdsa_encode_name.c in Sources */,
+				1595974023691D6F007DBE15 /* salsa20_ivctr64.c in Sources */,
+				1595977B23691D6F007DBE15 /* f9_test.c in Sources */,
+				159596B823691D6F007DBE15 /* xts_encrypt.c in Sources */,
+				1595971123691D6F007DBE15 /* chacha20poly1305_memory.c in Sources */,
+				1595965C23691D6F007DBE15 /* tweetnacl.c in Sources */,
+				1595965623691D6F007DBE15 /* dsa_verify_hash.c in Sources */,
+				1595960B23691D6F007DBE15 /* der_length_short_integer.c in Sources */,
+				159595DB23691D6F007DBE15 /* crypt_register_all_prngs.c in Sources */,
+				1595976923691D6F007DBE15 /* poly1305_memory.c in Sources */,
+				1595961B23691D6F007DBE15 /* der_decode_custom_type.c in Sources */,
+				1595973D23691D6F007DBE15 /* salsa20_keystream.c in Sources */,
+				1595966823691D6F007DBE15 /* ecc_export_openssl.c in Sources */,
+				1595969123691D6F007DBE15 /* pkcs_1_v1_5_encode.c in Sources */,
+				1595976C23691D6F007DBE15 /* poly1305.c in Sources */,
+				1595975123691D6F007DBE15 /* pmac_ntz.c in Sources */,
+				1595961023691D6F007DBE15 /* der_encode_ia5_string.c in Sources */,
+				159595DA23691D6F007DBE15 /* crypt_find_hash_any.c in Sources */,
+				1595971023691D6F007DBE15 /* chacha20poly1305_init.c in Sources */,
+				159596D323691D6F007DBE15 /* lrw_start.c in Sources */,
+				1595975223691D6F007DBE15 /* pmac_done.c in Sources */,
+				1595960423691D6F007DBE15 /* der_decode_asn1_identifier.c in Sources */,
+				1595977223691D6F007DBE15 /* xcbc_test.c in Sources */,
+				159595F123691D6F007DBE15 /* mem_neq.c in Sources */,
+				1595964123691D6F007DBE15 /* rsa_decrypt_key.c in Sources */,
+				1595979E23691D70007DBE15 /* blowfish.c in Sources */,
+				159595CB23691D6F007DBE15 /* crypt_register_prng.c in Sources */,
+				1595968B23691D6F007DBE15 /* pkcs_1_os2ip.c in Sources */,
+				159596CA23691D6F007DBE15 /* cbc_done.c in Sources */,
+				1595975523691D6F007DBE15 /* pmac_memory_multi.c in Sources */,
+				1595978123691D6F007DBE15 /* omac_test.c in Sources */,
+				159595F423691D6F007DBE15 /* der_encode_octet_string.c in Sources */,
+				159596AA23691D6F007DBE15 /* blake2b.c in Sources */,
+				159596ED23691D6F007DBE15 /* sprng.c in Sources */,
+				159597A923691D70007DBE15 /* twofish_tab.c in Sources */,
+				1595970B23691D6F007DBE15 /* chacha20poly1305_add_aad.c in Sources */,
+				1595964223691D6F007DBE15 /* rsa_encrypt_key.c in Sources */,
+				1595964723691D6F007DBE15 /* rsa_make_key.c in Sources */,
+				1595973323691D6F007DBE15 /* chacha_setup.c in Sources */,
+				1595971323691D6F007DBE15 /* ocb_encrypt.c in Sources */,
+				1595979523691D70007DBE15 /* camellia.c in Sources */,
+				159595D923691D6F007DBE15 /* crypt_sizes.c in Sources */,
+				1595965823691D6F007DBE15 /* dsa_free.c in Sources */,
+				159595E123691D6F007DBE15 /* pkcs_5_1.c in Sources */,
+				1595976723691D6F007DBE15 /* blake2bmac_memory.c in Sources */,
+				159595F723691D6F007DBE15 /* der_encode_raw_bit_string.c in Sources */,
+				159595C323691D6F007DBE15 /* crypt_prng_descriptor.c in Sources */,
+				159596B923691D6F007DBE15 /* xts_done.c in Sources */,
+				1595971423691D6F007DBE15 /* ocb_shift_xor.c in Sources */,
+				159596DF23691D6F007DBE15 /* cfb_start.c in Sources */,
+				1595978523691D6F007DBE15 /* omac_done.c in Sources */,
+				159596DE23691D6F007DBE15 /* cfb_encrypt.c in Sources */,
+				159596CD23691D6F007DBE15 /* cbc_encrypt.c in Sources */,
+				1595964C23691D6F007DBE15 /* dsa_make_key.c in Sources */,
+				1595969423691D6F007DBE15 /* x25519_make_key.c in Sources */,
+				1595978423691D6F007DBE15 /* omac_memory.c in Sources */,
+				1595977123691D6F007DBE15 /* xcbc_file.c in Sources */,
+				1595972B23691D6F007DBE15 /* rc4_stream_memory.c in Sources */,
+				159596C723691D6F007DBE15 /* ofb_decrypt.c in Sources */,
+				1595973B23691D6F007DBE15 /* salsa20_test.c in Sources */,
+				159596EC23691D6F007DBE15 /* sober128.c in Sources */,
+				159595F023691D6F007DBE15 /* zeromem.c in Sources */,
+				159595C223691D6F007DBE15 /* crypt_find_cipher_any.c in Sources */,
+				159596F423691D6F007DBE15 /* eax_encrypt.c in Sources */,
+				159595C023691D6F007DBE15 /* crypt_unregister_cipher.c in Sources */,
+				1595979823691D70007DBE15 /* safer_tab.c in Sources */,
+				1595963923691D6F007DBE15 /* dh_check_pubkey.c in Sources */,
+				159595FA23691D6F007DBE15 /* der_decode_bit_string.c in Sources */,
+				159596AE23691D6F007DBE15 /* sha3.c in Sources */,
+				1595966223691D6F007DBE15 /* ed25519_make_key.c in Sources */,
+				159596DB23691D6F007DBE15 /* f8_encrypt.c in Sources */,
+				1595977723691D6F007DBE15 /* f9_init.c in Sources */,
+				159596EE23691D6F007DBE15 /* yarrow.c in Sources */,
+				159595CF23691D6F007DBE15 /* crypt_cipher_descriptor.c in Sources */,
+				159595FD23691D6F007DBE15 /* der_length_object_identifier.c in Sources */,
+				1595978323691D6F007DBE15 /* omac_memory_multi.c in Sources */,
+				1595967123691D6F007DBE15 /* ecc_get_key.c in Sources */,
+				159596DD23691D6F007DBE15 /* cfb_done.c in Sources */,
+				1595975023691D6F007DBE15 /* pmac_shift_xor.c in Sources */,
+				1595969223691D6F007DBE15 /* pkcs_1_oaep_encode.c in Sources */,
+				159595EF23691D6F007DBE15 /* base32_encode.c in Sources */,
+				159595B923691D6F007DBE15 /* copy_or_zeromem.c in Sources */,
+				159595D823691D6F007DBE15 /* crypt_argchk.c in Sources */,
+				1595962423691D6F007DBE15 /* der_decode_sequence_flexi.c in Sources */,
+				159596C623691D6F007DBE15 /* ofb_setiv.c in Sources */,
+				159595D523691D6F007DBE15 /* crypt_register_hash.c in Sources */,
+				159596EA23691D6F007DBE15 /* fortuna.c in Sources */,
+				159595C123691D6F007DBE15 /* crypt.c in Sources */,
+				159595C423691D6F007DBE15 /* crypt_constants.c in Sources */,
+				159595EE23691D6F007DBE15 /* base32_decode.c in Sources */,
+				159596E523691D6F007DBE15 /* ecb_decrypt.c in Sources */,
+				1595967C23691D6F007DBE15 /* ecc_sizes.c in Sources */,
+				1595971523691D6F007DBE15 /* ocb_init.c in Sources */,
+				159596CF23691D6F007DBE15 /* lrw_test.c in Sources */,
+				1595967D23691D6F007DBE15 /* ltc_ecc_mul2add.c in Sources */,
+				1595965123691D6F007DBE15 /* dsa_generate_pqg.c in Sources */,
+				1595970A23691D6F007DBE15 /* chacha20poly1305_done.c in Sources */,
+				1595967723691D6F007DBE15 /* ecc_get_oid_str.c in Sources */,
+				1595971923691D6F007DBE15 /* ocb_test.c in Sources */,
+				1595963723691D6F007DBE15 /* dh_export_key.c in Sources */,
+				1595977C23691D6F007DBE15 /* pelican.c in Sources */,
+				1595969723691D6F007DBE15 /* x25519_shared_secret.c in Sources */,
+				1595971823691D6F007DBE15 /* ocb_done_encrypt.c in Sources */,
+				1595962E23691D6F007DBE15 /* x509_decode_public_key_from_certificate.c in Sources */,
+				1595966723691D6F007DBE15 /* ecc_recover_key.c in Sources */,
+				159596E723691D6F007DBE15 /* chacha20.c in Sources */,
+				159595FF23691D6F007DBE15 /* der_decode_utf8_string.c in Sources */,
+				159597A623691D70007DBE15 /* xtea.c in Sources */,
+				1595973C23691D6F007DBE15 /* salsa20_memory.c in Sources */,
+				1595964D23691D6F007DBE15 /* dsa_verify_key.c in Sources */,
+				1595974623691D6F007DBE15 /* sosemanuk.c in Sources */,
+				1595970323691D6F007DBE15 /* ccm_test.c in Sources */,
+				1595966423691D6F007DBE15 /* ed25519_import.c in Sources */,
+				1595966923691D6F007DBE15 /* ltc_ecc_projective_add_point.c in Sources */,
+				1595962623691D6F007DBE15 /* der_sequence_free.c in Sources */,
+				1595966A23691D6F007DBE15 /* ecc_make_key.c in Sources */,
+				159596B723691D6F007DBE15 /* xts_decrypt.c in Sources */,
+				159595D723691D6F007DBE15 /* crypt_find_prng.c in Sources */,
+				159596A923691D6F007DBE15 /* md2.c in Sources */,
+				159596A723691D6F007DBE15 /* chc.c in Sources */,
+				159596B623691D6F007DBE15 /* xts_mult_x.c in Sources */,
+				1595970C23691D6F007DBE15 /* chacha20poly1305_setiv_rfc7905.c in Sources */,
+				159596FF23691D6F007DBE15 /* gcm_add_aad.c in Sources */,
+				1595979923691D70007DBE15 /* tea.c in Sources */,
+				1595967B23691D6F007DBE15 /* ltc_ecc_projective_dbl_point.c in Sources */,
+				1595968223691D6F007DBE15 /* ltc_ecc_import_point.c in Sources */,
+				159595E923691D6F007DBE15 /* ssh_encode_sequence_multi.c in Sources */,
+				159596F523691D6F007DBE15 /* eax_done.c in Sources */,
+				1595961323691D6F007DBE15 /* der_length_teletex_string.c in Sources */,
+				1595963823691D6F007DBE15 /* dh_set_pg_dhparam.c in Sources */,
+				1595973623691D6F007DBE15 /* sober128_test.c in Sources */,
+				159596AD23691D6F007DBE15 /* blake2s.c in Sources */,
+				1595970723691D6F007DBE15 /* ccm_memory.c in Sources */,
+				1595977523691D6F007DBE15 /* f9_memory_multi.c in Sources */,
+				159596F623691D6F007DBE15 /* eax_test.c in Sources */,
+				1595976E23691D6F007DBE15 /* xcbc_init.c in Sources */,
+				159595DF23691D6F007DBE15 /* base64_decode.c in Sources */,
+				159595B723691D6F007DBE15 /* compare_testvector.c in Sources */,
+				1595974723691D6F007DBE15 /* radix_to_bin.c in Sources */,
+				1595967923691D6F007DBE15 /* ltc_ecc_is_point.c in Sources */,
+				159595F223691D6F007DBE15 /* adler32.c in Sources */,
+				1595960723691D6F007DBE15 /* der_asn1_maps.c in Sources */,
+				159596D023691D6F007DBE15 /* lrw_process.c in Sources */,
+				159596E023691D6F007DBE15 /* cfb_getiv.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		1595936323691B13007DBE15 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.1;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		1595936423691B13007DBE15 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		1595936623691B13007DBE15 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"ARCHS[sdk=appletvos*]" = arm64;
+				"ARCHS[sdk=appletvsimulator*]" = "$(ARCHS_STANDARD)";
+				"ARCHS[sdk=iphoneos*]" = (
+					arm64,
+					armv7,
+				);
+				"ARCHS[sdk=iphonesimulator*]" = "$(ARCHS_STANDARD)";
+				"ARCHS[sdk=macosx*]" = "$(ARCHS_STANDARD)";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "TomCrypt/TomCrypt-Prefix.pch";
+				INFOPLIST_FILE = TomCrypt/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACH_O_TYPE = staticlib;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = net.libtom.TomCrypt;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvos appletvsimulator macosx";
+				SUPPORTS_MACCATALYST = YES;
+				TARGETED_DEVICE_FAMILY = "1,2,3";
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				"VALID_ARCHS[sdk=appletvos*]" = arm64;
+				"VALID_ARCHS[sdk=appletvsimulator*]" = "i386 x86_64";
+				"VALID_ARCHS[sdk=iphoneos*]" = "arm64e arm64 armv7s armv7";
+				"VALID_ARCHS[sdk=iphonesimulator*]" = "i386 x86_64";
+				"VALID_ARCHS[sdk=macosx*]" = "i386 x86_64";
+			};
+			name = Debug;
+		};
+		1595936723691B13007DBE15 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"ARCHS[sdk=appletvos*]" = arm64;
+				"ARCHS[sdk=iphoneos*]" = (
+					arm64,
+					armv7,
+				);
+				"ARCHS[sdk=macosx*]" = "$(ARCHS_STANDARD)";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "TomCrypt/TomCrypt-Prefix.pch";
+				INFOPLIST_FILE = TomCrypt/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACH_O_TYPE = staticlib;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = net.libtom.TomCrypt;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvos appletvsimulator macosx";
+				SUPPORTS_MACCATALYST = YES;
+				TARGETED_DEVICE_FAMILY = "1,2,3";
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				"VALID_ARCHS[sdk=appletvos*]" = arm64;
+				"VALID_ARCHS[sdk=appletvsimulator*]" = "i386 x86_64";
+				"VALID_ARCHS[sdk=iphoneos*]" = "arm64e arm64 armv7s armv7";
+				"VALID_ARCHS[sdk=iphonesimulator*]" = "i386 x86_64";
+				"VALID_ARCHS[sdk=macosx*]" = "i386 x86_64";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		1595935723691B13007DBE15 /* Build configuration list for PBXProject "TomCrypt" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1595936323691B13007DBE15 /* Debug */,
+				1595936423691B13007DBE15 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1595936523691B13007DBE15 /* Build configuration list for PBXNativeTarget "TomCrypt" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1595936623691B13007DBE15 /* Debug */,
+				1595936723691B13007DBE15 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 1595935423691B13007DBE15 /* Project object */;
+}

--- a/macos/TomCrypt.xcodeproj/xcshareddata/xcschemes/TomCrypt.xcscheme
+++ b/macos/TomCrypt.xcodeproj/xcshareddata/xcschemes/TomCrypt.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1110"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1595935C23691B13007DBE15"
+               BuildableName = "TomCrypt.framework"
+               BlueprintName = "TomCrypt"
+               ReferencedContainer = "container:TomCrypt.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1595935C23691B13007DBE15"
+            BuildableName = "TomCrypt.framework"
+            BlueprintName = "TomCrypt"
+            ReferencedContainer = "container:TomCrypt.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/macos/TomCrypt/Info.plist
+++ b/macos/TomCrypt/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/macos/TomCrypt/TomCrypt-Prefix.pch
+++ b/macos/TomCrypt/TomCrypt-Prefix.pch
@@ -1,0 +1,14 @@
+//
+//  TomCrypt-Prefix.pch
+//  TomCrypt
+//
+//  Created by v on 2019/10/30.
+//  Copyright © 2019 libtom. All rights reserved.
+//
+
+#ifndef TomCrypt_Prefix_pch
+#define TomCrypt_Prefix_pch
+
+#include "../../src/headers/tomcrypt.h"
+
+#endif /* TomCrypt_Prefix_pch */

--- a/src/headers/tomcrypt.h
+++ b/src/headers/tomcrypt.h
@@ -81,6 +81,10 @@ enum {
    CRYPT_HASH_OVERFLOW      /* Hash applied to too many bits */
 };
 
+#ifdef __cplusplus
+   }
+#endif
+
 #include "tomcrypt_cfg.h"
 #include "tomcrypt_macros.h"
 #include "tomcrypt_cipher.h"
@@ -92,10 +96,6 @@ enum {
 #include "tomcrypt_misc.h"
 #include "tomcrypt_argchk.h"
 #include "tomcrypt_pkcs.h"
-
-#ifdef __cplusplus
-   }
-#endif
 
 #endif /* TOMCRYPT_H_ */
 

--- a/src/headers/tomcrypt_argchk.h
+++ b/src/headers/tomcrypt_argchk.h
@@ -7,6 +7,10 @@
  * guarantee it works.
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Defines the LTC_ARGCHK macro used within the library */
 /* ARGTYPE is defined in tomcrypt_cfg.h */
 
@@ -14,6 +18,7 @@
 #if ARGTYPE == 0
 
 #include <signal.h>
+
 
 LTC_NORETURN void crypt_argchk(const char *v, const char *s, int d);
 #define LTC_ARGCHK(x) do { if (!(x)) { crypt_argchk(#x, __FILE__, __LINE__); } }while(0)
@@ -42,6 +47,9 @@ LTC_NORETURN void crypt_argchk(const char *v, const char *s, int d);
 
 #endif
 
+#ifdef __cplusplus
+}
+#endif
 
 /* ref:         $Format:%D$ */
 /* git commit:  $Format:%H$ */

--- a/src/headers/tomcrypt_cfg.h
+++ b/src/headers/tomcrypt_cfg.h
@@ -16,6 +16,10 @@
 #ifndef TOMCRYPT_CFG_H
 #define TOMCRYPT_CFG_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(_WIN32) || defined(_MSC_VER)
    #define LTC_CALL __cdecl
 #elif !defined(LTC_CALL)
@@ -309,6 +313,11 @@ typedef unsigned long ltc_mp_digit;
 #  define LTC_DEPRECATED(s)
 #  define LTC_DEPRECATED_PRAGMA(s)
 #endif
+
+#ifdef __cplusplus
+}
+#endif
+
 /* ref:         $Format:%D$ */
 /* git commit:  $Format:%H$ */
 /* commit time: $Format:%ai$ */

--- a/src/headers/tomcrypt_cipher.h
+++ b/src/headers/tomcrypt_cipher.h
@@ -7,6 +7,10 @@
  * guarantee it works.
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ---- SYMMETRIC KEY STUFF -----
  *
  * We put each of the ciphers scheduled keys in their own structs then we put all of
@@ -1164,6 +1168,10 @@ int sober128_stream_memory(const unsigned char *key,    unsigned long keylen,
                            unsigned char *dataout);
 
 #endif /* LTC_SOBER128_STREAM */
+
+#ifdef __cplusplus
+}
+#endif
 
 /* ref:         $Format:%D$ */
 /* git commit:  $Format:%H$ */

--- a/src/headers/tomcrypt_hash.h
+++ b/src/headers/tomcrypt_hash.h
@@ -7,6 +7,10 @@
  * guarantee it works.
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ---- HASH FUNCTIONS ---- */
 #if defined(LTC_SHA3) || defined(LTC_KECCAK)
 struct sha3_state {
@@ -505,6 +509,10 @@ int hash_memory_multi(int hash, unsigned char *out, unsigned long *outlen,
 #ifndef LTC_NO_FILE
 int hash_filehandle(int hash, FILE *in, unsigned char *out, unsigned long *outlen);
 int hash_file(int hash, const char *fname, unsigned char *out, unsigned long *outlen);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 /* ref:         $Format:%D$ */

--- a/src/headers/tomcrypt_mac.h
+++ b/src/headers/tomcrypt_mac.h
@@ -7,6 +7,10 @@
  * guarantee it works.
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef LTC_HMAC
 typedef struct Hmac_state {
      hash_state     md;
@@ -558,6 +562,10 @@ int chacha20poly1305_memory(const unsigned char *key, unsigned long keylen,
 int chacha20poly1305_test(void);
 
 #endif /* LTC_CHACHA20POLY1305_MODE */
+
+#ifdef __cplusplus
+}
+#endif
 
 /* ref:         $Format:%D$ */
 /* git commit:  $Format:%H$ */

--- a/src/headers/tomcrypt_macros.h
+++ b/src/headers/tomcrypt_macros.h
@@ -7,6 +7,10 @@
  * guarantee it works.
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ---- HELPER MACROS ---- */
 #ifdef ENDIAN_NEUTRAL
 
@@ -457,6 +461,10 @@ static inline ulong64 ROR64(ulong64 word, int i)
 /* there is no snprintf before Visual C++ 2015 */
 #if defined(_MSC_VER) && _MSC_VER < 1900
 #define snprintf _snprintf
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 /* ref:         $Format:%D$ */

--- a/src/headers/tomcrypt_math.h
+++ b/src/headers/tomcrypt_math.h
@@ -7,6 +7,10 @@
  * guarantee it works.
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** math functions **/
 
 #define LTC_MP_LT   -1
@@ -522,6 +526,10 @@ extern const ltc_math_descriptor tfm_desc;
 
 #ifdef GMP_DESC
 extern const ltc_math_descriptor gmp_desc;
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 /* ref:         $Format:%D$ */

--- a/src/headers/tomcrypt_misc.h
+++ b/src/headers/tomcrypt_misc.h
@@ -7,6 +7,10 @@
  * guarantee it works.
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ---- LTC_BASE64 Routines ---- */
 #ifdef LTC_BASE64
 int base64_encode(const unsigned char *in,  unsigned long inlen,
@@ -179,6 +183,10 @@ int ssh_decode_sequence_multi(const unsigned char *in, unsigned long *inlen, ...
 #endif /* LTC_SSH */
 
 int compare_testvector(const void* is, const unsigned long is_len, const void* should, const unsigned long should_len, const char* what, int which);
+
+#ifdef __cplusplus
+}
+#endif
 
 /* ref:         $Format:%D$ */
 /* git commit:  $Format:%H$ */

--- a/src/headers/tomcrypt_pk.h
+++ b/src/headers/tomcrypt_pk.h
@@ -7,6 +7,10 @@
  * guarantee it works.
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ---- NUMBER THEORY ---- */
 
 enum public_key_type {
@@ -784,6 +788,10 @@ int der_decode_generalizedtime(const unsigned char *in, unsigned long *inlen,
 
 int der_length_generalizedtime(const ltc_generalizedtime *gtime, unsigned long *outlen);
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 /* ref:         $Format:%D$ */

--- a/src/headers/tomcrypt_pkcs.h
+++ b/src/headers/tomcrypt_pkcs.h
@@ -7,6 +7,10 @@
  * guarantee it works.
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* PKCS Header Info */
 
 /* ===> PKCS #1 -- RSA Cryptography <=== */
@@ -103,6 +107,9 @@ int pkcs_5_alg2(const unsigned char *password, unsigned long password_len,
 int pkcs_5_test (void);
 #endif  /* LTC_PKCS_5 */
 
+#ifdef __cplusplus
+}
+#endif
 
 /* ref:         $Format:%D$ */
 /* git commit:  $Format:%H$ */

--- a/src/headers/tomcrypt_prng.h
+++ b/src/headers/tomcrypt_prng.h
@@ -7,6 +7,10 @@
  * guarantee it works.
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ---- PRNG Stuff ---- */
 #ifdef LTC_YARROW
 struct yarrow_prng {
@@ -227,6 +231,9 @@ extern unsigned long (*ltc_rng)(unsigned char *out, unsigned long outlen,
       void (*callback)(void));
 #endif
 
+#ifdef __cplusplus
+}
+#endif
 
 /* ref:         $Format:%D$ */
 /* git commit:  $Format:%H$ */


### PR DESCRIPTION
* [ ] documentation is added or updated
* [ ] tests are added or updated

1. add xcodeproj for ios/tvos/macos.
2. add extern “C” in every header file for fixing xcode build error when import tomcrypt.h.
3. output file `TomCrypt.framework` is staticlib type.