### PR TITLE
remove unused `hashstate` from `hmac_state`

### DIFF
--- a/src/headers/tomcrypt_mac.h
+++ b/src/headers/tomcrypt_mac.h
@@ -11,7 +11,6 @@
 typedef struct Hmac_state {
      hash_state     md;
      int            hash;
-     hash_state     hashstate;
      unsigned char  key[MAXBLOCKSIZE];
 } hmac_state;
 


### PR DESCRIPTION
I'm not sure how this was overlooked for so long.