### PR TITLE
Cast STORE64H/STORE64L argument to ulong64

### DIFF
--- a/src/headers/tomcrypt_macros.h
+++ b/src/headers/tomcrypt_macros.h
@@ -21,10 +21,10 @@
            ((ulong32)((y)[0] & 255)); } while(0)
 
 #define STORE64L(x, y)                                                                     \
-  do { (y)[7] = (unsigned char)(((x)>>56)&255); (y)[6] = (unsigned char)(((x)>>48)&255);   \
-       (y)[5] = (unsigned char)(((x)>>40)&255); (y)[4] = (unsigned char)(((x)>>32)&255);   \
-       (y)[3] = (unsigned char)(((x)>>24)&255); (y)[2] = (unsigned char)(((x)>>16)&255);   \
-       (y)[1] = (unsigned char)(((x)>>8)&255); (y)[0] = (unsigned char)((x)&255); } while(0)
+  do { (y)[7] = (unsigned char)(((ulong64)(x)>>56)&255); (y)[6] = (unsigned char)(((ulong64)(x)>>48)&255);   \
+       (y)[5] = (unsigned char)(((ulong64)(x)>>40)&255); (y)[4] = (unsigned char)(((ulong64)(x)>>32)&255);   \
+       (y)[3] = (unsigned char)(((ulong64)(x)>>24)&255); (y)[2] = (unsigned char)(((ulong64)(x)>>16)&255);   \
+       (y)[1] = (unsigned char)(((ulong64)(x)>>8)&255); (y)[0] = (unsigned char)((ulong64)(x)&255); } while(0)
 
 #define LOAD64L(x, y)                                                       \
   do { x = (((ulong64)((y)[7] & 255))<<56)|(((ulong64)((y)[6] & 255))<<48)| \
@@ -43,10 +43,10 @@
            ((ulong32)((y)[3] & 255)); } while(0)
 
 #define STORE64H(x, y)                                                                     \
-do { (y)[0] = (unsigned char)(((x)>>56)&255); (y)[1] = (unsigned char)(((x)>>48)&255);     \
-     (y)[2] = (unsigned char)(((x)>>40)&255); (y)[3] = (unsigned char)(((x)>>32)&255);     \
-     (y)[4] = (unsigned char)(((x)>>24)&255); (y)[5] = (unsigned char)(((x)>>16)&255);     \
-     (y)[6] = (unsigned char)(((x)>>8)&255); (y)[7] = (unsigned char)((x)&255); } while(0)
+do { (y)[0] = (unsigned char)(((ulong64)(x)>>56)&255); (y)[1] = (unsigned char)(((ulong64)(x)>>48)&255);     \
+     (y)[2] = (unsigned char)(((ulong64)(x)>>40)&255); (y)[3] = (unsigned char)(((ulong64)(x)>>32)&255);     \
+     (y)[4] = (unsigned char)(((ulong64)(x)>>24)&255); (y)[5] = (unsigned char)(((ulong64)(x)>>16)&255);     \
+     (y)[6] = (unsigned char)(((ulong64)(x)>>8)&255); (y)[7] = (unsigned char)((ulong64)(x)&255); } while(0)
 
 #define LOAD64H(x, y)                                                      \
 do { x = (((ulong64)((y)[0] & 255))<<56)|(((ulong64)((y)[1] & 255))<<48) | \
@@ -125,10 +125,10 @@ asm __volatile__ (             \
 #else
 
 #define STORE64H(x, y)                                                                     \
-do { (y)[0] = (unsigned char)(((x)>>56)&255); (y)[1] = (unsigned char)(((x)>>48)&255);     \
-     (y)[2] = (unsigned char)(((x)>>40)&255); (y)[3] = (unsigned char)(((x)>>32)&255);     \
-     (y)[4] = (unsigned char)(((x)>>24)&255); (y)[5] = (unsigned char)(((x)>>16)&255);     \
-     (y)[6] = (unsigned char)(((x)>>8)&255); (y)[7] = (unsigned char)((x)&255); } while(0)
+do { (y)[0] = (unsigned char)(((ulong64)(x)>>56)&255); (y)[1] = (unsigned char)(((ulong64)(x)>>48)&255);     \
+     (y)[2] = (unsigned char)(((ulong64)(x)>>40)&255); (y)[3] = (unsigned char)(((ulong64)(x)>>32)&255);     \
+     (y)[4] = (unsigned char)(((ulong64)(x)>>24)&255); (y)[5] = (unsigned char)(((ulong64)(x)>>16)&255);     \
+     (y)[6] = (unsigned char)(((ulong64)(x)>>8)&255); (y)[7] = (unsigned char)((ulong64)(x)&255); } while(0)
 
 #define LOAD64H(x, y)                                                      \
 do { x = (((ulong64)((y)[0] & 255))<<56)|(((ulong64)((y)[1] & 255))<<48) | \
@@ -147,10 +147,10 @@ do { x = (((ulong64)((y)[0] & 255))<<56)|(((ulong64)((y)[1] & 255))<<48) | \
   do { XMEMCPY(&(x), y, 4); } while(0)
 
 #define STORE64L(x, y)                                                                     \
-  do { (y)[7] = (unsigned char)(((x)>>56)&255); (y)[6] = (unsigned char)(((x)>>48)&255);   \
-       (y)[5] = (unsigned char)(((x)>>40)&255); (y)[4] = (unsigned char)(((x)>>32)&255);   \
-       (y)[3] = (unsigned char)(((x)>>24)&255); (y)[2] = (unsigned char)(((x)>>16)&255);   \
-       (y)[1] = (unsigned char)(((x)>>8)&255); (y)[0] = (unsigned char)((x)&255); } while(0)
+  do { (y)[7] = (unsigned char)(((ulong64)(x))>>56)&255); (y)[6] = (unsigned char)((((ulong64)(x))>>48)&255);   \
+       (y)[5] = (unsigned char)(((ulong64)(x))>>40)&255); (y)[4] = (unsigned char)((((ulong64)(x))>>32)&255);   \
+       (y)[3] = (unsigned char)(((ulong64)(x))>>24)&255); (y)[2] = (unsigned char)((((ulong64)(x))>>16)&255);   \
+       (y)[1] = (unsigned char)(((ulong64)(x))>>8)&255); (y)[0] = (unsigned char)(((ulong64)(x))&255); } while(0)
 
 #define LOAD64L(x, y)                                                       \
   do { x = (((ulong64)((y)[7] & 255))<<56)|(((ulong64)((y)[6] & 255))<<48)| \
@@ -187,10 +187,10 @@ do { x = (((ulong64)((y)[0] & 255))<<56)|(((ulong64)((y)[1] & 255))<<48) | \
            ((ulong32)((y)[0] & 255)); } while(0)
 
 #define STORE64L(x, y)                                                                     \
-do { (y)[7] = (unsigned char)(((x)>>56)&255); (y)[6] = (unsigned char)(((x)>>48)&255);     \
-     (y)[5] = (unsigned char)(((x)>>40)&255); (y)[4] = (unsigned char)(((x)>>32)&255);     \
-     (y)[3] = (unsigned char)(((x)>>24)&255); (y)[2] = (unsigned char)(((x)>>16)&255);     \
-     (y)[1] = (unsigned char)(((x)>>8)&255); (y)[0] = (unsigned char)((x)&255); } while(0)
+do { (y)[7] = (unsigned char)((((ulong64)(x))>>56)&255); (y)[6] = (unsigned char)((((ulong64)(x))>>48)&255);     \
+     (y)[5] = (unsigned char)((((ulong64)(x))>>40)&255); (y)[4] = (unsigned char)((((ulong64)(x))>>32)&255);     \
+     (y)[3] = (unsigned char)((((ulong64)(x))>>24)&255); (y)[2] = (unsigned char)((((ulong64)(x))>>16)&255);     \
+     (y)[1] = (unsigned char)((((ulong64)(x))>>8)&255); (y)[0] = (unsigned char)(((ulong64)(x))&255); } while(0)
 
 #define LOAD64L(x, y)                                                      \
 do { x = (((ulong64)((y)[7] & 255))<<56)|(((ulong64)((y)[6] & 255))<<48) | \
@@ -207,10 +207,10 @@ do { x = (((ulong64)((y)[7] & 255))<<56)|(((ulong64)((y)[6] & 255))<<48) | \
   do { XMEMCPY(&(x), y, 4); } while(0)
 
 #define STORE64H(x, y)                                                                     \
-  do { (y)[0] = (unsigned char)(((x)>>56)&255); (y)[1] = (unsigned char)(((x)>>48)&255);   \
-       (y)[2] = (unsigned char)(((x)>>40)&255); (y)[3] = (unsigned char)(((x)>>32)&255);   \
-       (y)[4] = (unsigned char)(((x)>>24)&255); (y)[5] = (unsigned char)(((x)>>16)&255);   \
-       (y)[6] = (unsigned char)(((x)>>8)&255);  (y)[7] = (unsigned char)((x)&255); } while(0)
+  do { (y)[0] = (unsigned char)(((ulong64)(x)>>56)&255); (y)[1] = (unsigned char)(((ulong64)(x)>>48)&255);   \
+       (y)[2] = (unsigned char)(((ulong64)(x)>>40)&255); (y)[3] = (unsigned char)(((ulong64)(x)>>32)&255);   \
+       (y)[4] = (unsigned char)(((ulong64)(x)>>24)&255); (y)[5] = (unsigned char)(((ulong64)(x)>>16)&255);   \
+       (y)[6] = (unsigned char)(((ulong64)(x)>>8)&255);  (y)[7] = (unsigned char)((ulong64)(x)&255); } while(0)
 
 #define LOAD64H(x, y)                                                       \
   do { x = (((ulong64)((y)[0] & 255))<<56)|(((ulong64)((y)[1] & 255))<<48)| \


### PR DESCRIPTION
Avoids undefined behaviour with right shift greater than 32 bits. (c99 6.5.7 "If the value of the right operand is negative or is *greater than or equal to the width* of the promoted left operand, the behavior is undefined."

I haven't reproduced it here but it was hit using STORE64H outside of libtomcrypt on BCM4706 MIPS32r2 with GCC 4.2.4  https://github.com/mkj/dropbear/pull/99

The patch doesn't seem to affect code generation with -DLTC_NO_ASM on x64.