### PR TITLE
Avoid zero length array with LTC_BASE64_URL unset

### DIFF
--- a/src/misc/base64/base64_decode.c
+++ b/src/misc/base64/base64_decode.c
@@ -48,8 +48,8 @@ static const unsigned char map_base64[256] = {
 255, 255, 255, 255 };
 #endif /* LTC_BASE64 */
 
-static const unsigned char map_base64url[] = {
 #if defined(LTC_BASE64_URL)
+static const unsigned char map_base64url[] = {
 255, 255, 255, 255, 255, 255, 255, 255, 255, 253, 253, 255,
 255, 253, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
 255, 255, 255, 255, 255, 255, 255, 255, 253, 255, 255, 255,
@@ -72,8 +72,8 @@ static const unsigned char map_base64url[] = {
 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
 255, 255, 255, 255
-#endif /* LTC_BASE64_URL */
 };
+#endif /* LTC_BASE64_URL */
 
 enum {
    insane = 0,
@@ -132,8 +132,14 @@ static int _base64_decode_internal(const char *in,  unsigned long inlen,
    }
 
    if (y != 0) {
+      int allow_b64url = 0;
+#ifdef LTC_BASE64_URL
+      if (map == map_base64url) {
+        allow_b64url = 1;
+      }
+#endif
       if (y == 1) return CRYPT_INVALID_PACKET;
-      if (((y + g) != 4) && (mode == strict) && (map != map_base64url)) return CRYPT_INVALID_PACKET;
+      if (((y + g) != 4) && (mode == strict) && (!allow_b64url)) return CRYPT_INVALID_PACKET;
       t = t << (6 * (4 - y));
       if (z + y - 1 > *outlen) return CRYPT_BUFFER_OVERFLOW;
       if (y >= 2) out[z++] = (unsigned char) ((t >> 16) & 255);


### PR DESCRIPTION
If LTC_BASE64_URL is unset it creates a zero length array, which isn't allowed by some compilers