### PR TITLE
fix DSA dependency to SHA2

### DIFF
--- a/src/headers/tomcrypt_pk.h
+++ b/src/headers/tomcrypt_pk.h
@@ -384,11 +384,14 @@ int x25519_shared_secret(const curve25519_key *private_key,
 
 #ifdef LTC_MDSA
 
-/* Max diff between group and modulus size in bytes */
-#define LTC_MDSA_DELTA     512
+/* Max diff between group and modulus size in bytes (max case: L=8192bits, N=256bits) */
+#define LTC_MDSA_DELTA 992
 
-/* Max DSA group size in bytes (default allows 4k-bit groups) */
-#define LTC_MDSA_MAX_GROUP 512
+/* Max DSA group size in bytes */
+#define LTC_MDSA_MAX_GROUP 64
+
+/* Max DSA modulus size in bytes (the actual DSA size, max 8192 bits) */
+#define LTC_MDSA_MAX_MODULUS 1024
 
 /** DSA key structure */
 typedef struct {

--- a/src/misc/crypt/crypt_constants.c
+++ b/src/misc/crypt/crypt_constants.c
@@ -102,6 +102,7 @@ static const crypt_constant s_crypt_constants[] = {
     {"LTC_MDSA", 1},
     C_STRINGIFY(LTC_MDSA_DELTA),
     C_STRINGIFY(LTC_MDSA_MAX_GROUP),
+    C_STRINGIFY(LTC_MDSA_MAX_MODULUS),
 #else
     {"LTC_MDSA", 0},
 #endif

--- a/src/pk/dsa/dsa_generate_pqg.c
+++ b/src/pk/dsa/dsa_generate_pqg.c
@@ -87,17 +87,24 @@ static int s_dsa_make_params(prng_state *prng, int wprng, int group_size, int mo
   else                { mr_tests_q = 64; }
 #endif
 
+  hash = -1;
+#ifdef LTC_SHA256
   if (N <= 256) {
     hash = register_hash(&sha256_desc);
   }
-  else if (N <= 384) {
+#endif
+#ifdef LTC_SHA384
+  if ((N <= 384) && (hash == -1)) {
     hash = register_hash(&sha384_desc);
   }
-  else if (N <= 512) {
+#endif
+#ifdef LTC_SHA512
+  if ((N <= 512) && (hash == -1)) {
     hash = register_hash(&sha512_desc);
   }
-  else {
-    return CRYPT_INVALID_ARG; /* group_size too big */
+#endif
+  if (hash == -1) {
+    return CRYPT_INVALID_ARG; /* group_size too big or no appropriate hash function found */
   }
 
   if ((err = hash_is_valid(hash)) != CRYPT_OK)                                   { return err; }

--- a/src/pk/dsa/dsa_generate_pqg.c
+++ b/src/pk/dsa/dsa_generate_pqg.c
@@ -29,7 +29,7 @@ static int s_dsa_make_params(prng_state *prng, int wprng, int group_size, int mo
   const char *accepted_hashes[] = { "sha3-512", "sha512", "sha3-384", "sha384", "sha3-256", "sha256" };
 
   /* check size */
-  if (group_size >= LTC_MDSA_MAX_GROUP || group_size < 1 || group_size >= modulus_size) {
+  if (group_size > LTC_MDSA_MAX_GROUP || group_size < 1 || group_size >= modulus_size || modulus_size > LTC_MDSA_MAX_MODULUS) {
     return CRYPT_INVALID_ARG;
   }
 

--- a/src/pk/dsa/dsa_generate_pqg.c
+++ b/src/pk/dsa/dsa_generate_pqg.c
@@ -26,6 +26,7 @@ static int s_dsa_make_params(prng_state *prng, int wprng, int group_size, int mo
   int err, res, mr_tests_q, mr_tests_p, found_p, found_q, hash;
   unsigned char *wbuf, *sbuf, digest[MAXBLOCKSIZE];
   void *t2L1, *t2N1, *t2q, *t2seedlen, *U, *W, *X, *c, *h, *e, *seedinc;
+  const char *accepted_hashes[] = { "sha3-512", "sha512", "sha3-384", "sha384", "sha3-256", "sha256" };
 
   /* check size */
   if (group_size >= LTC_MDSA_MAX_GROUP || group_size < 1 || group_size >= modulus_size) {
@@ -88,15 +89,10 @@ static int s_dsa_make_params(prng_state *prng, int wprng, int group_size, int mo
 #endif
 
   hash = -1;
-#if defined(LTC_SHA3)
-  hash = register_hash(&sha3_512_desc);
-#elif defined(LTC_SHA512)
-  hash = register_hash(&sha512_desc);
-#elif defined(LTC_SHA384)
-  hash = register_hash(&sha384_desc);
-#elif defined(LTC_SHA256)
-  hash = register_hash(&sha256_desc);
-#endif
+  for (i = 0; i < sizeof(accepted_hashes)/sizeof(accepted_hashes[0]); ++i) {
+    hash = find_hash(accepted_hashes[i]);
+    if (hash != -1) break;
+  }
   if (hash == -1) {
     return CRYPT_INVALID_ARG; /* no appropriate hash function found */
   }

--- a/src/pk/dsa/dsa_generate_pqg.c
+++ b/src/pk/dsa/dsa_generate_pqg.c
@@ -88,23 +88,20 @@ static int s_dsa_make_params(prng_state *prng, int wprng, int group_size, int mo
 #endif
 
   hash = -1;
-#ifdef LTC_SHA256
-  if (N <= 256) {
-    hash = register_hash(&sha256_desc);
-  }
-#endif
-#ifdef LTC_SHA384
-  if ((N <= 384) && (hash == -1)) {
-    hash = register_hash(&sha384_desc);
-  }
-#endif
-#ifdef LTC_SHA512
-  if ((N <= 512) && (hash == -1)) {
-    hash = register_hash(&sha512_desc);
-  }
+#if defined(LTC_SHA3)
+  hash = register_hash(&sha3_512_desc);
+#elif defined(LTC_SHA512)
+  hash = register_hash(&sha512_desc);
+#elif defined(LTC_SHA384)
+  hash = register_hash(&sha384_desc);
+#elif defined(LTC_SHA256)
+  hash = register_hash(&sha256_desc);
 #endif
   if (hash == -1) {
-    return CRYPT_INVALID_ARG; /* group_size too big or no appropriate hash function found */
+    return CRYPT_INVALID_ARG; /* no appropriate hash function found */
+  }
+  if (N > hash_descriptor[hash].hashsize * 8) {
+    return CRYPT_INVALID_ARG; /* group_size too big */
   }
 
   if ((err = hash_is_valid(hash)) != CRYPT_OK)                                   { return err; }


### PR DESCRIPTION
DSA had a hard dependency to the basic sha2 operations.
In case one wanted to compile e.g. only with sha256 this lead to a
compilation error.

While working on this I thought whether it wouldn't make sense to use sha3 there or at least give the possibility.