### PR TITLE
docs: fix simple typo, succes -> success

### DIFF
--- a/src/mac/f9/f9_test.c
+++ b/src/mac/f9/f9_test.c
@@ -10,7 +10,7 @@
 #ifdef LTC_F9_MODE
 
 /** Test f9-MAC mode
-  Return CRYPT_OK on succes
+  Return CRYPT_OK on success
 */
 int f9_test(void)
 {

--- a/src/mac/xcbc/xcbc_test.c
+++ b/src/mac/xcbc/xcbc_test.c
@@ -10,7 +10,7 @@
 #ifdef LTC_XCBC
 
 /** Test XCBC-MAC mode
-  Return CRYPT_OK on succes
+  Return CRYPT_OK on success
 */
 int xcbc_test(void)
 {


### PR DESCRIPTION
There is a small typo in src/mac/f9/f9_test.c, src/mac/xcbc/xcbc_test.c.

Should read `success` rather than `succes`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md