### PR TITLE
Makefile: Fix shared library build in MinGW.

### DIFF
--- a/makefile.shared
+++ b/makefile.shared
@@ -30,7 +30,7 @@ else
   endif
 endif
 
-ifeq ($(PLATFORM), CYGWIN)
+ifneq ($(findstring $(PLATFORM),CYGWIN MINGW32 MINGW64 MSYS),)
   NO_UNDEFINED:=-no-undefined
 endif
 


### PR DESCRIPTION
This enables -no-undefined linker flag in mingw toolchain.
Previous related commit 9c2c9f8af4c1e0073284baceb34a5c88f0e33b49
