### PR TITLE
rsa: add rsa key generate with bignumber public exponent

### DIFF
--- a/doc/crypt.tex
+++ b/doc/crypt.tex
@@ -4326,10 +4326,27 @@ The \textit{e} parameter is the encryption exponent desired, typical values are 
 trivial math attacks, and not super slow.  The \textit{key} parameter is where the constructed key is placed.  All keys must be at
 least 128 bytes, and no more than 512 bytes in size (\textit{that is from 1024 to 4096 bits}).
 
+\index{rsa\_make\_key\_ubin\_e()}
+\begin{verbatim}
+int rsa_make_key_ubin_e(
+             prng_state *prng,
+                    int  wprng,
+                    int  size,
+    const unsigned char *e,
+           unsigned long elen,
+                rsa_key *key);
+\end{verbatim}
+
+Where \textit{wprng} is the index into the PRNG descriptor array.  The \textit{size} parameter is the size in bytes of the RSA modulus desired.
+The \textit{e} parameter is the hexadecimal buffer of the encryption exponent desired, from 3 upto 255 bits value.  Stick with 65537 since it is big enough
+to prevent trivial math attacks, and not super slow.  The \textit{elen} parameter is the size in bytes of the encryption exponent \textit{e}.
+The \textit{key} parameter is where the constructed key is placed.  All keys must be at
+least 128 bytes, and no more than 512 bytes in size (\textit{that is from 1024 to 4096 bits}).
+
 \index{rsa\_free()}
-Note: the \textit{rsa\_make\_key()} function allocates memory at run--time when you make the key.  Make sure to call
-\textit{rsa\_free()} (see below) when you are finished with the key.  If \textit{rsa\_make\_key()} fails it will automatically
-free the memory allocated.
+Note: the \textit{rsa\_make\_key()} and \textit{rsa\_make\_key\_ubin\_e()} functions allocates memory at run--time when you make the key.
+Make sure to call \textit{rsa\_free()} (see below) when you are finished with the key.  If \textit{rsa\_make\_key()} or \textit{rsa\_make\_key\_ubin\_e()} 
+fails it will automatically free the memory allocated.
 
 \index{PK\_PRIVATE} \index{PK\_PUBLIC}
 There are two types of RSA keys.  The types are {\bf PK\_PRIVATE} and {\bf PK\_PUBLIC}.  The first type is a private

--- a/src/headers/tomcrypt_pk.h
+++ b/src/headers/tomcrypt_pk.h
@@ -45,7 +45,8 @@ typedef struct Rsa_key {
 } rsa_key;
 
 int rsa_make_key(prng_state *prng, int wprng, int size, long e, rsa_key *key);
-
+int rsa_make_key_ubin_e(prng_state *prng, int wprng, int size,
+                        const unsigned char *e, unsigned long elen, rsa_key *key);
 int rsa_get_size(const rsa_key *key);
 
 int rsa_exptmod(const unsigned char *in,   unsigned long inlen,

--- a/src/headers/tomcrypt_private.h
+++ b/src/headers/tomcrypt_private.h
@@ -223,6 +223,8 @@ int pk_oid_num_to_str(const unsigned long *oid, unsigned long oidlen, char *OID,
 #ifdef LTC_MRSA
 int rsa_init(rsa_key *key);
 void rsa_shrink_key(rsa_key *key);
+int rsa_make_key_bn_e(prng_state *prng, int wprng, int size, void *e,
+                      rsa_key *key); /* used by op-tee */
 #endif /* LTC_MRSA */
 
 /* ---- DH Routines ---- */

--- a/src/pk/rsa/rsa_make_key.c
+++ b/src/pk/rsa/rsa_make_key.c
@@ -9,51 +9,37 @@
 
 #ifdef LTC_MRSA
 
-/**
-   Create an RSA key
-   @param prng     An active PRNG state
-   @param wprng    The index of the PRNG desired
-   @param size     The size of the modulus (key size) desired (octets)
-   @param e        The "e" value (public key).  e==65537 is a good choice
-   @param key      [out] Destination of a newly created private key pair
-   @return CRYPT_OK if successful, upon error all allocated ram is freed
-*/
-int rsa_make_key(prng_state *prng, int wprng, int size, long e, rsa_key *key)
+static int s_rsa_make_key(prng_state *prng, int wprng, int size, void *e, rsa_key *key)
 {
-   void *p, *q, *tmp1, *tmp2, *tmp3;
+   void *p, *q, *tmp1, *tmp2;
    int    err;
 
    LTC_ARGCHK(ltc_mp.name != NULL);
    LTC_ARGCHK(key         != NULL);
    LTC_ARGCHK(size        > 0);
 
-   if ((e < 3) || ((e & 1) == 0)) {
-      return CRYPT_INVALID_ARG;
-   }
-
    if ((err = prng_is_valid(wprng)) != CRYPT_OK) {
       return err;
    }
 
-   if ((err = mp_init_multi(&p, &q, &tmp1, &tmp2, &tmp3, NULL)) != CRYPT_OK) {
+   if ((err = mp_init_multi(&p, &q, &tmp1, &tmp2, NULL)) != CRYPT_OK) {
       return err;
    }
 
    /* make primes p and q (optimization provided by Wayne Scott) */
-   if ((err = mp_set_int(tmp3, e)) != CRYPT_OK)                      { goto cleanup; }  /* tmp3 = e */
 
    /* make prime "p" */
    do {
        if ((err = rand_prime( p, size/2, prng, wprng)) != CRYPT_OK)  { goto cleanup; }
        if ((err = mp_sub_d( p, 1,  tmp1)) != CRYPT_OK)               { goto cleanup; }  /* tmp1 = p-1 */
-       if ((err = mp_gcd( tmp1,  tmp3,  tmp2)) != CRYPT_OK)          { goto cleanup; }  /* tmp2 = gcd(p-1, e) */
+       if ((err = mp_gcd( tmp1,  e,  tmp2)) != CRYPT_OK)             { goto cleanup; }  /* tmp2 = gcd(p-1, e) */
    } while (mp_cmp_d( tmp2, 1) != 0);                                                  /* while e divides p-1 */
 
    /* make prime "q" */
    do {
        if ((err = rand_prime( q, size/2, prng, wprng)) != CRYPT_OK)  { goto cleanup; }
        if ((err = mp_sub_d( q, 1,  tmp1)) != CRYPT_OK)               { goto cleanup; } /* tmp1 = q-1 */
-       if ((err = mp_gcd( tmp1,  tmp3,  tmp2)) != CRYPT_OK)          { goto cleanup; } /* tmp2 = gcd(q-1, e) */
+       if ((err = mp_gcd( tmp1,  e,  tmp2)) != CRYPT_OK)          { goto cleanup; } /* tmp2 = gcd(q-1, e) */
    } while (mp_cmp_d( tmp2, 1) != 0);                                                 /* while e divides q-1 */
 
    /* tmp1 = lcm(p-1, q-1) */
@@ -66,7 +52,7 @@ int rsa_make_key(prng_state *prng, int wprng, int size, long e, rsa_key *key)
       goto errkey;
    }
 
-   if ((err = mp_set_int( key->e, e)) != CRYPT_OK)                     { goto errkey; } /* key->e =  e */
+   if ((err = mp_copy( e,  key->e)) != CRYPT_OK)                       { goto errkey; } /* key->e =  e */
    if ((err = mp_invmod( key->e,  tmp1,  key->d)) != CRYPT_OK)         { goto errkey; } /* key->d = 1/e mod lcm(p-1,q-1) */
    if ((err = mp_mul( p,  q,  key->N)) != CRYPT_OK)                    { goto errkey; } /* key->N = pq */
 
@@ -90,7 +76,89 @@ int rsa_make_key(prng_state *prng, int wprng, int size, long e, rsa_key *key)
 errkey:
    rsa_free(key);
 cleanup:
-   mp_clear_multi(tmp3, tmp2, tmp1, q, p, NULL);
+   mp_clear_multi(tmp2, tmp1, q, p, NULL);
+   return err;
+}
+
+/**
+   Create an RSA key based on a long public exponent type
+   @param prng     An active PRNG state
+   @param wprng    The index of the PRNG desired
+   @param size     The size of the modulus (key size) desired (octets)
+   @param e        The "e" value (public key).  e==65537 is a good choice
+   @param key      [out] Destination of a newly created private key pair
+   @return CRYPT_OK if successful, upon error all allocated ram is freed
+*/
+int rsa_make_key(prng_state *prng, int wprng, int size, long e, rsa_key *key)
+{
+   void *tmp_e;
+   int err;
+
+   if ((e < 3) || ((e & 1) == 0)) {
+     return CRYPT_INVALID_ARG;
+   }
+
+   if ((err = mp_init(&tmp_e)) != CRYPT_OK) {
+     return err;
+   }
+
+   if ((err = mp_set_int(tmp_e, e)) == CRYPT_OK)
+     err = s_rsa_make_key(prng, wprng, size, tmp_e, key);
+
+   mp_clear(tmp_e);
+
+   return err;
+}
+
+/**
+   Create an RSA key based on a hexadecimal public exponent type
+   @param prng     An active PRNG state
+   @param wprng    The index of the PRNG desired
+   @param size     The size of the modulus (key size) desired (octets)
+   @param e        The "e" value (public key).  e==65537 is a good choice
+   @param elen     The length of e (octets)
+   @param key      [out] Destination of a newly created private key pair
+   @return CRYPT_OK if successful, upon error all allocated ram is freed
+*/
+int rsa_make_key_ubin_e(prng_state *prng, int wprng, int size,
+                        const unsigned char *e, unsigned long elen, rsa_key *key)
+{
+   int err;
+   void *tmp_e;
+
+   if ((err = mp_init(&tmp_e)) != CRYPT_OK) {
+      return err;
+   }
+
+   if ((err = mp_read_unsigned_bin(tmp_e, (unsigned char *)e, elen)) == CRYPT_OK)
+     err = rsa_make_key_bn_e(prng, wprng, size, tmp_e, key);
+
+   mp_clear(tmp_e);
+
+   return err;
+}
+
+/**
+   Create an RSA key based on a bignumber public exponent type
+   @param prng     An active PRNG state
+   @param wprng    The index of the PRNG desired
+   @param size     The size of the modulus (key size) desired (octets)
+   @param e        The "e" value (public key).  e==65537 is a good choice
+   @param key      [out] Destination of a newly created private key pair
+   @return CRYPT_OK if successful, upon error all allocated ram is freed
+*/
+int rsa_make_key_bn_e(prng_state *prng, int wprng, int size, void *e, rsa_key *key)
+{
+   int err;
+   int e_bits;
+
+   e_bits = mp_count_bits(e);
+   if ((e_bits > 1 && e_bits < 256) && (mp_get_digit(e, 0) & 1)) {
+     err = s_rsa_make_key(prng, wprng, size, e, key);
+   } else {
+     err = CRYPT_INVALID_ARG;
+   }
+
    return err;
 }
 


### PR DESCRIPTION
Function rsa_make_key() limits the RSA key generates to a public
exponent of type long (32 bits or 64 bits).
RSA standard specify that public exponent e can be between 65537 (included)
and 2^256 (excluded).

Add function rsa_make_key_bn_e to use a bignumber public exponent.

Signed-off-by: Cedric Neveux <cedric.neveux@nxp.com>

<!--

Thank you for your pull request.

If this fixes an existing github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.

-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

* [x] documentation is added or updated
* [x] tests are added or updated
