### PR TITLE
makefile.shared: Don't use libtool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,13 @@
 # suppress compiler/linker output
 *.[oa]
 *.obj
-*.l[oa]
+*.dylib*
+*.dll*
+*.so*
 [Dd]ebug/
 [Rr]elease/
 /MSVC_*
-.libs/
+.bin/
 
 # release files
 /libtomcrypt-*

--- a/bin.in
+++ b/bin.in
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Shell wrapper script for the executables when built with the shared
+# libtomcrypt library.
+
+set -euf
+
+rootdir="$(cd -- "${0%/*}/" && pwd -P)"
+binpath="$rootdir/.bin/${0##*/}"
+
+[ -z "${LD_LIBRARY_PATH:=$rootdir}" ] ||
+	LD_LIBRARY_PATH="$rootdir:$LD_LIBRARY_PATH"
+
+export LD_LIBRARY_PATH
+
+if [ -n "${1+x}" ]; then
+	exec "$binpath" "${@:-}"
+else
+	exec "$binpath"
+fi

--- a/helper.pl
+++ b/helper.pl
@@ -273,7 +273,7 @@ sub patch_file {
 sub version_from_tomcrypt_h {
   my $h = read_file(shift);
   if ($h =~ /\n#define\s*SCRYPT\s*"([0-9]+)\.([0-9]+)\.([0-9]+)(\S*)"/s) {
-    return "VERSION_PC=$1.$2.$3", "VERSION_LT=1:1", "VERSION=$1.$2.$3$4", "PROJECT_NUMBER=$1.$2.$3$4";
+    return "VERSION_PC=$1.$2.$3", "VERSION_MAJOR=1", "VERSION_MINOR=0", "VERSION_PATCH=1", "VERSION=$1.$2.$3$4", "PROJECT_NUMBER=$1.$2.$3$4";
   }
   else {
     die "#define SCRYPT not found in tomcrypt.h";

--- a/makefile.shared
+++ b/makefile.shared
@@ -1,6 +1,6 @@
 # MAKEFILE for linux GCC
 #
-# This makefile produces a shared object and requires libtool to be installed.
+# This makefile produces a shared object.
 #
 # Thanks to Zed Shaw for helping debug this on BSD/OSX.
 # Tom St Denis
@@ -24,33 +24,33 @@ PLATFORM := $(shell uname | sed -e 's/_.*//')
 # Linux                   (on all Linux distros)
 # Darwin                  (on macOS, OS X)
 
-ifeq ($(LIBTOOL),rlibtool)
-  TGTLIBTOOL:=slibtool-shared
+INSTALL_CMD := install
+UNINSTALL_CMD := rm -f
+
+NAME := libtomcrypt
+PIC := -fPIC
+SHARED := $(PIC)
+
+ifeq ($(UNAME), Darwin)
+	NO_UNDEFINED := -Wl,-undefined,error
+	SHARED += -dynamiclib
 else
-  ifndef LIBTOOL
-    ifeq ($(PLATFORM), Darwin)
-      TGTLIBTOOL:=glibtool
-    else
-      TGTLIBTOOL:=libtool
-    endif
-  else
-    TGTLIBTOOL=$(LIBTOOL)
-  endif
+	NO_UNDEFIED := -Wl,--no-undefined
+	SHARED += -shared
 endif
 
-ifneq ($(findstring $(PLATFORM),CYGWIN MINGW32 MINGW64 MSYS),)
-  NO_UNDEFINED:=-no-undefined
+ifeq ($(PLATFORM), Darwin)
+	TARGET := $(NAME).dylib
+else ifeq ($(OS), Windows_NT)
+	TARGET := $(NAME).dll
+else
+	TARGET := $(NAME).so
 endif
-
-LTCOMPILE = $(TGTLIBTOOL) --mode=compile --tag=CC $(CC)
-INSTALL_CMD = $(TGTLIBTOOL) --mode=install install
-UNINSTALL_CMD = $(TGTLIBTOOL) --mode=uninstall rm
 
 #Output filenames for various targets.
 ifndef LIBNAME
-   LIBNAME=libtomcrypt.la
+	LIBNAME = $(TARGET).$(VERSION_LT)
 endif
-
 
 include makefile_include.mk
 
@@ -74,40 +74,58 @@ endif
 LTC_PKG_CONFIG_CFLAGS += $(PKG_CONFIG_CFLAGS)
 LTC_PKG_CONFIG_LIBS += $(PKG_CONFIG_LIBS)
 
+.PHONY: check install install_bins uninstall
+
+.bin/.tag: bin.in
+	mkdir -p .bin
+	touch $@
+
 #ciphers come in two flavours... enc+dec and enc
 src/ciphers/aes/aes_enc.o: src/ciphers/aes/aes.c src/ciphers/aes/aes_tab.c
-	$(LTCOMPILE) $(LTC_CFLAGS) $(CPPFLAGS) $(LTC_LDFLAGS) -DENCRYPT_ONLY -c src/ciphers/aes/aes.c -o src/ciphers/aes/aes_enc.o
+	$(CC) $(LTC_CFLAGS) $(PIC) $(CPPFLAGS) -DENCRYPT_ONLY -c src/ciphers/aes/aes.c -o src/ciphers/aes/aes_enc.o
 src/ciphers/aes/aes_enc_desc.o: src/ciphers/aes/aes_desc.c
-	$(LTCOMPILE) $(LTC_CFLAGS) $(CPPFLAGS) $(LTC_LDFLAGS) -DENCRYPT_ONLY -c src/ciphers/aes/aes_desc.c -o src/ciphers/aes/aes_enc_desc.o
+	$(CC) $(LTC_CFLAGS) $(PIC) $(CPPFLAGS) -DENCRYPT_ONLY -c src/ciphers/aes/aes_desc.c -o src/ciphers/aes/aes_enc_desc.o
 
 .c.o:
-	$(LTCOMPILE) $(LTC_CFLAGS) $(CPPFLAGS) $(LTC_LDFLAGS) -o $@ -c $<
-
-LOBJECTS = $(OBJECTS:.o=.lo)
+	$(CC) $(LTC_CFLAGS) $(PIC) $(CPPFLAGS) -o $@ -c $<
 
 $(LIBNAME): $(OBJECTS)
-	$(TGTLIBTOOL) --mode=link --tag=CC $(CC) $(LTC_LDFLAGS) $(LOBJECTS) $(EXTRALIBS) -o $@ -rpath $(LIBPATH) -version-info $(VERSION_LT) $(NO_UNDEFINED)
+	$(CC) $(LTC_LDFLAGS) $(OBJECTS) $(EXTRALIBS) $(SHARED) -Wl,-soname,$(TARGET).$(VERSION_MAJOR) $(NO_UNDEFINED) -o $@
 
-test: $(call print-help,test,Builds the library and the 'test' application to run all self-tests) $(LIBNAME) $(TOBJECTS)
-	$(TGTLIBTOOL) --mode=link --tag=CC $(CC) $(LTC_LDFLAGS) -o $(TEST) $(TOBJECTS) $(LIBNAME) $(EXTRALIBS)
+$(TARGET).$(VERSION_MAJOR) $(TARGET): $(LIBNAME)
+	ln -sf $< $@
+
+.bin/$(TEST): $(TARGET).$(VERSION_MAJOR) $(TARGET) $(TOBJECTS) .bin/.tag
+	$(CC) $(LTC_LDFLAGS) $(TOBJECTS) -L. -ltomcrypt $(EXTRALIBS) $(NO_UNDEFINED) -o $@
+
+test: $(call print-help,test,Builds the library and the 'test' application to run all self-tests) .bin/$(TEST)
+	$(INSTALL_CMD) -m 755 bin.in $@
 
 # build the demos from a template
 define DEMO_template
-$(1): $(call print-help,$(1),Builds the library and the '$(1)' demo) demos/$(1).o $$(LIBNAME)
-	$$(TGTLIBTOOL) --mode=link --tag=CC $$(CC) $$(LTC_LDFLAGS) $$^ $$(EXTRALIBS) -o $$@
+.bin/$(1): demos/$(1).o $$(TARGET).$$(VERSION_MAJOR) $$(TARGET) .bin/.tag
+	$$(CC) $$(LTC_LDFLAGS) $$< -L. -ltomcrypt $$(EXTRALIBS) $(NO_UNDEFINED) -o $$@
+
+$(1): $(call print-help,$(1),Builds the library and the '$(1)' demo) .bin/$(1)
+	$$(INSTALL_CMD) -m 755 bin.in $(1)
 endef
 
 $(foreach demo, $(strip $(DEMOS)), $(eval $(call DEMO_template,$(demo))))
 
 install: $(call print-help,install,Installs the library + headers + pkg-config file) .common_install
+	ln -sf $(LIBNAME) $(DESTDIR)/$(LIBPATH)/$(TARGET).$(VERSION_MAJOR)
+	ln -sf $(LIBNAME) $(DESTDIR)/$(LIBPATH)/$(TARGET)
 	sed -e 's,^prefix=.*,prefix=$(PREFIX),' -e 's,^Version:.*,Version: $(VERSION_PC),' -e 's,^libdir=.*,libdir=$(LIBPATH),' \
 		-e 's,^includedir=.*,includedir=$(INCPATH),' \
 		-e 's,@PKG_CONFIG_LIBS@,$(LTC_PKG_CONFIG_LIBS),' \
 		-e 's,@PKG_CONFIG_CFLAGS@,$(LTC_PKG_CONFIG_CFLAGS),' libtomcrypt.pc.in > libtomcrypt.pc
-	install -p -d $(DESTDIR)$(LIBPATH)/pkgconfig
-	install -p -m 644 libtomcrypt.pc $(DESTDIR)$(LIBPATH)/pkgconfig/
+	$(INSTALL_CMD) -p -d $(DESTDIR)$(LIBPATH)/pkgconfig
+	$(INSTALL_CMD) -p -m 644 libtomcrypt.pc $(DESTDIR)$(LIBPATH)/pkgconfig/
 
-install_bins: $(call print-help,install_bins,Installs the useful demos ($(USEFUL_DEMOS))) .common_install_bins
+install_bins: $(call print-help,install_bins,Installs the useful demos ($(USEFUL_DEMOS))) $(USEFUL_DEMOS) $(DESTDIR)$(BINPATH)
+	$(INSTALL_CMD) -p -m 775 $(foreach demo, $(strip $(USEFUL_DEMOS)),.bin/$(demo)) $(DESTDIR)$(BINPATH)
 
 uninstall: $(call print-help,uninstall,Uninstalls the library + headers + pkg-config file) .common_uninstall
-	rm $(DESTDIR)$(LIBPATH)/pkgconfig/libtomcrypt.pc
+	$(UNINSTALL_CMD) $(DESTDIR)/$(LIBPATH)/$(TARGET).$(VERSION_MAJOR)
+	$(UNINSTALL_CMD) $(DESTDIR)/$(LIBPATH)/$(TARGET)
+	$(UNINSTALL_CMD) $(DESTDIR)$(LIBPATH)/pkgconfig/libtomcrypt.pc

--- a/makefile_include.mk
+++ b/makefile_include.mk
@@ -5,8 +5,11 @@
 # The version - BEWARE: VERSION, VERSION_PC and VERSION_LT are updated via ./updatemakes.sh
 VERSION=1.18.2-develop
 VERSION_PC=1.18.2
-# http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
-VERSION_LT=1:1
+# https://semver.org/
+VERSION_MAJOR=1
+VERSION_MINOR=0
+VERSION_PATCH=1
+VERSION_LT=$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH)
 
 # Compiler and Linker Names
 ifndef CROSS_COMPILE
@@ -507,30 +510,30 @@ install_hooks: $(call print-help,install_hooks,Installs the git hooks)
 HEADER_FILES=$(notdir $(HEADERS_PUB))
 .common_uninstall:
 	$(UNINSTALL_CMD) $(DESTDIR)$(LIBPATH)/$(LIBNAME)
-	rm $(HEADER_FILES:%=$(DESTDIR)$(INCPATH)/%)
+	$(UNINSTALL_CMD) $(HEADER_FILES:%=$(DESTDIR)$(INCPATH)/%)
 
 #This rule cleans the source tree of all compiled code, not including the pdf
 #documentation.
 clean: $(call print-help,clean,Clean everything besides the pdf documentation)
 	find . -type f    -name "*.o"   \
-               -o -name "*.lo"  \
-               -o -name "*.a"   \
-               -o -name "*.la"  \
-               -o -name "*.obj" \
-               -o -name "*.lib" \
-               -o -name "*.exe" \
-               -o -name "*.dll" \
-               -o -name "*.so"  \
-               -o -name "*.gcov"\
-               -o -name "*.gcda"\
-               -o -name "*.gcno"\
-               -o -name "*.il"  \
-               -o -name "*.dyn" \
+               -o -name "*.a"     \
+               -o -name "*.obj"   \
+               -o -name "*.lib"   \
+               -o -name "*.exe"   \
+               -o -name "*.dll*"  \
+               -o -name "*.dylib*"\
+               -o -name "*.so*"   \
+               -o -name "*.out"   \
+               -o -name "*.gcov"  \
+               -o -name "*.gcda"  \
+               -o -name "*.gcno"  \
+               -o -name "*.il"    \
+               -o -name "*.dyn"   \
                -o -name "*.dpi"  | xargs rm -f
 	rm -f $(TIMING) $(TEST) $(DEMOS)
 	rm -f *_tv.txt
 	rm -f *.pc
-	rm -rf `find . -type d -name "*.libs" | xargs`
+	rm -rf `find . -type d -name "*.bin" | xargs`
 	$(MAKE) -C doc/ clean
 
 zipup: $(call print-help,zipup,Prepare the archives for a release) doc/crypt.pdf


### PR DESCRIPTION
Gentoo Bug: https://bugs.gentoo.org/777084

This changes the `makefile.shared` build to not require libtool during the build instead of the existing hacks. This is helpful for avoiding the already existing hacks for slibtool. I am not sure this is the direction the libtomcrypt / libtommath projects want to go, but I am proposing it as an option.

Note: I tested this on Gentoo and Slackware linux, but there may be issues for other platforms I can't personally test and they should be tested first.
