### PR TITLE
contextualized extension of the Ed25519 scheme

### DIFF
--- a/doc/crypt.tex
+++ b/doc/crypt.tex
@@ -5909,25 +5909,49 @@ It has support for the following output formats:
 To sign and/or verify a message use the following functions:
 
 \index{ed25519\_sign}
+\index{ed25519ctx\_sign}
+\index{ed25519ph\_sign}
 \begin{verbatim}
-int ed25519_sign(const unsigned char  *msg, unsigned long msglen,
-                       unsigned char  *sig, unsigned long *siglen,
+int ed25519_sign(const  unsigned char *msg, unsigned long msglen,
+                        unsigned char *sig, unsigned long *siglen,
                  const curve25519_key *private_key);
+int ed25519ctx_sign(const  unsigned char *msg, unsigned long  msglen,
+                           unsigned char *sig, unsigned long *siglen,
+                    const  unsigned char *ctx, unsigned long  ctxlen,
+                    const curve25519_key *private_key);
+int ed25519ph_sign(const  unsigned char *msg, unsigned long  msglen,
+                          unsigned char *sig, unsigned long *siglen,
+                   const  unsigned char *ctx, unsigned long  ctxlen,
+                   const curve25519_key *private_key);
 \end{verbatim}
 
-This function will EdDSA sign the message stored in the array pointed to by \textit{msg} of length \textit{msglen} octets.  The signature
-will be stored in the array pointed to by \textit{sig} of length \textit{siglen} octets.
+These functions will EdDSA sign the message stored in the array pointed to by \textit{msg} of length \textit{msglen} octets.  The signature
+will be stored in the array pointed to by \textit{sig} of length \textit{siglen} octets.  The \texttt{ctx} and \texttt{ph} variants also
+allow passing a context \textit{ctx} of length \textit{ctxlen} octets.  This context is allowed to be max. 255 octets long.
 
 \index{ed25519\_verify}
+\index{ed25519ctx\_verify}
+\index{ed25519ph\_verify}
 \begin{verbatim}
 int ed25519_verify(const  unsigned char *msg, unsigned long msglen,
                    const  unsigned char *sig, unsigned long siglen,
-                   int *stat, const curve25519_key *public_key);
+                                    int *stat,
+                   const curve25519_key *public_key);
+int ed25519ctx_verify(const  unsigned char *msg, unsigned long msglen,
+                      const  unsigned char *sig, unsigned long siglen,
+                      const  unsigned char *ctx, unsigned long ctxlen,
+                                       int *stat,
+                      const curve25519_key *public_key);
+int ed25519ph_verify(const  unsigned char *msg, unsigned long msglen,
+                     const  unsigned char *sig, unsigned long siglen,
+                     const  unsigned char *ctx, unsigned long ctxlen,
+                                      int *stat,
+                     const curve25519_key *public_key);
 \end{verbatim}
 
-This function will verify the EdDSA signature in the array pointed to by \textit{sig} of length \textit{siglen} octets, against the message
+These functions will verify the EdDSA signature in the array pointed to by \textit{sig} of length \textit{siglen} octets, against the message
 pointed to by the array \textit{msg} of length \textit{msglen}. It will store a non--zero value in \textit{stat} if the signature is valid.  Note:
-the function will not return an error if the signature is invalid. It will return an error, if the actual signature payload is an invalid format.
+the function will not return an error if the signature is invalid. It will only return an error if the actual signature payload is an invalid format.
 
 
 \chapter{Digital Signature Algorithm}

--- a/libtomcrypt_VS2008.vcproj
+++ b/libtomcrypt_VS2008.vcproj
@@ -2327,6 +2327,10 @@
 				Name="ec25519"
 				>
 				<File
+					RelativePath="src\pk\ec25519\ec25519_crypto_ctx.c"
+					>
+				</File>
+				<File
 					RelativePath="src\pk\ec25519\ec25519_export.c"
 					>
 				</File>

--- a/makefile.mingw
+++ b/makefile.mingw
@@ -179,17 +179,17 @@ src/pk/dsa/dsa_decrypt_key.o src/pk/dsa/dsa_encrypt_key.o src/pk/dsa/dsa_export.
 src/pk/dsa/dsa_generate_key.o src/pk/dsa/dsa_generate_pqg.o src/pk/dsa/dsa_import.o \
 src/pk/dsa/dsa_make_key.o src/pk/dsa/dsa_set.o src/pk/dsa/dsa_set_pqg_dsaparam.o \
 src/pk/dsa/dsa_shared_secret.o src/pk/dsa/dsa_sign_hash.o src/pk/dsa/dsa_verify_hash.o \
-src/pk/dsa/dsa_verify_key.o src/pk/ec25519/ec25519_export.o src/pk/ec25519/ec25519_import_pkcs8.o \
-src/pk/ec25519/tweetnacl.o src/pk/ecc/ecc.o src/pk/ecc/ecc_ansi_x963_export.o \
-src/pk/ecc/ecc_ansi_x963_import.o src/pk/ecc/ecc_decrypt_key.o src/pk/ecc/ecc_encrypt_key.o \
-src/pk/ecc/ecc_export.o src/pk/ecc/ecc_export_openssl.o src/pk/ecc/ecc_find_curve.o \
-src/pk/ecc/ecc_free.o src/pk/ecc/ecc_get_key.o src/pk/ecc/ecc_get_oid_str.o src/pk/ecc/ecc_get_size.o \
-src/pk/ecc/ecc_import.o src/pk/ecc/ecc_import_openssl.o src/pk/ecc/ecc_import_pkcs8.o \
-src/pk/ecc/ecc_import_x509.o src/pk/ecc/ecc_make_key.o src/pk/ecc/ecc_recover_key.o \
-src/pk/ecc/ecc_set_curve.o src/pk/ecc/ecc_set_curve_internal.o src/pk/ecc/ecc_set_key.o \
-src/pk/ecc/ecc_shared_secret.o src/pk/ecc/ecc_sign_hash.o src/pk/ecc/ecc_sizes.o \
-src/pk/ecc/ecc_ssh_ecdsa_encode_name.o src/pk/ecc/ecc_verify_hash.o src/pk/ecc/ltc_ecc_export_point.o \
-src/pk/ecc/ltc_ecc_import_point.o src/pk/ecc/ltc_ecc_is_point.o \
+src/pk/dsa/dsa_verify_key.o src/pk/ec25519/ec25519_crypto_ctx.o src/pk/ec25519/ec25519_export.o \
+src/pk/ec25519/ec25519_import_pkcs8.o src/pk/ec25519/tweetnacl.o src/pk/ecc/ecc.o \
+src/pk/ecc/ecc_ansi_x963_export.o src/pk/ecc/ecc_ansi_x963_import.o src/pk/ecc/ecc_decrypt_key.o \
+src/pk/ecc/ecc_encrypt_key.o src/pk/ecc/ecc_export.o src/pk/ecc/ecc_export_openssl.o \
+src/pk/ecc/ecc_find_curve.o src/pk/ecc/ecc_free.o src/pk/ecc/ecc_get_key.o src/pk/ecc/ecc_get_oid_str.o \
+src/pk/ecc/ecc_get_size.o src/pk/ecc/ecc_import.o src/pk/ecc/ecc_import_openssl.o \
+src/pk/ecc/ecc_import_pkcs8.o src/pk/ecc/ecc_import_x509.o src/pk/ecc/ecc_make_key.o \
+src/pk/ecc/ecc_recover_key.o src/pk/ecc/ecc_set_curve.o src/pk/ecc/ecc_set_curve_internal.o \
+src/pk/ecc/ecc_set_key.o src/pk/ecc/ecc_shared_secret.o src/pk/ecc/ecc_sign_hash.o \
+src/pk/ecc/ecc_sizes.o src/pk/ecc/ecc_ssh_ecdsa_encode_name.o src/pk/ecc/ecc_verify_hash.o \
+src/pk/ecc/ltc_ecc_export_point.o src/pk/ecc/ltc_ecc_import_point.o src/pk/ecc/ltc_ecc_is_point.o \
 src/pk/ecc/ltc_ecc_is_point_at_infinity.o src/pk/ecc/ltc_ecc_map.o src/pk/ecc/ltc_ecc_mul2add.o \
 src/pk/ecc/ltc_ecc_mulmod.o src/pk/ecc/ltc_ecc_mulmod_timing.o src/pk/ecc/ltc_ecc_points.o \
 src/pk/ecc/ltc_ecc_projective_add_point.o src/pk/ecc/ltc_ecc_projective_dbl_point.o \

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -172,17 +172,17 @@ src/pk/dsa/dsa_decrypt_key.obj src/pk/dsa/dsa_encrypt_key.obj src/pk/dsa/dsa_exp
 src/pk/dsa/dsa_generate_key.obj src/pk/dsa/dsa_generate_pqg.obj src/pk/dsa/dsa_import.obj \
 src/pk/dsa/dsa_make_key.obj src/pk/dsa/dsa_set.obj src/pk/dsa/dsa_set_pqg_dsaparam.obj \
 src/pk/dsa/dsa_shared_secret.obj src/pk/dsa/dsa_sign_hash.obj src/pk/dsa/dsa_verify_hash.obj \
-src/pk/dsa/dsa_verify_key.obj src/pk/ec25519/ec25519_export.obj src/pk/ec25519/ec25519_import_pkcs8.obj \
-src/pk/ec25519/tweetnacl.obj src/pk/ecc/ecc.obj src/pk/ecc/ecc_ansi_x963_export.obj \
-src/pk/ecc/ecc_ansi_x963_import.obj src/pk/ecc/ecc_decrypt_key.obj src/pk/ecc/ecc_encrypt_key.obj \
-src/pk/ecc/ecc_export.obj src/pk/ecc/ecc_export_openssl.obj src/pk/ecc/ecc_find_curve.obj \
-src/pk/ecc/ecc_free.obj src/pk/ecc/ecc_get_key.obj src/pk/ecc/ecc_get_oid_str.obj src/pk/ecc/ecc_get_size.obj \
-src/pk/ecc/ecc_import.obj src/pk/ecc/ecc_import_openssl.obj src/pk/ecc/ecc_import_pkcs8.obj \
-src/pk/ecc/ecc_import_x509.obj src/pk/ecc/ecc_make_key.obj src/pk/ecc/ecc_recover_key.obj \
-src/pk/ecc/ecc_set_curve.obj src/pk/ecc/ecc_set_curve_internal.obj src/pk/ecc/ecc_set_key.obj \
-src/pk/ecc/ecc_shared_secret.obj src/pk/ecc/ecc_sign_hash.obj src/pk/ecc/ecc_sizes.obj \
-src/pk/ecc/ecc_ssh_ecdsa_encode_name.obj src/pk/ecc/ecc_verify_hash.obj src/pk/ecc/ltc_ecc_export_point.obj \
-src/pk/ecc/ltc_ecc_import_point.obj src/pk/ecc/ltc_ecc_is_point.obj \
+src/pk/dsa/dsa_verify_key.obj src/pk/ec25519/ec25519_crypto_ctx.obj src/pk/ec25519/ec25519_export.obj \
+src/pk/ec25519/ec25519_import_pkcs8.obj src/pk/ec25519/tweetnacl.obj src/pk/ecc/ecc.obj \
+src/pk/ecc/ecc_ansi_x963_export.obj src/pk/ecc/ecc_ansi_x963_import.obj src/pk/ecc/ecc_decrypt_key.obj \
+src/pk/ecc/ecc_encrypt_key.obj src/pk/ecc/ecc_export.obj src/pk/ecc/ecc_export_openssl.obj \
+src/pk/ecc/ecc_find_curve.obj src/pk/ecc/ecc_free.obj src/pk/ecc/ecc_get_key.obj src/pk/ecc/ecc_get_oid_str.obj \
+src/pk/ecc/ecc_get_size.obj src/pk/ecc/ecc_import.obj src/pk/ecc/ecc_import_openssl.obj \
+src/pk/ecc/ecc_import_pkcs8.obj src/pk/ecc/ecc_import_x509.obj src/pk/ecc/ecc_make_key.obj \
+src/pk/ecc/ecc_recover_key.obj src/pk/ecc/ecc_set_curve.obj src/pk/ecc/ecc_set_curve_internal.obj \
+src/pk/ecc/ecc_set_key.obj src/pk/ecc/ecc_shared_secret.obj src/pk/ecc/ecc_sign_hash.obj \
+src/pk/ecc/ecc_sizes.obj src/pk/ecc/ecc_ssh_ecdsa_encode_name.obj src/pk/ecc/ecc_verify_hash.obj \
+src/pk/ecc/ltc_ecc_export_point.obj src/pk/ecc/ltc_ecc_import_point.obj src/pk/ecc/ltc_ecc_is_point.obj \
 src/pk/ecc/ltc_ecc_is_point_at_infinity.obj src/pk/ecc/ltc_ecc_map.obj src/pk/ecc/ltc_ecc_mul2add.obj \
 src/pk/ecc/ltc_ecc_mulmod.obj src/pk/ecc/ltc_ecc_mulmod_timing.obj src/pk/ecc/ltc_ecc_points.obj \
 src/pk/ecc/ltc_ecc_projective_add_point.obj src/pk/ecc/ltc_ecc_projective_dbl_point.obj \

--- a/makefile.unix
+++ b/makefile.unix
@@ -189,17 +189,17 @@ src/pk/dsa/dsa_decrypt_key.o src/pk/dsa/dsa_encrypt_key.o src/pk/dsa/dsa_export.
 src/pk/dsa/dsa_generate_key.o src/pk/dsa/dsa_generate_pqg.o src/pk/dsa/dsa_import.o \
 src/pk/dsa/dsa_make_key.o src/pk/dsa/dsa_set.o src/pk/dsa/dsa_set_pqg_dsaparam.o \
 src/pk/dsa/dsa_shared_secret.o src/pk/dsa/dsa_sign_hash.o src/pk/dsa/dsa_verify_hash.o \
-src/pk/dsa/dsa_verify_key.o src/pk/ec25519/ec25519_export.o src/pk/ec25519/ec25519_import_pkcs8.o \
-src/pk/ec25519/tweetnacl.o src/pk/ecc/ecc.o src/pk/ecc/ecc_ansi_x963_export.o \
-src/pk/ecc/ecc_ansi_x963_import.o src/pk/ecc/ecc_decrypt_key.o src/pk/ecc/ecc_encrypt_key.o \
-src/pk/ecc/ecc_export.o src/pk/ecc/ecc_export_openssl.o src/pk/ecc/ecc_find_curve.o \
-src/pk/ecc/ecc_free.o src/pk/ecc/ecc_get_key.o src/pk/ecc/ecc_get_oid_str.o src/pk/ecc/ecc_get_size.o \
-src/pk/ecc/ecc_import.o src/pk/ecc/ecc_import_openssl.o src/pk/ecc/ecc_import_pkcs8.o \
-src/pk/ecc/ecc_import_x509.o src/pk/ecc/ecc_make_key.o src/pk/ecc/ecc_recover_key.o \
-src/pk/ecc/ecc_set_curve.o src/pk/ecc/ecc_set_curve_internal.o src/pk/ecc/ecc_set_key.o \
-src/pk/ecc/ecc_shared_secret.o src/pk/ecc/ecc_sign_hash.o src/pk/ecc/ecc_sizes.o \
-src/pk/ecc/ecc_ssh_ecdsa_encode_name.o src/pk/ecc/ecc_verify_hash.o src/pk/ecc/ltc_ecc_export_point.o \
-src/pk/ecc/ltc_ecc_import_point.o src/pk/ecc/ltc_ecc_is_point.o \
+src/pk/dsa/dsa_verify_key.o src/pk/ec25519/ec25519_crypto_ctx.o src/pk/ec25519/ec25519_export.o \
+src/pk/ec25519/ec25519_import_pkcs8.o src/pk/ec25519/tweetnacl.o src/pk/ecc/ecc.o \
+src/pk/ecc/ecc_ansi_x963_export.o src/pk/ecc/ecc_ansi_x963_import.o src/pk/ecc/ecc_decrypt_key.o \
+src/pk/ecc/ecc_encrypt_key.o src/pk/ecc/ecc_export.o src/pk/ecc/ecc_export_openssl.o \
+src/pk/ecc/ecc_find_curve.o src/pk/ecc/ecc_free.o src/pk/ecc/ecc_get_key.o src/pk/ecc/ecc_get_oid_str.o \
+src/pk/ecc/ecc_get_size.o src/pk/ecc/ecc_import.o src/pk/ecc/ecc_import_openssl.o \
+src/pk/ecc/ecc_import_pkcs8.o src/pk/ecc/ecc_import_x509.o src/pk/ecc/ecc_make_key.o \
+src/pk/ecc/ecc_recover_key.o src/pk/ecc/ecc_set_curve.o src/pk/ecc/ecc_set_curve_internal.o \
+src/pk/ecc/ecc_set_key.o src/pk/ecc/ecc_shared_secret.o src/pk/ecc/ecc_sign_hash.o \
+src/pk/ecc/ecc_sizes.o src/pk/ecc/ecc_ssh_ecdsa_encode_name.o src/pk/ecc/ecc_verify_hash.o \
+src/pk/ecc/ltc_ecc_export_point.o src/pk/ecc/ltc_ecc_import_point.o src/pk/ecc/ltc_ecc_is_point.o \
 src/pk/ecc/ltc_ecc_is_point_at_infinity.o src/pk/ecc/ltc_ecc_map.o src/pk/ecc/ltc_ecc_mul2add.o \
 src/pk/ecc/ltc_ecc_mulmod.o src/pk/ecc/ltc_ecc_mulmod_timing.o src/pk/ecc/ltc_ecc_points.o \
 src/pk/ecc/ltc_ecc_projective_add_point.o src/pk/ecc/ltc_ecc_projective_dbl_point.o \

--- a/makefile_include.mk
+++ b/makefile_include.mk
@@ -350,17 +350,17 @@ src/pk/dsa/dsa_decrypt_key.o src/pk/dsa/dsa_encrypt_key.o src/pk/dsa/dsa_export.
 src/pk/dsa/dsa_generate_key.o src/pk/dsa/dsa_generate_pqg.o src/pk/dsa/dsa_import.o \
 src/pk/dsa/dsa_make_key.o src/pk/dsa/dsa_set.o src/pk/dsa/dsa_set_pqg_dsaparam.o \
 src/pk/dsa/dsa_shared_secret.o src/pk/dsa/dsa_sign_hash.o src/pk/dsa/dsa_verify_hash.o \
-src/pk/dsa/dsa_verify_key.o src/pk/ec25519/ec25519_export.o src/pk/ec25519/ec25519_import_pkcs8.o \
-src/pk/ec25519/tweetnacl.o src/pk/ecc/ecc.o src/pk/ecc/ecc_ansi_x963_export.o \
-src/pk/ecc/ecc_ansi_x963_import.o src/pk/ecc/ecc_decrypt_key.o src/pk/ecc/ecc_encrypt_key.o \
-src/pk/ecc/ecc_export.o src/pk/ecc/ecc_export_openssl.o src/pk/ecc/ecc_find_curve.o \
-src/pk/ecc/ecc_free.o src/pk/ecc/ecc_get_key.o src/pk/ecc/ecc_get_oid_str.o src/pk/ecc/ecc_get_size.o \
-src/pk/ecc/ecc_import.o src/pk/ecc/ecc_import_openssl.o src/pk/ecc/ecc_import_pkcs8.o \
-src/pk/ecc/ecc_import_x509.o src/pk/ecc/ecc_make_key.o src/pk/ecc/ecc_recover_key.o \
-src/pk/ecc/ecc_set_curve.o src/pk/ecc/ecc_set_curve_internal.o src/pk/ecc/ecc_set_key.o \
-src/pk/ecc/ecc_shared_secret.o src/pk/ecc/ecc_sign_hash.o src/pk/ecc/ecc_sizes.o \
-src/pk/ecc/ecc_ssh_ecdsa_encode_name.o src/pk/ecc/ecc_verify_hash.o src/pk/ecc/ltc_ecc_export_point.o \
-src/pk/ecc/ltc_ecc_import_point.o src/pk/ecc/ltc_ecc_is_point.o \
+src/pk/dsa/dsa_verify_key.o src/pk/ec25519/ec25519_crypto_ctx.o src/pk/ec25519/ec25519_export.o \
+src/pk/ec25519/ec25519_import_pkcs8.o src/pk/ec25519/tweetnacl.o src/pk/ecc/ecc.o \
+src/pk/ecc/ecc_ansi_x963_export.o src/pk/ecc/ecc_ansi_x963_import.o src/pk/ecc/ecc_decrypt_key.o \
+src/pk/ecc/ecc_encrypt_key.o src/pk/ecc/ecc_export.o src/pk/ecc/ecc_export_openssl.o \
+src/pk/ecc/ecc_find_curve.o src/pk/ecc/ecc_free.o src/pk/ecc/ecc_get_key.o src/pk/ecc/ecc_get_oid_str.o \
+src/pk/ecc/ecc_get_size.o src/pk/ecc/ecc_import.o src/pk/ecc/ecc_import_openssl.o \
+src/pk/ecc/ecc_import_pkcs8.o src/pk/ecc/ecc_import_x509.o src/pk/ecc/ecc_make_key.o \
+src/pk/ecc/ecc_recover_key.o src/pk/ecc/ecc_set_curve.o src/pk/ecc/ecc_set_curve_internal.o \
+src/pk/ecc/ecc_set_key.o src/pk/ecc/ecc_shared_secret.o src/pk/ecc/ecc_sign_hash.o \
+src/pk/ecc/ecc_sizes.o src/pk/ecc/ecc_ssh_ecdsa_encode_name.o src/pk/ecc/ecc_verify_hash.o \
+src/pk/ecc/ltc_ecc_export_point.o src/pk/ecc/ltc_ecc_import_point.o src/pk/ecc/ltc_ecc_is_point.o \
 src/pk/ecc/ltc_ecc_is_point_at_infinity.o src/pk/ecc/ltc_ecc_map.o src/pk/ecc/ltc_ecc_mul2add.o \
 src/pk/ecc/ltc_ecc_mulmod.o src/pk/ecc/ltc_ecc_mulmod_timing.o src/pk/ecc/ltc_ecc_points.o \
 src/pk/ecc/ltc_ecc_projective_add_point.o src/pk/ecc/ltc_ecc_projective_dbl_point.o \

--- a/src/headers/tomcrypt_pk.h
+++ b/src/headers/tomcrypt_pk.h
@@ -355,25 +355,30 @@ int ed25519_import_pkcs8(const unsigned char *in, unsigned long inlen,
                                   const void *pwd, unsigned long pwdlen,
                               curve25519_key *key);
 
-int ed25519_sign(const unsigned char  *msg, unsigned long msglen,
-                       unsigned char  *sig, unsigned long *siglen,
+int ed25519_sign(const  unsigned char *msg, unsigned long msglen,
+                        unsigned char *sig, unsigned long *siglen,
                  const curve25519_key *private_key);
-int ed25519ctx_sign(const unsigned char *msg, unsigned long msglen,
-                    unsigned char *sig, unsigned long *siglen,
-                    const char* ctx, const curve25519_key *private_key);
-int ed25519ph_sign(const unsigned char *msg, unsigned long msglen,
-                   unsigned char *sig, unsigned long *siglen,
-                   const char *ctx, const curve25519_key *private_key);
+int ed25519ctx_sign(const  unsigned char *msg, unsigned long  msglen,
+                           unsigned char *sig, unsigned long *siglen,
+                    const  unsigned char *ctx, unsigned long  ctxlen,
+                    const curve25519_key *private_key);
+int ed25519ph_sign(const  unsigned char *msg, unsigned long  msglen,
+                          unsigned char *sig, unsigned long *siglen,
+                   const  unsigned char *ctx, unsigned long  ctxlen,
+                   const curve25519_key *private_key);
 int ed25519_verify(const  unsigned char *msg, unsigned long msglen,
                    const  unsigned char *sig, unsigned long siglen,
-                   int *stat, const curve25519_key *public_key);
+                                    int *stat,
+                   const curve25519_key *public_key);
 int ed25519ctx_verify(const  unsigned char *msg, unsigned long msglen,
                       const  unsigned char *sig, unsigned long siglen,
-                      int *stat, const char* ctx,
+                      const  unsigned char *ctx, unsigned long ctxlen,
+                                       int *stat,
                       const curve25519_key *public_key);
 int ed25519ph_verify(const  unsigned char *msg, unsigned long msglen,
                      const  unsigned char *sig, unsigned long siglen,
-                     int *stat, const char* ctx,
+                     const  unsigned char *ctx, unsigned long ctxlen,
+                                      int *stat,
                      const curve25519_key *public_key);
 
 /** X25519 Key-Exchange API */

--- a/src/headers/tomcrypt_pk.h
+++ b/src/headers/tomcrypt_pk.h
@@ -358,10 +358,23 @@ int ed25519_import_pkcs8(const unsigned char *in, unsigned long inlen,
 int ed25519_sign(const unsigned char  *msg, unsigned long msglen,
                        unsigned char  *sig, unsigned long *siglen,
                  const curve25519_key *private_key);
-
+int ed25519ctx_sign(const unsigned char *msg, unsigned long msglen,
+                    unsigned char *sig, unsigned long *siglen,
+                    const char* ctx, const curve25519_key *private_key);
+int ed25519ph_sign(const unsigned char *msg, unsigned long msglen,
+                   unsigned char *sig, unsigned long *siglen,
+                   const char *ctx, const curve25519_key *private_key);
 int ed25519_verify(const  unsigned char *msg, unsigned long msglen,
                    const  unsigned char *sig, unsigned long siglen,
                    int *stat, const curve25519_key *public_key);
+int ed25519ctx_verify(const  unsigned char *msg, unsigned long msglen,
+                      const  unsigned char *sig, unsigned long siglen,
+                      int *stat, const char* ctx,
+                      const curve25519_key *public_key);
+int ed25519ph_verify(const  unsigned char *msg, unsigned long msglen,
+                     const  unsigned char *sig, unsigned long siglen,
+                     int *stat, const char* ctx,
+                     const curve25519_key *public_key);
 
 /** X25519 Key-Exchange API */
 int x25519_make_key(prng_state *prng, int wprng, curve25519_key *key);

--- a/src/headers/tomcrypt_private.h
+++ b/src/headers/tomcrypt_private.h
@@ -9,8 +9,6 @@
 
 #define LTC_PAD_MASK       (0xF000U)
 
-#define ED25519_CONTEXT_PREFIX "SigEd25519 no Ed25519 collisions"
-
 /*
  * Internal Enums
  */
@@ -346,8 +344,6 @@ int tweetnacl_crypto_sk_to_pk(unsigned char *pk, const unsigned char *sk);
 int tweetnacl_crypto_scalarmult(unsigned char *q, const unsigned char *n, const unsigned char *p);
 int tweetnacl_crypto_scalarmult_base(unsigned char *q,const unsigned char *n);
 int tweetnacl_crypto_ph(unsigned char *out, const unsigned char *msg, unsigned long msglen);
-int tweetnacl_crypto_ctx(unsigned char *out, unsigned long *outlen,
-                       unsigned char flag, const char *pr, const char* ctx);
 
 typedef int (*sk_to_pk)(unsigned char *pk ,const unsigned char *sk);
 int ec25519_import_pkcs8(const unsigned char *in, unsigned long inlen,
@@ -357,6 +353,9 @@ int ec25519_import_pkcs8(const unsigned char *in, unsigned long inlen,
 int ec25519_export(       unsigned char *out, unsigned long *outlen,
                                     int  which,
                    const curve25519_key *key);
+int ec25519_crypto_ctx(      unsigned char *out, unsigned long *outlen,
+                             unsigned char flag,
+                       const unsigned char *ctx, unsigned long  ctxlen);
 #endif /* LTC_CURVE25519 */
 
 #ifdef LTC_DER

--- a/src/headers/tomcrypt_private.h
+++ b/src/headers/tomcrypt_private.h
@@ -9,6 +9,8 @@
 
 #define LTC_PAD_MASK       (0xF000U)
 
+#define ED25519_CONTEXT_PREFIX "SigEd25519 no Ed25519 collisions"
+
 /*
  * Internal Enums
  */
@@ -331,16 +333,21 @@ int dsa_int_validate_primes(const dsa_key *key, int *stat);
 int tweetnacl_crypto_sign(
   unsigned char *sm,unsigned long long *smlen,
   const unsigned char *m,unsigned long long mlen,
-  const unsigned char *sk, const unsigned char *pk);
+  const unsigned char *sk,const unsigned char *pk,
+  const unsigned char *ctx,unsigned long long cs);
 int tweetnacl_crypto_sign_open(
   int *stat,
   unsigned char *m,unsigned long long *mlen,
   const unsigned char *sm,unsigned long long smlen,
+  const unsigned char *ctx, unsigned long cs,
   const unsigned char *pk);
 int tweetnacl_crypto_sign_keypair(prng_state *prng, int wprng, unsigned char *pk,unsigned char *sk);
 int tweetnacl_crypto_sk_to_pk(unsigned char *pk, const unsigned char *sk);
 int tweetnacl_crypto_scalarmult(unsigned char *q, const unsigned char *n, const unsigned char *p);
 int tweetnacl_crypto_scalarmult_base(unsigned char *q,const unsigned char *n);
+int tweetnacl_crypto_ph(unsigned char *out, const unsigned char *msg, unsigned long msglen);
+int tweetnacl_crypto_ctx(unsigned char *out, unsigned long *outlen,
+                       unsigned char flag, const char *pr, const char* ctx);
 
 typedef int (*sk_to_pk)(unsigned char *pk ,const unsigned char *sk);
 int ec25519_import_pkcs8(const unsigned char *in, unsigned long inlen,

--- a/src/pk/ec25519/ec25519_crypto_ctx.c
+++ b/src/pk/ec25519/ec25519_crypto_ctx.c
@@ -1,0 +1,40 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis */
+/* SPDX-License-Identifier: Unlicense */
+#include "tomcrypt_private.h"
+
+/**
+  @file ec25519_crypto_ctx.c
+  curve25519 crypto context helper
+*/
+
+#ifdef LTC_CURVE25519
+
+int ec25519_crypto_ctx(unsigned char *out, unsigned long *outlen, unsigned char flag, const unsigned char *ctx, unsigned long ctxlen)
+{
+  unsigned char *buf = out;
+
+  const char *prefix = "SigEd25519 no Ed25519 collisions";
+  const unsigned long prefix_len = XSTRLEN(prefix);
+  const unsigned char ctxlen8 = (unsigned char)ctxlen;
+
+  if (ctxlen > 255u) return CRYPT_INPUT_TOO_LONG;
+  if (*outlen < prefix_len + 2u + ctxlen) return CRYPT_BUFFER_OVERFLOW;
+
+  XMEMCPY(buf, prefix, prefix_len);
+  buf += prefix_len;
+  XMEMCPY(buf, &flag, 1);
+  buf++;
+  XMEMCPY(buf, &ctxlen8, 1);
+  buf++;
+
+  if (ctxlen > 0u) {
+    XMEMCPY(buf, ctx, ctxlen);
+    buf += ctxlen;
+  }
+
+  *outlen = buf-out;
+
+  return CRYPT_OK;
+}
+
+#endif

--- a/src/pk/ec25519/tweetnacl.c
+++ b/src/pk/ec25519/tweetnacl.c
@@ -504,40 +504,5 @@ int tweetnacl_crypto_sign_open(int *stat, u8 *m,u64 *mlen,const u8 *sm,u64 smlen
 
 int tweetnacl_crypto_ph(u8 *out,const u8 *msg,size_t msglen)
 {
-  hash_state md;
-
-  sha512_init(&md);
-
-  if(sha512_process(&md, msg, msglen) != CRYPT_OK)
-    return CRYPT_INVALID_ARG;
-
-  if(sha512_done(&md, out) != CRYPT_OK)
-    return CRYPT_INVALID_ARG;
-
-  return CRYPT_OK;
-}
-
-int tweetnacl_crypto_ctx(u8 *out,size_t *outlen,u8 flag,const char *pr, const char *ctx)
-{
-  u8 *buf = out;
-  const int ctx_prefix_len = strlen(pr);
-  const int ctxlen = ctx ? strlen(ctx) : 0;
-
-  if(ctxlen > 255) return CRYPT_INPUT_TOO_LONG;
-
-  XMEMCPY(buf, pr, ctx_prefix_len);
-  buf += ctx_prefix_len;
-  XMEMCPY(buf, &flag, 1);
-  buf++;
-  XMEMCPY(buf, &ctxlen, 1);
-  buf++;
-
-  if(ctxlen > 0) {
-    XMEMCPY(buf, ctx, ctxlen);
-    buf += ctxlen;
-  }
-
-  *outlen = buf-out;
-
-  return CRYPT_OK;
+  return tweetnacl_crypto_hash(out, msg, msglen);
 }

--- a/src/pk/ec25519/tweetnacl.c
+++ b/src/pk/ec25519/tweetnacl.c
@@ -235,6 +235,27 @@ static int tweetnacl_crypto_hash(u8 *out,const u8 *m,u64 n)
   return 0;
 }
 
+static int tweetnacl_crypto_hash_ctx(u8 *out,const u8 *m,u64 n,const u8 *ctx,u32 cs)
+{
+  unsigned long len;
+  int err;
+  u8 buf[512];
+
+  if(cs == 0)
+    return tweetnacl_crypto_hash(out,m,n);
+
+  len = n + cs;
+  if (len > 512) return CRYPT_HASH_OVERFLOW;
+
+  XMEMCPY(buf,ctx,cs);
+  XMEMCPY(buf+cs,m,n);
+
+  err = tweetnacl_crypto_hash(out,buf,len);
+  zeromem(buf, len);
+
+  return err;
+}
+
 sv add(gf p[4],gf q[4])
 {
   gf a,b,c,d,t,e,f,g,h;
@@ -376,7 +397,7 @@ sv reduce(u8 *r)
   modL(r,x);
 }
 
-int tweetnacl_crypto_sign(u8 *sm,u64 *smlen,const u8 *m,u64 mlen,const u8 *sk,const u8 *pk)
+int tweetnacl_crypto_sign(u8 *sm,u64 *smlen,const u8 *m,u64 mlen,const u8 *sk,const u8 *pk, const u8 *ctx, u64 cs)
 {
   u8 d[64],h[64],r[64];
   i64 i,j,x[64];
@@ -391,13 +412,13 @@ int tweetnacl_crypto_sign(u8 *sm,u64 *smlen,const u8 *m,u64 mlen,const u8 *sk,co
   FOR(i,(i64)mlen) sm[64 + i] = m[i];
   FOR(i,32) sm[32 + i] = d[32 + i];
 
-  tweetnacl_crypto_hash(r, sm+32, mlen+32);
+  tweetnacl_crypto_hash_ctx(r, sm+32, mlen+32,ctx,cs);
   reduce(r);
   scalarbase(p,r);
   pack(sm,p);
 
   FOR(i,32) sm[i+32] = pk[i];
-  tweetnacl_crypto_hash(h,sm,mlen + 64);
+  tweetnacl_crypto_hash_ctx(h,sm,mlen + 64,ctx,cs);
   reduce(h);
 
   FOR(i,64) x[i] = 0;
@@ -444,7 +465,7 @@ static int unpackneg(gf r[4],const u8 p[32])
   return 0;
 }
 
-int tweetnacl_crypto_sign_open(int *stat, u8 *m,u64 *mlen,const u8 *sm,u64 smlen,const u8 *pk)
+int tweetnacl_crypto_sign_open(int *stat, u8 *m,u64 *mlen,const u8 *sm,u64 smlen,const u8 *ctx,size_t cs,const u8 *pk)
 {
   u64 i;
   u8 s[32],t[32],h[64];
@@ -460,7 +481,7 @@ int tweetnacl_crypto_sign_open(int *stat, u8 *m,u64 *mlen,const u8 *sm,u64 smlen
   XMEMMOVE(m,sm,smlen);
   XMEMMOVE(s,m + 32,32);
   XMEMMOVE(m + 32,pk,32);
-  tweetnacl_crypto_hash(h,m,smlen);
+  tweetnacl_crypto_hash_ctx(h,m,smlen,ctx,cs);
   reduce(h);
   scalarmult(p,q,h);
 
@@ -478,5 +499,45 @@ int tweetnacl_crypto_sign_open(int *stat, u8 *m,u64 *mlen,const u8 *sm,u64 smlen
   *stat = 1;
   XMEMMOVE(m,m + 64,smlen);
   *mlen = smlen;
+  return CRYPT_OK;
+}
+
+int tweetnacl_crypto_ph(u8 *out,const u8 *msg,size_t msglen)
+{
+  hash_state md;
+
+  sha512_init(&md);
+
+  if(sha512_process(&md, msg, msglen) != CRYPT_OK)
+    return CRYPT_INVALID_ARG;
+
+  if(sha512_done(&md, out) != CRYPT_OK)
+    return CRYPT_INVALID_ARG;
+
+  return CRYPT_OK;
+}
+
+int tweetnacl_crypto_ctx(u8 *out,size_t *outlen,u8 flag,const char *pr, const char *ctx)
+{
+  u8 *buf = out;
+  const int ctx_prefix_len = strlen(pr);
+  const int ctxlen = ctx ? strlen(ctx) : 0;
+
+  if(ctxlen > 255) return CRYPT_INPUT_TOO_LONG;
+
+  XMEMCPY(buf, pr, ctx_prefix_len);
+  buf += ctx_prefix_len;
+  XMEMCPY(buf, &flag, 1);
+  buf++;
+  XMEMCPY(buf, &ctxlen, 1);
+  buf++;
+
+  if(ctxlen > 0) {
+    XMEMCPY(buf, ctx, ctxlen);
+    buf += ctxlen;
+  }
+
+  *outlen = buf-out;
+
   return CRYPT_OK;
 }

--- a/src/pk/ed25519/ed25519_sign.c
+++ b/src/pk/ed25519/ed25519_sign.c
@@ -9,9 +9,9 @@
 
 #ifdef LTC_CURVE25519
 
-static int ed25519_sign_private(const unsigned char *msg, unsigned long msglen,
-                       unsigned char *sig, unsigned long *siglen,
-                          const char* ctx, unsigned long ctxlen,
+static int s_ed25519_sign(const unsigned char  *msg, unsigned long  msglen,
+                                unsigned char  *sig, unsigned long *siglen,
+                          const unsigned char  *ctx, unsigned long  ctxlen,
                           const curve25519_key *private_key)
 {
    unsigned char *s;
@@ -61,21 +61,21 @@ static int ed25519_sign_private(const unsigned char *msg, unsigned long msglen,
    @param private_key     The private Ed25519 key in the pair
    @return CRYPT_OK if successful
 */
-int ed25519ctx_sign(const unsigned char *msg, unsigned long msglen,
-                          unsigned char *sig, unsigned long *siglen,
-                    const char* ctx, const curve25519_key *private_key)
+int ed25519ctx_sign(const  unsigned char *msg, unsigned long  msglen,
+                           unsigned char *sig, unsigned long *siglen,
+                    const  unsigned char *ctx, unsigned long  ctxlen,
+                    const curve25519_key *private_key)
 {
+   int err;
    unsigned char ctx_prefix[512] = {0};
-   unsigned long ctx_prefix_size = 0;
+   unsigned long ctx_prefix_size = sizeof(ctx_prefix);
 
    LTC_ARGCHK(ctx != NULL);
 
-   if(tweetnacl_crypto_ctx(ctx_prefix, &ctx_prefix_size, 0,
-                           ED25519_CONTEXT_PREFIX, ctx) != CRYPT_OK)
-      return CRYPT_INVALID_ARG;
+   if ((err = ec25519_crypto_ctx(ctx_prefix, &ctx_prefix_size, 0, ctx, ctxlen)) != CRYPT_OK)
+      return err;
 
-   return ed25519_sign_private(msg, msglen, sig, siglen, ctx_prefix,
-                               ctx_prefix_size, private_key);
+   return s_ed25519_sign(msg, msglen, sig, siglen, ctx_prefix, ctx_prefix_size, private_key);
 }
 
 /**
@@ -88,26 +88,26 @@ int ed25519ctx_sign(const unsigned char *msg, unsigned long msglen,
    @param private_key     The private Ed25519 key in the pair
    @return CRYPT_OK if successful
 */
-int ed25519ph_sign(const unsigned char *msg, unsigned long msglen,
-                         unsigned char *sig, unsigned long *siglen,
-                   const char *ctx, const curve25519_key *private_key)
+int ed25519ph_sign(const  unsigned char *msg, unsigned long  msglen,
+                          unsigned char *sig, unsigned long *siglen,
+                   const  unsigned char *ctx, unsigned long  ctxlen,
+                   const curve25519_key *private_key)
 {
+   int err;
    unsigned char ctx_prefix[512] = {0};
    unsigned char msg_hash[64] = {0};
-   unsigned long ctx_prefix_size = 0;
+   unsigned long ctx_prefix_size = sizeof(ctx_prefix);
 
-   if (tweetnacl_crypto_ctx(ctx_prefix, &ctx_prefix_size, 1,
-                            ED25519_CONTEXT_PREFIX, ctx) != CRYPT_OK)
-      return CRYPT_INVALID_ARG;
+   if ((err = ec25519_crypto_ctx(ctx_prefix, &ctx_prefix_size, 1, ctx, ctxlen)) != CRYPT_OK)
+      return err;
 
-   if (tweetnacl_crypto_ph(msg_hash, msg, msglen) != CRYPT_OK)
-      return CRYPT_INVALID_ARG;
+   if ((err = tweetnacl_crypto_ph(msg_hash, msg, msglen)) != CRYPT_OK)
+      return err;
 
    msg = msg_hash;
    msglen = 64;
 
-   return ed25519_sign_private(msg, msglen, sig, siglen, ctx_prefix,
-                               ctx_prefix_size, private_key);
+   return s_ed25519_sign(msg, msglen, sig, siglen, ctx_prefix, ctx_prefix_size, private_key);
 }
 
 /**
@@ -119,11 +119,11 @@ int ed25519ph_sign(const unsigned char *msg, unsigned long msglen,
    @param private_key     The private Ed25519 key in the pair
    @return CRYPT_OK if successful
 */
-int ed25519_sign(const unsigned char *msg, unsigned long msglen,
-                       unsigned char *sig, unsigned long *siglen,
+int ed25519_sign(const  unsigned char *msg, unsigned long msglen,
+                        unsigned char *sig, unsigned long *siglen,
                  const curve25519_key *private_key)
 {
-   return ed25519_sign_private(msg, msglen, sig, siglen, 0, 0, private_key);
+   return s_ed25519_sign(msg, msglen, sig, siglen, NULL, 0, private_key);
 }
 
 #endif

--- a/src/pk/ed25519/ed25519_verify.c
+++ b/src/pk/ed25519/ed25519_verify.c
@@ -9,12 +9,11 @@
 
 #ifdef LTC_CURVE25519
 
-static int ed25519_verify_private(
-                   const unsigned char *msg, unsigned long msglen,
-                   const unsigned char *sig, unsigned long siglen,
-                   int *stat,
-                   const char *ctx, unsigned long ctxlen,
-                   const curve25519_key *public_key)
+static int s_ed25519_verify(const  unsigned char *msg, unsigned long msglen,
+                            const  unsigned char *sig, unsigned long siglen,
+                            const  unsigned char *ctx, unsigned long ctxlen,
+                                             int *stat,
+                            const curve25519_key *public_key)
 {
    unsigned char* m;
    unsigned long long mlen;
@@ -46,7 +45,7 @@ static int ed25519_verify_private(
                                     public_key->pub);
 
 #ifdef LTC_CLEAN_STACK
-   zeromem(m, mlen);
+   zeromem(m, msglen + siglen);
 #endif
    XFREE(m);
 
@@ -54,82 +53,85 @@ static int ed25519_verify_private(
 }
 
 /**
-   Verify an Ed25519 signature.
+   Verify an Ed25519ctx signature.
+   @param msg             [in] The data to be verified
+   @param msglen          [in] The size of the data to be verified
    @param sig             [in] The signature to be verified
    @param siglen          [in] The size of the signature to be verified
+   @param ctx             [in] The context
+   @param ctxlen          [in] The size of the context
    @param stat            [out] The result of the signature verification, 1==valid, 0==invalid
-   @param ctx             [in] The context is a constant null terminated string
    @param public_key      [in] The public Ed25519 key in the pair
    @return CRYPT_OK if successful
 */
-int ed25519ctx_verify(const unsigned char *msg, unsigned long msglen,
-                      const unsigned char *sig, unsigned long siglen,
-                      int *stat, const char *ctx,
+int ed25519ctx_verify(const  unsigned char *msg, unsigned long msglen,
+                      const  unsigned char *sig, unsigned long siglen,
+                      const  unsigned char *ctx, unsigned long ctxlen,
+                                       int *stat,
                       const curve25519_key *public_key)
 {
    unsigned char ctx_prefix[512] = {0};
-   unsigned long ctx_prefix_size = 0;
+   unsigned long ctx_prefix_size = sizeof(ctx_prefix);
 
    LTC_ARGCHK(ctx != NULL);
 
-   if(tweetnacl_crypto_ctx(ctx_prefix, &ctx_prefix_size, 0,
-                           ED25519_CONTEXT_PREFIX, ctx) != CRYPT_OK)
+   if (ec25519_crypto_ctx(ctx_prefix, &ctx_prefix_size, 0, ctx, ctxlen) != CRYPT_OK)
       return CRYPT_INVALID_ARG;
 
-   return ed25519_verify_private(msg, msglen, sig, siglen, stat,
-                                 ctx_prefix, ctx_prefix_size, public_key);
+   return s_ed25519_verify(msg, msglen, sig, siglen, ctx_prefix, ctx_prefix_size, stat, public_key);
 }
 
 /**
-   Verify an Ed25519 signature.
-   @param msg             [in] The data to be signed
-   @param msglen          [in] The size of the data to be signed
+   Verify an Ed25519ph signature.
+   @param msg             [in] The data to be verified
+   @param msglen          [in] The size of the data to be verified
    @param sig             [in] The signature to be verified
    @param siglen          [in] The size of the signature to be verified
+   @param ctx             [in] The context
+   @param ctxlen          [in] The size of the context
    @param stat            [out] The result of the signature verification, 1==valid, 0==invalid
-   @param ctx             [in] The context is a constant null terminated string
    @param public_key      [in] The public Ed25519 key in the pair
    @return CRYPT_OK if successful
 */
-int ed25519ph_verify(const unsigned char *msg, unsigned long msglen,
-                     const unsigned char *sig, unsigned long siglen,
-                     int *stat, const char *ctx,
+int ed25519ph_verify(const  unsigned char *msg, unsigned long msglen,
+                     const  unsigned char *sig, unsigned long siglen,
+                     const  unsigned char *ctx, unsigned long ctxlen,
+                                      int *stat,
                      const curve25519_key *public_key)
 {
+   int err;
    unsigned char ctx_prefix[512] = {0};
    unsigned char msg_hash[64] = {0};
-   unsigned long ctx_prefix_size = 0;
+   unsigned long ctx_prefix_size = sizeof(ctx_prefix);
 
-   if(tweetnacl_crypto_ctx(ctx_prefix, &ctx_prefix_size, 1,
-                           ED25519_CONTEXT_PREFIX, ctx) != CRYPT_OK)
-      return CRYPT_INVALID_ARG;
+   if ((err = ec25519_crypto_ctx(ctx_prefix, &ctx_prefix_size, 1, ctx, ctxlen)) != CRYPT_OK)
+      return err;
 
-   if (tweetnacl_crypto_ph(msg_hash, msg, msglen) != CRYPT_OK)
-      return CRYPT_INVALID_ARG;
+   if ((err = tweetnacl_crypto_ph(msg_hash, msg, msglen)) != CRYPT_OK)
+      return err;
 
    msg = msg_hash;
    msglen = 64;
 
-   return ed25519_verify_private(msg, msglen, sig, siglen, stat,
-                                 ctx_prefix, ctx_prefix_size, public_key);
+   return s_ed25519_verify(msg, msglen, sig, siglen, ctx_prefix, ctx_prefix_size, stat, public_key);
 }
 
 /**
    Verify an Ed25519 signature.
-   @param msg             [in] The data to be signed
-   @param msglen          [in] The size of the data to be signed
+   @param msg             [in] The data to be verified
+   @param msglen          [in] The size of the data to be verified
    @param sig             [in] The signature to be verified
    @param siglen          [in] The size of the signature to be verified
    @param stat            [out] The result of the signature verification, 1==valid, 0==invalid
    @param public_key      [in] The public Ed25519 key in the pair
    @return CRYPT_OK if successful
 */
-int ed25519_verify(const unsigned char *msg, unsigned long msglen,
-                   const unsigned char *sig, unsigned long siglen,
-                   int *stat, const curve25519_key *public_key)
+int ed25519_verify(const  unsigned char *msg, unsigned long msglen,
+                   const  unsigned char *sig, unsigned long siglen,
+                                    int *stat,
+                   const curve25519_key *public_key)
 {
-   return ed25519_verify_private(msg, msglen, sig, siglen,
-                                 stat, 0, 0, public_key);
+   return s_ed25519_verify(msg, msglen, sig, siglen, NULL, 0, stat, public_key);
 }
 
 #endif


### PR DESCRIPTION
This PR adds Ed25519 context support and message pre-hashing support when signin/verifying.
<!--

Thank you for your pull request.

If this fixes an existing github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.

-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

* [x] documentation is updated
* [x] tests are added
