### PR TITLE
Improve vararg apis

### DIFF
--- a/demos/tv_gen.c
+++ b/demos/tv_gen.c
@@ -693,7 +693,7 @@ static void ecc_gen(void)
             mp_mul_d(k, 3, k);
         }
    }
-   mp_clear_multi(k, order, modulus, a, NULL);
+   mp_clear_multi(k, order, modulus, a, LTC_NULL);
    ltc_ecc_del_point(G);
    ltc_ecc_del_point(R);
    fclose(out);

--- a/makefile.mingw
+++ b/makefile.mingw
@@ -226,10 +226,10 @@ src/stream/sosemanuk/sosemanuk_memory.o src/stream/sosemanuk/sosemanuk_test.o
 TOBJECTS=tests/base16_test.o tests/base32_test.o tests/base64_test.o tests/bcrypt_test.o \
 tests/cipher_hash_test.o tests/common.o tests/der_test.o tests/dh_test.o tests/dsa_test.o \
 tests/ecc_test.o tests/ed25519_test.o tests/file_test.o tests/mac_test.o tests/misc_test.o \
-tests/modes_test.o tests/mpi_test.o tests/multi_test.o tests/no_prng.o tests/padding_test.o \
-tests/pkcs_1_eme_test.o tests/pkcs_1_emsa_test.o tests/pkcs_1_oaep_test.o tests/pkcs_1_pss_test.o \
-tests/pkcs_1_test.o tests/prng_test.o tests/rotate_test.o tests/rsa_test.o tests/ssh_test.o \
-tests/store_test.o tests/test.o tests/x25519_test.o
+tests/modes_test.o tests/mpi_test.o tests/multi_test.o tests/no_null_termination_check_test.o \
+tests/no_prng.o tests/padding_test.o tests/pkcs_1_eme_test.o tests/pkcs_1_emsa_test.o \
+tests/pkcs_1_oaep_test.o tests/pkcs_1_pss_test.o tests/pkcs_1_test.o tests/prng_test.o \
+tests/rotate_test.o tests/rsa_test.o tests/ssh_test.o tests/store_test.o tests/test.o tests/x25519_test.o
 
 #The following headers will be installed by "make install"
 HEADERS_PUB=src/headers/tomcrypt.h src/headers/tomcrypt_argchk.h src/headers/tomcrypt_cfg.h \

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -219,10 +219,10 @@ src/stream/sosemanuk/sosemanuk_memory.obj src/stream/sosemanuk/sosemanuk_test.ob
 TOBJECTS=tests/base16_test.obj tests/base32_test.obj tests/base64_test.obj tests/bcrypt_test.obj \
 tests/cipher_hash_test.obj tests/common.obj tests/der_test.obj tests/dh_test.obj tests/dsa_test.obj \
 tests/ecc_test.obj tests/ed25519_test.obj tests/file_test.obj tests/mac_test.obj tests/misc_test.obj \
-tests/modes_test.obj tests/mpi_test.obj tests/multi_test.obj tests/no_prng.obj tests/padding_test.obj \
-tests/pkcs_1_eme_test.obj tests/pkcs_1_emsa_test.obj tests/pkcs_1_oaep_test.obj tests/pkcs_1_pss_test.obj \
-tests/pkcs_1_test.obj tests/prng_test.obj tests/rotate_test.obj tests/rsa_test.obj tests/ssh_test.obj \
-tests/store_test.obj tests/test.obj tests/x25519_test.obj
+tests/modes_test.obj tests/mpi_test.obj tests/multi_test.obj tests/no_null_termination_check_test.obj \
+tests/no_prng.obj tests/padding_test.obj tests/pkcs_1_eme_test.obj tests/pkcs_1_emsa_test.obj \
+tests/pkcs_1_oaep_test.obj tests/pkcs_1_pss_test.obj tests/pkcs_1_test.obj tests/prng_test.obj \
+tests/rotate_test.obj tests/rsa_test.obj tests/ssh_test.obj tests/store_test.obj tests/test.obj tests/x25519_test.obj
 
 #The following headers will be installed by "make install"
 HEADERS_PUB=src/headers/tomcrypt.h src/headers/tomcrypt_argchk.h src/headers/tomcrypt_cfg.h \

--- a/makefile.unix
+++ b/makefile.unix
@@ -236,10 +236,10 @@ src/stream/sosemanuk/sosemanuk_memory.o src/stream/sosemanuk/sosemanuk_test.o
 TOBJECTS=tests/base16_test.o tests/base32_test.o tests/base64_test.o tests/bcrypt_test.o \
 tests/cipher_hash_test.o tests/common.o tests/der_test.o tests/dh_test.o tests/dsa_test.o \
 tests/ecc_test.o tests/ed25519_test.o tests/file_test.o tests/mac_test.o tests/misc_test.o \
-tests/modes_test.o tests/mpi_test.o tests/multi_test.o tests/no_prng.o tests/padding_test.o \
-tests/pkcs_1_eme_test.o tests/pkcs_1_emsa_test.o tests/pkcs_1_oaep_test.o tests/pkcs_1_pss_test.o \
-tests/pkcs_1_test.o tests/prng_test.o tests/rotate_test.o tests/rsa_test.o tests/ssh_test.o \
-tests/store_test.o tests/test.o tests/x25519_test.o
+tests/modes_test.o tests/mpi_test.o tests/multi_test.o tests/no_null_termination_check_test.o \
+tests/no_prng.o tests/padding_test.o tests/pkcs_1_eme_test.o tests/pkcs_1_emsa_test.o \
+tests/pkcs_1_oaep_test.o tests/pkcs_1_pss_test.o tests/pkcs_1_test.o tests/prng_test.o \
+tests/rotate_test.o tests/rsa_test.o tests/ssh_test.o tests/store_test.o tests/test.o tests/x25519_test.o
 
 #The following headers will be installed by "make install"
 HEADERS_PUB=src/headers/tomcrypt.h src/headers/tomcrypt_argchk.h src/headers/tomcrypt_cfg.h \

--- a/makefile_include.mk
+++ b/makefile_include.mk
@@ -397,10 +397,10 @@ src/stream/sosemanuk/sosemanuk_memory.o src/stream/sosemanuk/sosemanuk_test.o
 TOBJECTS=tests/base16_test.o tests/base32_test.o tests/base64_test.o tests/bcrypt_test.o \
 tests/cipher_hash_test.o tests/common.o tests/der_test.o tests/dh_test.o tests/dsa_test.o \
 tests/ecc_test.o tests/ed25519_test.o tests/file_test.o tests/mac_test.o tests/misc_test.o \
-tests/modes_test.o tests/mpi_test.o tests/multi_test.o tests/no_prng.o tests/padding_test.o \
-tests/pkcs_1_eme_test.o tests/pkcs_1_emsa_test.o tests/pkcs_1_oaep_test.o tests/pkcs_1_pss_test.o \
-tests/pkcs_1_test.o tests/prng_test.o tests/rotate_test.o tests/rsa_test.o tests/ssh_test.o \
-tests/store_test.o tests/test.o tests/x25519_test.o
+tests/modes_test.o tests/mpi_test.o tests/multi_test.o tests/no_null_termination_check_test.o \
+tests/no_prng.o tests/padding_test.o tests/pkcs_1_eme_test.o tests/pkcs_1_emsa_test.o \
+tests/pkcs_1_oaep_test.o tests/pkcs_1_pss_test.o tests/pkcs_1_test.o tests/prng_test.o \
+tests/rotate_test.o tests/rsa_test.o tests/ssh_test.o tests/store_test.o tests/test.o tests/x25519_test.o
 
 # The following headers will be installed by "make install"
 HEADERS_PUB=src/headers/tomcrypt.h src/headers/tomcrypt_argchk.h src/headers/tomcrypt_cfg.h \

--- a/src/headers/tomcrypt_cfg.h
+++ b/src/headers/tomcrypt_cfg.h
@@ -295,6 +295,15 @@ typedef unsigned long ltc_mp_digit;
    #define LTC_ALIGN(n)
 #endif
 
+/* Define `LTC_NO_NULL_TERMINATION_CHECK` in the user code
+ * before including `tomcrypt.h` to disable this functionality.
+ */
+#if defined(__GNUC__) && __GNUC__ >= 4 && !defined(LTC_NO_NULL_TERMINATION_CHECK)
+#   define LTC_NULL_TERMINATED __attribute__((sentinel))
+#else
+#   define LTC_NULL_TERMINATED
+#endif
+
 #if defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 405)
 #  define LTC_DEPRECATED(s) __attribute__((deprecated("replaced by " #s)))
 #  define PRIVATE_LTC_DEPRECATED_PRAGMA(s) _Pragma(#s)

--- a/src/headers/tomcrypt_hash.h
+++ b/src/headers/tomcrypt_hash.h
@@ -494,7 +494,8 @@ int hash_memory(int hash,
                 const unsigned char *in,  unsigned long inlen,
                       unsigned char *out, unsigned long *outlen);
 int hash_memory_multi(int hash, unsigned char *out, unsigned long *outlen,
-                      const unsigned char *in, unsigned long inlen, ...);
+                      const unsigned char *in, unsigned long inlen, ...)
+                      LTC_NULL_TERMINATED;
 
 #ifndef LTC_NO_FILE
 int hash_filehandle(int hash, FILE *in, unsigned char *out, unsigned long *outlen);

--- a/src/headers/tomcrypt_mac.h
+++ b/src/headers/tomcrypt_mac.h
@@ -19,7 +19,8 @@ int hmac_memory(int hash,
 int hmac_memory_multi(int hash,
                 const unsigned char *key,  unsigned long keylen,
                       unsigned char *out,  unsigned long *outlen,
-                const unsigned char *in,   unsigned long inlen, ...);
+                const unsigned char *in,   unsigned long inlen, ...)
+                LTC_NULL_TERMINATED;
 int hmac_file(int hash, const char *fname, const unsigned char *key,
               unsigned long keylen,
               unsigned char *out, unsigned long *outlen);
@@ -47,7 +48,8 @@ int omac_memory(int cipher,
 int omac_memory_multi(int cipher,
                 const unsigned char *key, unsigned long keylen,
                       unsigned char *out, unsigned long *outlen,
-                const unsigned char *in,  unsigned long inlen, ...);
+                const unsigned char *in,  unsigned long inlen, ...)
+                LTC_NULL_TERMINATED;
 int omac_file(int cipher,
               const unsigned char *key, unsigned long keylen,
               const          char *filename,
@@ -83,7 +85,8 @@ int pmac_memory(int cipher,
 int pmac_memory_multi(int cipher,
                 const unsigned char *key, unsigned long keylen,
                       unsigned char *out, unsigned long *outlen,
-                const unsigned char *in, unsigned long inlen, ...);
+                const unsigned char *in, unsigned long inlen, ...)
+                LTC_NULL_TERMINATED;
 
 int pmac_file(int cipher,
              const unsigned char *key, unsigned long keylen,
@@ -112,7 +115,10 @@ int poly1305_init(poly1305_state *st, const unsigned char *key, unsigned long ke
 int poly1305_process(poly1305_state *st, const unsigned char *in, unsigned long inlen);
 int poly1305_done(poly1305_state *st, unsigned char *mac, unsigned long *maclen);
 int poly1305_memory(const unsigned char *key, unsigned long keylen, const unsigned char *in, unsigned long inlen, unsigned char *mac, unsigned long *maclen);
-int poly1305_memory_multi(const unsigned char *key, unsigned long keylen, unsigned char *mac, unsigned long *maclen, const unsigned char *in,  unsigned long inlen, ...);
+int poly1305_memory_multi(const unsigned char *key, unsigned long keylen,
+                                unsigned char *mac, unsigned long *maclen,
+                          const unsigned char *in,  unsigned long inlen, ...)
+                          LTC_NULL_TERMINATED;
 int poly1305_file(const char *fname, const unsigned char *key, unsigned long keylen, unsigned char *mac, unsigned long *maclen);
 int poly1305_test(void);
 #endif /* LTC_POLY1305 */
@@ -123,7 +129,10 @@ int blake2smac_init(blake2smac_state *st, unsigned long outlen, const unsigned c
 int blake2smac_process(blake2smac_state *st, const unsigned char *in, unsigned long inlen);
 int blake2smac_done(blake2smac_state *st, unsigned char *mac, unsigned long *maclen);
 int blake2smac_memory(const unsigned char *key, unsigned long keylen, const unsigned char *in, unsigned long inlen, unsigned char *mac, unsigned long *maclen);
-int blake2smac_memory_multi(const unsigned char *key, unsigned long keylen, unsigned char *mac, unsigned long *maclen, const unsigned char *in,  unsigned long inlen, ...);
+int blake2smac_memory_multi(const unsigned char *key, unsigned long keylen,
+                                  unsigned char *mac, unsigned long *maclen,
+                            const unsigned char *in,  unsigned long inlen, ...)
+                            LTC_NULL_TERMINATED;
 int blake2smac_file(const char *fname, const unsigned char *key, unsigned long keylen, unsigned char *mac, unsigned long *maclen);
 int blake2smac_test(void);
 #endif /* LTC_BLAKE2SMAC */
@@ -134,7 +143,10 @@ int blake2bmac_init(blake2bmac_state *st, unsigned long outlen, const unsigned c
 int blake2bmac_process(blake2bmac_state *st, const unsigned char *in, unsigned long inlen);
 int blake2bmac_done(blake2bmac_state *st, unsigned char *mac, unsigned long *maclen);
 int blake2bmac_memory(const unsigned char *key, unsigned long keylen, const unsigned char *in, unsigned long inlen, unsigned char *mac, unsigned long *maclen);
-int blake2bmac_memory_multi(const unsigned char *key, unsigned long keylen, unsigned char *mac, unsigned long *maclen, const unsigned char *in,  unsigned long inlen, ...);
+int blake2bmac_memory_multi(const unsigned char *key, unsigned long keylen,
+                                  unsigned char *mac, unsigned long *maclen,
+                            const unsigned char *in,  unsigned long inlen, ...)
+                            LTC_NULL_TERMINATED;
 int blake2bmac_file(const char *fname, const unsigned char *key, unsigned long keylen, unsigned char *mac, unsigned long *maclen);
 int blake2bmac_test(void);
 #endif /* LTC_BLAKE2BMAC */
@@ -186,7 +198,8 @@ int xcbc_memory(int cipher,
 int xcbc_memory_multi(int cipher,
                 const unsigned char *key, unsigned long keylen,
                       unsigned char *out, unsigned long *outlen,
-                const unsigned char *in,  unsigned long inlen, ...);
+                const unsigned char *in,  unsigned long inlen, ...)
+                LTC_NULL_TERMINATED;
 int xcbc_file(int cipher,
               const unsigned char *key, unsigned long keylen,
               const          char *filename,
@@ -220,7 +233,8 @@ int f9_memory(int cipher,
 int f9_memory_multi(int cipher,
                 const unsigned char *key, unsigned long keylen,
                       unsigned char *out, unsigned long *outlen,
-                const unsigned char *in,  unsigned long inlen, ...);
+                const unsigned char *in,  unsigned long inlen, ...)
+                LTC_NULL_TERMINATED;
 int f9_file(int cipher,
               const unsigned char *key, unsigned long keylen,
               const          char *fname,

--- a/src/headers/tomcrypt_math.h
+++ b/src/headers/tomcrypt_math.h
@@ -502,9 +502,9 @@ typedef struct {
 
 extern ltc_math_descriptor ltc_mp;
 
-int ltc_init_multi(void **a, ...);
-void ltc_deinit_multi(void *a, ...);
-void ltc_cleanup_multi(void **a, ...);
+int ltc_init_multi(void **a, ...) LTC_NULL_TERMINATED;
+void ltc_deinit_multi(void *a, ...) LTC_NULL_TERMINATED;
+void ltc_cleanup_multi(void **a, ...) LTC_NULL_TERMINATED;
 
 #ifdef LTM_DESC
 extern const ltc_math_descriptor ltm_desc;

--- a/src/headers/tomcrypt_misc.h
+++ b/src/headers/tomcrypt_misc.h
@@ -93,7 +93,7 @@ const char *error_to_string(int err);
 extern const char *crypt_build_settings;
 
 /* ---- HMM ---- */
-int crypt_fsa(void *mp, ...);
+int crypt_fsa(void *mp, ...) LTC_NULL_TERMINATED;
 
 /* ---- Dynamic language support ---- */
 int crypt_get_constant(const char* namein, int *valueout);
@@ -172,8 +172,8 @@ typedef enum ssh_data_type_ {
 } ssh_data_type;
 
 /* VA list handy helpers with tuples of <type, data> */
-int ssh_encode_sequence_multi(unsigned char *out, unsigned long *outlen, ...);
-int ssh_decode_sequence_multi(const unsigned char *in, unsigned long *inlen, ...);
+int ssh_encode_sequence_multi(unsigned char *out, unsigned long *outlen, ...) LTC_NULL_TERMINATED;
+int ssh_decode_sequence_multi(const unsigned char *in, unsigned long *inlen, ...) LTC_NULL_TERMINATED;
 #endif /* LTC_SSH */
 
 int compare_testvector(const void* is, const unsigned long is_len, const void* should, const unsigned long should_len, const char* what, int which);

--- a/src/headers/tomcrypt_pk.h
+++ b/src/headers/tomcrypt_pk.h
@@ -654,8 +654,8 @@ int der_encode_setof(const ltc_asn1_list *list, unsigned long inlen,
                      unsigned char *out,        unsigned long *outlen);
 
 /* VA list handy helpers with triplets of <type, size, data> */
-int der_encode_sequence_multi(unsigned char *out, unsigned long *outlen, ...);
-int der_decode_sequence_multi(const unsigned char *in, unsigned long inlen, ...);
+int der_encode_sequence_multi(unsigned char *out, unsigned long *outlen, ...) LTC_NULL_TERMINATED;
+int der_decode_sequence_multi(const unsigned char *in, unsigned long inlen, ...) LTC_NULL_TERMINATED;
 
 /* FLEXI DECODER handle unknown list decoder */
 int  der_decode_sequence_flexi(const unsigned char *in, unsigned long *inlen, ltc_asn1_list **out);

--- a/src/headers/tomcrypt_private.h
+++ b/src/headers/tomcrypt_private.h
@@ -384,7 +384,8 @@ extern const unsigned long  der_asn1_tag_to_type_map_sz;
 extern const int der_asn1_type_to_identifier_map[];
 extern const unsigned long der_asn1_type_to_identifier_map_sz;
 
-int der_decode_sequence_multi_ex(const unsigned char *in, unsigned long inlen, unsigned int flags, ...);
+int der_decode_sequence_multi_ex(const unsigned char *in, unsigned long inlen, unsigned int flags, ...)
+                                 LTC_NULL_TERMINATED;
 
 int der_teletex_char_encode(int c);
 int der_teletex_value_decode(int v);

--- a/src/headers/tomcrypt_private.h
+++ b/src/headers/tomcrypt_private.h
@@ -9,6 +9,14 @@
 
 #define LTC_PAD_MASK       (0xF000U)
 
+/* `NULL` as defined by the standard is not guaranteed to be of a pointer
+ * type. In order to make sure that in vararg API's a pointer type is used,
+ * define our own version and use that one internally.
+ */
+#ifndef LTC_NULL
+   #define LTC_NULL ((void *)0)
+#endif
+
 /*
  * Internal Enums
  */

--- a/src/math/fp/ltc_ecc_fp_mulmod.c
+++ b/src/math/fp/ltc_ecc_fp_mulmod.c
@@ -1544,7 +1544,7 @@ int ltc_ecc_fp_restore_state(unsigned char *in, unsigned long inlen)
             goto ERR_OUT;
          }
          fp_cache[i].LUT[x] = p;
-         if ((err = mp_init_multi(&p->x, &p->y, NULL)) != CRYPT_OK) {
+         if ((err = mp_init_multi(&p->x, &p->y, LTC_NULL)) != CRYPT_OK) {
             goto ERR_OUT;
          }
          p->z = NULL;

--- a/src/misc/bcrypt/bcrypt.c
+++ b/src/misc/bcrypt/bcrypt.c
@@ -139,7 +139,7 @@ int bcrypt_pbkdf_openbsd(const          void *secret, unsigned long secret_len,
        if ((err = hash_memory_multi(hash_idx, buf[0], &x,
                                     salt, salt_len,
                                     blkbuf, 4uL,
-                                    NULL, 0)) != CRYPT_OK) {
+                                    LTC_NULL)) != CRYPT_OK) {
           goto LBL_ERR;
        }
        y = MAXBLOCKSIZE;

--- a/src/misc/pkcs12/pkcs12_kdf.c
+++ b/src/misc/pkcs12/pkcs12_kdf.c
@@ -39,7 +39,7 @@ int pkcs12_kdf(               int   hash_id,
 
    for (i = 0; i < c; i++) {
       Alen = sizeof(A);
-      err = hash_memory_multi(hash_id, A, &Alen, D, v, I, Slen + Plen, NULL); /* A = HASH(D || I) */
+      err = hash_memory_multi(hash_id, A, &Alen, D, v, I, Slen + Plen, LTC_NULL); /* A = HASH(D || I) */
       if (err != CRYPT_OK) goto DONE;
       for (j = 1; j < iterations; j++) {
          err = hash_memory(hash_id, A, Alen, A, &Alen); /* A = HASH(A) */

--- a/src/pk/asn1/der/sequence/der_decode_sequence_multi.c
+++ b/src/pk/asn1/der/sequence/der_decode_sequence_multi.c
@@ -34,14 +34,15 @@ static int s_der_decode_sequence_va(const unsigned char *in, unsigned long inlen
    x = 0;
    for (;;) {
        type = (ltc_asn1_type)va_arg(a1, int);
-       size = va_arg(a1, unsigned long);
-       data = va_arg(a1, void*);
-       LTC_UNUSED_PARAM(size);
-       LTC_UNUSED_PARAM(data);
 
        if (type == LTC_ASN1_EOL) {
           break;
        }
+
+       size = va_arg(a1, unsigned long);
+       data = va_arg(a1, void*);
+       LTC_UNUSED_PARAM(size);
+       LTC_UNUSED_PARAM(data);
 
        switch (type) {
            case LTC_ASN1_BOOLEAN:

--- a/src/pk/asn1/der/sequence/der_encode_sequence_multi.c
+++ b/src/pk/asn1/der/sequence/der_encode_sequence_multi.c
@@ -35,14 +35,15 @@ int der_encode_sequence_multi(unsigned char *out, unsigned long *outlen, ...)
    x = 0;
    for (;;) {
        type = (ltc_asn1_type)va_arg(args, int);
-       size = va_arg(args, unsigned long);
-       data = va_arg(args, void*);
-       LTC_UNUSED_PARAM(size);
-       LTC_UNUSED_PARAM(data);
 
        if (type == LTC_ASN1_EOL) {
           break;
        }
+
+       size = va_arg(args, unsigned long);
+       data = va_arg(args, void*);
+       LTC_UNUSED_PARAM(size);
+       LTC_UNUSED_PARAM(data);
 
        switch (type) {
            case LTC_ASN1_BOOLEAN:
@@ -89,12 +90,13 @@ int der_encode_sequence_multi(unsigned char *out, unsigned long *outlen, ...)
    x = 0;
    for (;;) {
        type = (ltc_asn1_type)va_arg(args, int);
-       size = va_arg(args, unsigned long);
-       data = va_arg(args, void*);
 
        if (type == LTC_ASN1_EOL) {
           break;
        }
+
+       size = va_arg(args, unsigned long);
+       data = va_arg(args, void*);
 
        switch (type) {
            case LTC_ASN1_BOOLEAN:

--- a/src/pk/dh/dh_free.c
+++ b/src/pk/dh/dh_free.c
@@ -12,7 +12,7 @@
 void dh_free(dh_key *key)
 {
    LTC_ARGCHKVD(key != NULL);
-   mp_cleanup_multi(&key->prime, &key->base, &key->y, &key->x, NULL);
+   mp_cleanup_multi(&key->prime, &key->base, &key->y, &key->x, LTC_NULL);
 }
 
 #endif /* LTC_MDH */

--- a/src/pk/dh/dh_import.c
+++ b/src/pk/dh/dh_import.c
@@ -22,7 +22,7 @@ int dh_import(const unsigned char *in, unsigned long inlen, dh_key *key)
    LTC_ARGCHK(key != NULL);
 
    /* init */
-   if ((err = mp_init_multi(&key->x, &key->y, &key->base, &key->prime, NULL)) != CRYPT_OK) {
+   if ((err = mp_init_multi(&key->x, &key->y, &key->base, &key->prime, LTC_NULL)) != CRYPT_OK) {
       return err;
    }
 

--- a/src/pk/dh/dh_set.c
+++ b/src/pk/dh/dh_set.c
@@ -26,7 +26,7 @@ int dh_set_pg(const unsigned char *p, unsigned long plen,
    LTC_ARGCHK(g           != NULL);
    LTC_ARGCHK(ltc_mp.name != NULL);
 
-   if ((err = mp_init_multi(&key->x, &key->y, &key->base, &key->prime, NULL)) != CRYPT_OK) {
+   if ((err = mp_init_multi(&key->x, &key->y, &key->base, &key->prime, LTC_NULL)) != CRYPT_OK) {
       return err;
    }
 
@@ -58,7 +58,7 @@ int dh_set_pg_groupsize(int groupsize, dh_key *key)
    for (i = 0; (groupsize > ltc_dh_sets[i].size) && (ltc_dh_sets[i].size != 0); i++);
    if (ltc_dh_sets[i].size == 0) return CRYPT_INVALID_KEYSIZE;
 
-   if ((err = mp_init_multi(&key->x, &key->y, &key->base, &key->prime, NULL)) != CRYPT_OK) {
+   if ((err = mp_init_multi(&key->x, &key->y, &key->base, &key->prime, LTC_NULL)) != CRYPT_OK) {
       return err;
    }
    if ((err = mp_read_radix(key->base, ltc_dh_sets[i].base, 16)) != CRYPT_OK)  { goto LBL_ERR; }

--- a/src/pk/dh/dh_set_pg_dhparam.c
+++ b/src/pk/dh/dh_set_pg_dhparam.c
@@ -24,7 +24,7 @@ int dh_set_pg_dhparam(const unsigned char *dhparam, unsigned long dhparamlen, dh
    LTC_ARGCHK(dhparam     != NULL);
    LTC_ARGCHK(dhparamlen  > 0);
 
-   if ((err = mp_init_multi(&key->x, &key->y, &key->base, &key->prime, NULL)) != CRYPT_OK) {
+   if ((err = mp_init_multi(&key->x, &key->y, &key->base, &key->prime, LTC_NULL)) != CRYPT_OK) {
       return err;
    }
    if ((err = der_decode_sequence_multi(dhparam, dhparamlen,

--- a/src/pk/dsa/dsa_encrypt_key.c
+++ b/src/pk/dsa/dsa_encrypt_key.c
@@ -50,7 +50,7 @@ int dsa_encrypt_key(const unsigned char *in,   unsigned long inlen,
     }
 
     /* make a random key and export the public copy */
-    if ((err = mp_init_multi(&g_pub, &g_priv, NULL)) != CRYPT_OK) {
+    if ((err = mp_init_multi(&g_pub, &g_priv, LTC_NULL)) != CRYPT_OK) {
        return err;
     }
 
@@ -63,7 +63,7 @@ int dsa_encrypt_key(const unsigned char *in,   unsigned long inlen,
        if (skey != NULL) {
           XFREE(skey);
        }
-       mp_clear_multi(g_pub, g_priv, NULL);
+       mp_clear_multi(g_pub, g_priv, LTC_NULL);
        return CRYPT_MEM;
     }
 
@@ -111,7 +111,7 @@ LBL_ERR:
     XFREE(skey);
     XFREE(expt);
 
-    mp_clear_multi(g_pub, g_priv, NULL);
+    mp_clear_multi(g_pub, g_priv, LTC_NULL);
     return err;
 }
 

--- a/src/pk/dsa/dsa_free.c
+++ b/src/pk/dsa/dsa_free.c
@@ -16,7 +16,7 @@
 void dsa_free(dsa_key *key)
 {
    LTC_ARGCHKVD(key != NULL);
-   mp_cleanup_multi(&key->y, &key->x, &key->q, &key->g, &key->p, NULL);
+   mp_cleanup_multi(&key->y, &key->x, &key->q, &key->g, &key->p, LTC_NULL);
    key->type = key->qord = 0;
 }
 

--- a/src/pk/dsa/dsa_generate_pqg.c
+++ b/src/pk/dsa/dsa_generate_pqg.c
@@ -108,7 +108,7 @@ static int s_dsa_make_params(prng_state *prng, int wprng, int group_size, int mo
   if ((wbuf = XMALLOC((n+1)*outbytes)) == NULL)                                  { err = CRYPT_MEM; goto cleanup3; }
   if ((sbuf = XMALLOC(seedbytes)) == NULL)                                       { err = CRYPT_MEM; goto cleanup2; }
 
-  err = mp_init_multi(&t2L1, &t2N1, &t2q, &t2seedlen, &U, &W, &X, &c, &h, &e, &seedinc, NULL);
+  err = mp_init_multi(&t2L1, &t2N1, &t2q, &t2seedlen, &U, &W, &X, &c, &h, &e, &seedinc, LTC_NULL);
   if (err != CRYPT_OK)                                                           { goto cleanup1; }
 
   if ((err = mp_2expt(t2L1, L-1)) != CRYPT_OK)                                   { goto cleanup; }
@@ -187,7 +187,7 @@ static int s_dsa_make_params(prng_state *prng, int wprng, int group_size, int mo
 
   err = CRYPT_OK;
 cleanup:
-  mp_clear_multi(t2L1, t2N1, t2q, t2seedlen, U, W, X, c, h, e, seedinc, NULL);
+  mp_clear_multi(t2L1, t2N1, t2q, t2seedlen, U, W, X, c, h, e, seedinc, LTC_NULL);
 cleanup1:
   XFREE(sbuf);
 cleanup2:
@@ -213,7 +213,7 @@ int dsa_generate_pqg(prng_state *prng, int wprng, int group_size, int modulus_si
    LTC_ARGCHK(ltc_mp.name != NULL);
 
    /* init mp_ints */
-   if ((err = mp_init_multi(&key->p, &key->g, &key->q, &key->x, &key->y, NULL)) != CRYPT_OK) {
+   if ((err = mp_init_multi(&key->p, &key->g, &key->q, &key->x, &key->y, LTC_NULL)) != CRYPT_OK) {
       return err;
    }
    /* generate params */

--- a/src/pk/dsa/dsa_import.c
+++ b/src/pk/dsa/dsa_import.c
@@ -28,7 +28,7 @@ int dsa_import(const unsigned char *in, unsigned long inlen, dsa_key *key)
    LTC_ARGCHK(ltc_mp.name != NULL);
 
    /* init key */
-   if (mp_init_multi(&key->p, &key->g, &key->q, &key->x, &key->y, NULL) != CRYPT_OK) {
+   if (mp_init_multi(&key->p, &key->g, &key->q, &key->x, &key->y, LTC_NULL) != CRYPT_OK) {
       return CRYPT_MEM;
    }
 

--- a/src/pk/dsa/dsa_set.c
+++ b/src/pk/dsa/dsa_set.c
@@ -30,7 +30,7 @@ int dsa_set_pqg(const unsigned char *p,  unsigned long plen,
    LTC_ARGCHK(ltc_mp.name != NULL);
 
    /* init key */
-   err = mp_init_multi(&key->p, &key->g, &key->q, &key->x, &key->y, NULL);
+   err = mp_init_multi(&key->p, &key->g, &key->q, &key->x, &key->y, LTC_NULL);
    if (err != CRYPT_OK) return err;
 
    if ((err = mp_read_unsigned_bin(key->p, (unsigned char *)p , plen)) != CRYPT_OK) { goto LBL_ERR; }

--- a/src/pk/dsa/dsa_set_pqg_dsaparam.c
+++ b/src/pk/dsa/dsa_set_pqg_dsaparam.c
@@ -25,7 +25,7 @@ int dsa_set_pqg_dsaparam(const unsigned char *dsaparam, unsigned long dsaparamle
    LTC_ARGCHK(ltc_mp.name != NULL);
 
    /* init key */
-   err = mp_init_multi(&key->p, &key->g, &key->q, &key->x, &key->y, NULL);
+   err = mp_init_multi(&key->p, &key->g, &key->q, &key->x, &key->y, LTC_NULL);
    if (err != CRYPT_OK) return err;
 
    if ((err = der_decode_sequence_multi(dsaparam, dsaparamlen,

--- a/src/pk/dsa/dsa_sign_hash.c
+++ b/src/pk/dsa/dsa_sign_hash.c
@@ -51,7 +51,7 @@ int dsa_sign_hash_raw(const unsigned char *in,  unsigned long inlen,
    }
 
    /* Init our temps */
-   if ((err = mp_init_multi(&k, &kinv, &tmp, NULL)) != CRYPT_OK)                       { goto ERRBUF; }
+   if ((err = mp_init_multi(&k, &kinv, &tmp, LTC_NULL)) != CRYPT_OK)                   { goto ERRBUF; }
 
    qbits = mp_count_bits(key->q);
 retry:
@@ -89,7 +89,7 @@ retry:
 
    err = CRYPT_OK;
 error:
-   mp_clear_multi(k, kinv, tmp, NULL);
+   mp_clear_multi(k, kinv, tmp, LTC_NULL);
 ERRBUF:
 #ifdef LTC_CLEAN_STACK
    zeromem(buf, LTC_MDSA_MAX_GROUP);
@@ -121,7 +121,7 @@ int dsa_sign_hash(const unsigned char *in,  unsigned long inlen,
    LTC_ARGCHK(outlen  != NULL);
    LTC_ARGCHK(key     != NULL);
 
-   if (mp_init_multi(&r, &s, NULL) != CRYPT_OK) {
+   if (mp_init_multi(&r, &s, LTC_NULL) != CRYPT_OK) {
       return CRYPT_MEM;
    }
 
@@ -135,7 +135,7 @@ int dsa_sign_hash(const unsigned char *in,  unsigned long inlen,
                              LTC_ASN1_EOL,     0UL, NULL);
 
 error:
-   mp_clear_multi(r, s, NULL);
+   mp_clear_multi(r, s, LTC_NULL);
    return err;
 }
 

--- a/src/pk/dsa/dsa_verify_hash.c
+++ b/src/pk/dsa/dsa_verify_hash.c
@@ -36,7 +36,7 @@ int dsa_verify_hash_raw(         void   *r,          void   *s,
    *stat = 0;
 
    /* init our variables */
-   if ((err = mp_init_multi(&w, &v, &u1, &u2, NULL)) != CRYPT_OK) {
+   if ((err = mp_init_multi(&w, &v, &u1, &u2, LTC_NULL)) != CRYPT_OK) {
       return err;
    }
 
@@ -72,7 +72,7 @@ int dsa_verify_hash_raw(         void   *r,          void   *s,
 
    err = CRYPT_OK;
 error:
-   mp_clear_multi(w, v, u1, u2, NULL);
+   mp_clear_multi(w, v, u1, u2, LTC_NULL);
    return err;
 }
 
@@ -98,7 +98,7 @@ int dsa_verify_hash(const unsigned char *sig,        unsigned long  siglen,
    LTC_ARGCHK(stat != NULL);
    *stat = 0; /* must be set before the first return */
 
-   if ((err = mp_init_multi(&r, &s, NULL)) != CRYPT_OK) {
+   if ((err = mp_init_multi(&r, &s, LTC_NULL)) != CRYPT_OK) {
       return err;
    }
 
@@ -119,7 +119,7 @@ int dsa_verify_hash(const unsigned char *sig,        unsigned long  siglen,
    err = dsa_verify_hash_raw(r, s, hash, hashlen, stat, key);
 
 LBL_ERR:
-   mp_clear_multi(r, s, NULL);
+   mp_clear_multi(r, s, LTC_NULL);
    return err;
 }
 

--- a/src/pk/dsa/dsa_verify_key.c
+++ b/src/pk/dsa/dsa_verify_key.c
@@ -62,7 +62,7 @@ int dsa_int_validate_pqg(const dsa_key *key, int *stat)
       return CRYPT_OK;
    }
 
-   if ((err = mp_init_multi(&tmp1, &tmp2, NULL)) != CRYPT_OK)        { return err; }
+   if ((err = mp_init_multi(&tmp1, &tmp2, LTC_NULL)) != CRYPT_OK)    { return err; }
 
    /* FIPS 186-4 chapter 4.1: q is a divisor of (p - 1) */
    if ((err = mp_sub_d(key->p, 1, tmp1)) != CRYPT_OK)                { goto error; }
@@ -84,7 +84,7 @@ int dsa_int_validate_pqg(const dsa_key *key, int *stat)
    err   = CRYPT_OK;
    *stat = 1;
 error:
-   mp_clear_multi(tmp2, tmp1, NULL);
+   mp_clear_multi(tmp2, tmp1, LTC_NULL);
    return err;
 }
 

--- a/src/pk/ecc/ecc_import_openssl.c
+++ b/src/pk/ecc/ecc_import_openssl.c
@@ -49,7 +49,7 @@ static int s_ecc_import_private_with_curve(const unsigned char *in, unsigned lon
    unsigned long cofactor = 0, ecver = 0, pkver = 0, tmpoid[16];
    int err;
 
-   if ((err = mp_init_multi(&prime, &order, &a, &b, &gx, &gy, NULL)) != CRYPT_OK) {
+   if ((err = mp_init_multi(&prime, &order, &a, &b, &gx, &gy, LTC_NULL)) != CRYPT_OK) {
       return err;
    }
 
@@ -95,7 +95,7 @@ static int s_ecc_import_private_with_curve(const unsigned char *in, unsigned lon
       err = ecc_set_key(bin_k, len_k, PK_PRIVATE, key);
    }
 error:
-   mp_clear_multi(prime, order, a, b, gx, gy, NULL);
+   mp_clear_multi(prime, order, a, b, gx, gy, LTC_NULL);
    return err;
 }
 

--- a/src/pk/ecc/ecc_import_pkcs8.c
+++ b/src/pk/ecc/ecc_import_pkcs8.c
@@ -60,7 +60,7 @@ int ecc_import_pkcs8(const unsigned char *in, unsigned long inlen,
    if (err != CRYPT_OK) return err;
 
    /* init key */
-   err = mp_init_multi(&a, &b, &gx, &gy, NULL);
+   err = mp_init_multi(&a, &b, &gx, &gy, LTC_NULL);
    if (err != CRYPT_OK) return err;
 
 
@@ -177,7 +177,7 @@ int ecc_import_pkcs8(const unsigned char *in, unsigned long inlen,
 LBL_ECCFREE:
    ecc_free(key);
 LBL_DONE:
-   mp_clear_multi(a, b, gx, gy, NULL);
+   mp_clear_multi(a, b, gx, gy, LTC_NULL);
    if (l) der_free_sequence_flexi(l);
    if (p) der_free_sequence_flexi(p);
    return err;

--- a/src/pk/ecc/ecc_import_x509.c
+++ b/src/pk/ecc/ecc_import_x509.c
@@ -40,7 +40,7 @@ static int s_ecc_import_x509_with_curve(const unsigned char *in, unsigned long i
    unsigned long cofactor = 0, ecver = 0, tmpoid[16];
    int err;
 
-   if ((err = mp_init_multi(&prime, &order, &a, &b, &gx, &gy, NULL)) != CRYPT_OK) {
+   if ((err = mp_init_multi(&prime, &order, &a, &b, &gx, &gy, LTC_NULL)) != CRYPT_OK) {
       return err;
    }
 
@@ -79,7 +79,7 @@ static int s_ecc_import_x509_with_curve(const unsigned char *in, unsigned long i
       err = ecc_set_key(bin_xy, len_xy, PK_PUBLIC, key);
    }
 error:
-   mp_clear_multi(prime, order, a, b, gx, gy, NULL);
+   mp_clear_multi(prime, order, a, b, gx, gy, LTC_NULL);
    return err;
 }
 

--- a/src/pk/ecc/ecc_recover_key.c
+++ b/src/pk/ecc/ecc_recover_key.c
@@ -46,7 +46,7 @@ int ecc_recover_key(const unsigned char *sig,  unsigned long siglen,
    }
 
    /* allocate ints */
-   if ((err = mp_init_multi(&r, &s, &v, &w, &t1, &t2, &u1, &u2, &v1, &v2, &e, &x, &y, &a_plus3, NULL)) != CRYPT_OK) {
+   if ((err = mp_init_multi(&r, &s, &v, &w, &t1, &t2, &u1, &u2, &v1, &v2, &e, &x, &y, &a_plus3, LTC_NULL)) != CRYPT_OK) {
       return err;
    }
 
@@ -72,7 +72,7 @@ int ecc_recover_key(const unsigned char *sig,  unsigned long siglen,
       if ((err = der_decode_sequence_multi_ex(sig, siglen, LTC_DER_SEQ_SEQUENCE | LTC_DER_SEQ_STRICT,
                                      LTC_ASN1_INTEGER, 1UL, r,
                                      LTC_ASN1_INTEGER, 1UL, s,
-                                     LTC_ASN1_EOL, 0UL, NULL)) != CRYPT_OK)                             { goto error; }
+                                     LTC_ASN1_EOL, 0UL, LTC_NULL)) != CRYPT_OK)                         { goto error; }
    }
    else if (sigformat == LTC_ECCSIG_RFC7518) {
       /* RFC7518 format - raw (r,s) */
@@ -120,7 +120,7 @@ int ecc_recover_key(const unsigned char *sig,  unsigned long siglen,
 
 
       /* Check curve matches identifier string */
-      if ((err = ecc_ssh_ecdsa_encode_name(name2, &name2len, key)) != CRYPT_OK)                                { goto error; }
+      if ((err = ecc_ssh_ecdsa_encode_name(name2, &name2len, key)) != CRYPT_OK)                         { goto error; }
       if ((namelen != name2len) || (XSTRCMP(name, name2) != 0)) {
          err = CRYPT_INVALID_ARG;
          goto error;
@@ -214,7 +214,7 @@ int ecc_recover_key(const unsigned char *sig,  unsigned long siglen,
 
    /* for curves with a == -3 keep ma == NULL */
    if (mp_cmp(a_plus3, m) != LTC_MP_EQ) {
-      if ((err = mp_init_multi(&mu, &ma, NULL)) != CRYPT_OK)                                            { goto error; }
+      if ((err = mp_init_multi(&mu, &ma, LTC_NULL)) != CRYPT_OK)                                        { goto error; }
       if ((err = mp_montgomery_normalization(mu, m)) != CRYPT_OK)                                       { goto error; }
       if ((err = mp_mulmod(a, mu, m, ma)) != CRYPT_OK)                                                  { goto error; }
    }
@@ -252,7 +252,7 @@ error:
    if (mR != NULL) ltc_ecc_del_point(mR);
    if (mQ != NULL) ltc_ecc_del_point(mQ);
    if (mG != NULL) ltc_ecc_del_point(mG);
-   mp_clear_multi(a_plus3, y, x, e, v2, v1, u2, u1, t2, t1, w, v, s, r, NULL);
+   mp_clear_multi(a_plus3, y, x, e, v2, v1, u2, u1, t2, t1, w, v, s, r, LTC_NULL);
    return err;
 }
 

--- a/src/pk/ecc/ecc_sign_hash.c
+++ b/src/pk/ecc/ecc_sign_hash.c
@@ -46,7 +46,7 @@ int ecc_sign_hash_ex(const unsigned char *in,  unsigned long inlen,
    }
 
    /* init the bignums */
-   if ((err = mp_init_multi(&r, &s, &e, &b, NULL)) != CRYPT_OK) {
+   if ((err = mp_init_multi(&r, &s, &e, &b, LTC_NULL)) != CRYPT_OK) {
       return err;
    }
 
@@ -174,7 +174,7 @@ int ecc_sign_hash_ex(const unsigned char *in,  unsigned long inlen,
 error:
    ecc_free(&pubkey);
 errnokey:
-   mp_clear_multi(r, s, e, b, NULL);
+   mp_clear_multi(r, s, e, b, LTC_NULL);
    return err;
 }
 

--- a/src/pk/ecc/ecc_verify_hash.c
+++ b/src/pk/ecc/ecc_verify_hash.c
@@ -42,7 +42,7 @@ int ecc_verify_hash_ex(const unsigned char *sig,  unsigned long siglen,
    *stat = 0;
 
    /* allocate ints */
-   if ((err = mp_init_multi(&r, &s, &v, &w, &u1, &u2, &e, &a_plus3, NULL)) != CRYPT_OK) {
+   if ((err = mp_init_multi(&r, &s, &v, &w, &u1, &u2, &e, &a_plus3, LTC_NULL)) != CRYPT_OK) {
       return err;
    }
 
@@ -66,7 +66,7 @@ int ecc_verify_hash_ex(const unsigned char *sig,  unsigned long siglen,
       if ((err = der_decode_sequence_multi_ex(sig, siglen, LTC_DER_SEQ_SEQUENCE | LTC_DER_SEQ_STRICT,
                                      LTC_ASN1_INTEGER, 1UL, r,
                                      LTC_ASN1_INTEGER, 1UL, s,
-                                     LTC_ASN1_EOL, 0UL, NULL)) != CRYPT_OK)                             { goto error; }
+                                     LTC_ASN1_EOL, 0UL, LTC_NULL)) != CRYPT_OK)                         { goto error; }
    }
    else if (sigformat == LTC_ECCSIG_RFC7518) {
       /* RFC7518 format - raw (r,s) */
@@ -106,7 +106,7 @@ int ecc_verify_hash_ex(const unsigned char *sig,  unsigned long siglen,
 
 
       /* Check curve matches identifier string */
-      if ((err = ecc_ssh_ecdsa_encode_name(name2, &name2len, key)) != CRYPT_OK)                                { goto error; }
+      if ((err = ecc_ssh_ecdsa_encode_name(name2, &name2len, key)) != CRYPT_OK)                         { goto error; }
       if ((namelen != name2len) || (XSTRCMP(name, name2) != 0)) {
          err = CRYPT_INVALID_ARG;
          goto error;
@@ -163,7 +163,7 @@ int ecc_verify_hash_ex(const unsigned char *sig,  unsigned long siglen,
 
    /* for curves with a == -3 keep ma == NULL */
    if (mp_cmp(a_plus3, m) != LTC_MP_EQ) {
-      if ((err = mp_init_multi(&mu, &ma, NULL)) != CRYPT_OK)                                            { goto error; }
+      if ((err = mp_init_multi(&mu, &ma, LTC_NULL)) != CRYPT_OK)                                        { goto error; }
       if ((err = mp_montgomery_normalization(mu, m)) != CRYPT_OK)                                       { goto error; }
       if ((err = mp_mulmod(a, mu, m, ma)) != CRYPT_OK)                                                  { goto error; }
    }
@@ -198,7 +198,7 @@ error:
    if (mQ != NULL) ltc_ecc_del_point(mQ);
    if (mu != NULL) mp_clear(mu);
    if (ma != NULL) mp_clear(ma);
-   mp_clear_multi(r, s, v, w, u1, u2, e, a_plus3, NULL);
+   mp_clear_multi(r, s, v, w, u1, u2, e, a_plus3, LTC_NULL);
    if (mp != NULL) mp_montgomery_free(mp);
    return err;
 }

--- a/src/pk/ecc/ltc_ecc_import_point.c
+++ b/src/pk/ecc/ltc_ecc_import_point.c
@@ -12,7 +12,7 @@ int ltc_ecc_import_point(const unsigned char *in, unsigned long inlen, void *pri
    void *t1, *t2;
 
    /* init key + temporary numbers */
-   if (mp_init_multi(&t1, &t2, NULL) != CRYPT_OK) {
+   if (mp_init_multi(&t1, &t2, LTC_NULL) != CRYPT_OK) {
       return CRYPT_MEM;
    }
 
@@ -54,7 +54,7 @@ int ltc_ecc_import_point(const unsigned char *in, unsigned long inlen, void *pri
 
    err = CRYPT_OK;
 cleanup:
-   mp_clear_multi(t1, t2, NULL);
+   mp_clear_multi(t1, t2, LTC_NULL);
    return err;
 }
 

--- a/src/pk/ecc/ltc_ecc_is_point.c
+++ b/src/pk/ecc/ltc_ecc_is_point.c
@@ -21,7 +21,7 @@ int ltc_ecc_is_point(const ltc_ecc_dp *dp, void *x, void *y)
   b     = dp->B;
   a     = dp->A;
 
-  if ((err = mp_init_multi(&t1, &t2, NULL)) != CRYPT_OK)  return err;
+  if ((err = mp_init_multi(&t1, &t2, LTC_NULL)) != CRYPT_OK)  return err;
 
   /* compute y^2 */
   if ((err = mp_sqr(y, t1)) != CRYPT_OK)                  goto cleanup;
@@ -55,7 +55,7 @@ int ltc_ecc_is_point(const ltc_ecc_dp *dp, void *x, void *y)
   }
 
 cleanup:
-  mp_clear_multi(t1, t2, NULL);
+  mp_clear_multi(t1, t2, LTC_NULL);
   return err;
 }
 

--- a/src/pk/ecc/ltc_ecc_is_point_at_infinity.c
+++ b/src/pk/ecc/ltc_ecc_is_point_at_infinity.c
@@ -27,7 +27,7 @@ int ltc_ecc_is_point_at_infinity(const ecc_point *P, void *modulus, int *retval)
    }
 
    /* initialize */
-   if ((err = mp_init_multi(&x3, &y2, NULL))      != CRYPT_OK)   goto done;
+   if ((err = mp_init_multi(&x3, &y2, LTC_NULL))  != CRYPT_OK)   goto done;
 
    /* compute y^2 */
    if ((err = mp_mulmod(P->y, P->y, modulus, y2)) != CRYPT_OK)   goto cleanup;
@@ -45,7 +45,7 @@ int ltc_ecc_is_point_at_infinity(const ecc_point *P, void *modulus, int *retval)
    }
 
 cleanup:
-   mp_clear_multi(x3, y2, NULL);
+   mp_clear_multi(x3, y2, LTC_NULL);
 done:
    return err;
 }

--- a/src/pk/ecc/ltc_ecc_map.c
+++ b/src/pk/ecc/ltc_ecc_map.c
@@ -30,7 +30,7 @@ int ltc_ecc_map(ecc_point *P, void *modulus, void *mp)
       return ltc_ecc_set_point_xyz(0, 0, 1, P);
    }
 
-   if ((err = mp_init_multi(&t1, &t2, NULL)) != CRYPT_OK) {
+   if ((err = mp_init_multi(&t1, &t2, LTC_NULL)) != CRYPT_OK) {
       return err;
    }
 
@@ -55,7 +55,7 @@ int ltc_ecc_map(ecc_point *P, void *modulus, void *mp)
 
    err = CRYPT_OK;
 done:
-   mp_clear_multi(t1, t2, NULL);
+   mp_clear_multi(t1, t2, LTC_NULL);
    return err;
 }
 

--- a/src/pk/ecc/ltc_ecc_points.c
+++ b/src/pk/ecc/ltc_ecc_points.c
@@ -21,7 +21,7 @@ ecc_point *ltc_ecc_new_point(void)
    if (p == NULL) {
       return NULL;
    }
-   if (mp_init_multi(&p->x, &p->y, &p->z, NULL) != CRYPT_OK) {
+   if (mp_init_multi(&p->x, &p->y, &p->z, LTC_NULL) != CRYPT_OK) {
       XFREE(p);
       return NULL;
    }
@@ -35,7 +35,7 @@ void ltc_ecc_del_point(ecc_point *p)
 {
    /* prevents free'ing null arguments */
    if (p != NULL) {
-      mp_clear_multi(p->x, p->y, p->z, NULL); /* note: p->z may be NULL but that's ok with this function anyways */
+      mp_clear_multi(p->x, p->y, p->z, LTC_NULL); /* note: p->z may be NULL but that's ok with this function anyways */
       XFREE(p);
    }
 }

--- a/src/pk/ecc/ltc_ecc_projective_add_point.c
+++ b/src/pk/ecc/ltc_ecc_projective_add_point.c
@@ -31,7 +31,7 @@ int ltc_ecc_projective_add_point(const ecc_point *P, const ecc_point *Q, ecc_poi
    LTC_ARGCHK(modulus != NULL);
    LTC_ARGCHK(mp      != NULL);
 
-   if ((err = mp_init_multi(&t1, &t2, &x, &y, &z, NULL)) != CRYPT_OK) {
+   if ((err = mp_init_multi(&t1, &t2, &x, &y, &z, LTC_NULL)) != CRYPT_OK) {
       return err;
    }
 
@@ -52,7 +52,7 @@ int ltc_ecc_projective_add_point(const ecc_point *P, const ecc_point *Q, ecc_poi
    if ((mp_cmp(P->x, Q->x) == LTC_MP_EQ) && (mp_cmp(P->z, Q->z) == LTC_MP_EQ)) {
       if (mp_cmp(P->y, Q->y) == LTC_MP_EQ) {
          /* here P = Q >> Result = 2 * P (use doubling) */
-         mp_clear_multi(t1, t2, x, y, z, NULL);
+         mp_clear_multi(t1, t2, x, y, z, LTC_NULL);
          return ltc_ecc_projective_dbl_point(P, R, ma, modulus, mp);
       }
       if ((err = mp_sub(modulus, Q->y, t1)) != CRYPT_OK)                       { goto done; }
@@ -190,7 +190,7 @@ int ltc_ecc_projective_add_point(const ecc_point *P, const ecc_point *Q, ecc_poi
 
    err = CRYPT_OK;
 done:
-   mp_clear_multi(t1, t2, x, y, z, NULL);
+   mp_clear_multi(t1, t2, x, y, z, LTC_NULL);
    return err;
 }
 

--- a/src/pk/ecc/ltc_ecc_projective_dbl_point.c
+++ b/src/pk/ecc/ltc_ecc_projective_dbl_point.c
@@ -47,7 +47,7 @@ int ltc_ecc_projective_dbl_point(const ecc_point *P, ecc_point *R, void *ma, voi
    LTC_ARGCHK(modulus != NULL);
    LTC_ARGCHK(mp      != NULL);
 
-   if ((err = mp_init_multi(&t1, &t2, NULL)) != CRYPT_OK) {
+   if ((err = mp_init_multi(&t1, &t2, LTC_NULL)) != CRYPT_OK) {
       return err;
    }
 
@@ -176,7 +176,7 @@ int ltc_ecc_projective_dbl_point(const ecc_point *P, ecc_point *R, void *ma, voi
 
    err = CRYPT_OK;
 done:
-   mp_clear_multi(t2, t1, NULL);
+   mp_clear_multi(t2, t1, LTC_NULL);
    return err;
 }
 #endif

--- a/src/pk/rsa/rsa_key.c
+++ b/src/pk/rsa/rsa_key.c
@@ -87,7 +87,7 @@ void rsa_shrink_key(rsa_key *key)
 int rsa_init(rsa_key *key)
 {
    LTC_ARGCHK(key != NULL);
-   return mp_init_multi(&key->e, &key->d, &key->N, &key->dQ, &key->dP, &key->qP, &key->p, &key->q, NULL);
+   return mp_init_multi(&key->e, &key->d, &key->N, &key->dQ, &key->dP, &key->qP, &key->p, &key->q, LTC_NULL);
 }
 
 /**
@@ -97,7 +97,7 @@ int rsa_init(rsa_key *key)
 void rsa_free(rsa_key *key)
 {
    LTC_ARGCHKVD(key != NULL);
-   mp_cleanup_multi(&key->q, &key->p, &key->qP, &key->dP, &key->dQ, &key->N, &key->d, &key->e, NULL);
+   mp_cleanup_multi(&key->q, &key->p, &key->qP, &key->dP, &key->dQ, &key->N, &key->d, &key->e, LTC_NULL);
 }
 
 #endif

--- a/src/pk/rsa/rsa_make_key.c
+++ b/src/pk/rsa/rsa_make_key.c
@@ -22,7 +22,7 @@ static int s_rsa_make_key(prng_state *prng, int wprng, int size, void *e, rsa_ke
       return err;
    }
 
-   if ((err = mp_init_multi(&p, &q, &tmp1, &tmp2, NULL)) != CRYPT_OK) {
+   if ((err = mp_init_multi(&p, &q, &tmp1, &tmp2, LTC_NULL)) != CRYPT_OK) {
       return err;
    }
 
@@ -76,7 +76,7 @@ static int s_rsa_make_key(prng_state *prng, int wprng, int size, void *e, rsa_ke
 errkey:
    rsa_free(key);
 cleanup:
-   mp_clear_multi(tmp2, tmp1, q, p, NULL);
+   mp_clear_multi(tmp2, tmp1, q, p, LTC_NULL);
    return err;
 }
 

--- a/tests/der_test.c
+++ b/tests/der_test.c
@@ -1405,18 +1405,18 @@ static void s_der_regression_test(void)
    void *x, *y;
    ltc_asn1_list seq[2];
    ltc_asn1_list *l;
-   mp_init_multi(&x, &y, NULL);
+   mp_init_multi(&x, &y, LTC_NULL);
    LTC_SET_ASN1(seq, 0, LTC_ASN1_INTEGER, x, 1UL);
    LTC_SET_ASN1(seq, 1, LTC_ASN1_INTEGER, y, 1UL);
    SHOULD_FAIL(der_decode_sequence(s_broken_sequence, sizeof(s_broken_sequence), seq, 2));
-   mp_cleanup_multi(&y, &x, NULL);
+   mp_cleanup_multi(&y, &x, LTC_NULL);
    len = sizeof(s_broken_sequence);
 
-   mp_init_multi(&x, &y, NULL);
+   mp_init_multi(&x, &y, LTC_NULL);
    LTC_SET_ASN1(seq, 0, LTC_ASN1_INTEGER, x, 1UL);
    LTC_SET_ASN1(seq, 1, LTC_ASN1_INTEGER, y, 1UL);
    SHOULD_FAIL_WITH(der_decode_sequence(s_addtl_bytes, sizeof(s_addtl_bytes), seq, 2), CRYPT_INPUT_TOO_LONG);
-   mp_cleanup_multi(&y, &x, NULL);
+   mp_cleanup_multi(&y, &x, LTC_NULL);
    len = sizeof(s_addtl_bytes);
    s_der_decode_print(s_addtl_bytes, &len);
 
@@ -1500,7 +1500,7 @@ static void der_toolong_test(void)
       der_sequence_free(list);
    }
 
-   mp_init_multi(&int1, &int2, NULL);
+   mp_init_multi(&int1, &int2, LTC_NULL);
    LTC_SET_ASN1(seqint,  0, LTC_ASN1_INTEGER,      int1,   1);
    LTC_SET_ASN1(seqint,  1, LTC_ASN1_INTEGER,      int2,   1);
 
@@ -1536,7 +1536,7 @@ static void der_toolong_test(void)
       der_sequence_free(list);
    }
 
-   mp_clear_multi(int1, int2, NULL);
+   mp_clear_multi(int1, int2, LTC_NULL);
 
    LTC_SET_ASN1(seqoid,  0, LTC_ASN1_OBJECT_IDENTIFIER, oid, sizeof(oid)/sizeof(oid[0]));
    LTC_SET_ASN1(seqoid,  1, LTC_ASN1_NULL,              NULL,   0);
@@ -1693,7 +1693,7 @@ int der_test(void)
       y >>= 3;
    }
 
-   DO(mp_init_multi(&a, &b, &c, &d, &e, &f, &g, NULL));
+   DO(mp_init_multi(&a, &b, &c, &d, &e, &f, &g, LTC_NULL));
    for (zz = 0; zz < 16; zz++) {
 #ifdef USE_TFM
       for (z = 0; z < 256; z++) {
@@ -1711,7 +1711,7 @@ int der_test(void)
          DO(der_decode_integer(buf[0], y, b));
          if (y != x || mp_cmp(a, b) != LTC_MP_EQ) {
             fprintf(stderr, "%lu: %lu vs %lu\n", z, x, y);
-            mp_clear_multi(a, b, c, d, e, f, g, NULL);
+            mp_clear_multi(a, b, c, d, e, f, g, LTC_NULL);
             return 1;
          }
       }
@@ -1738,7 +1738,7 @@ int der_test(void)
             fprintf(stderr, "\n");
             for (z = 0; z < y; z++) fprintf(stderr, "%02x ", buf[1][z]);
             fprintf(stderr, "\n");
-            mp_clear_multi(a, b, c, d, e, f, g, NULL);
+            mp_clear_multi(a, b, c, d, e, f, g, LTC_NULL);
             return 1;
          }
 
@@ -1747,12 +1747,12 @@ int der_test(void)
          DO(der_decode_short_integer(buf[1], y, &x));
          if (x != mp_get_int(a)) {
             fprintf(stderr, "DER INTEGER short decoding failed, %lu, %lu\n", x, mp_get_int(a));
-            mp_clear_multi(a, b, c, d, e, f, g, NULL);
+            mp_clear_multi(a, b, c, d, e, f, g, LTC_NULL);
             return 1;
          }
       }
    }
-   mp_clear_multi(a, b, c, d, e, f, g, NULL);
+   mp_clear_multi(a, b, c, d, e, f, g, LTC_NULL);
 
 
 /* Test bit string */

--- a/tests/dh_test.c
+++ b/tests/dh_test.c
@@ -9,7 +9,7 @@ static int s_prime_test(void)
    void *p, *g, *tmp;
    int x, err, primality;
 
-   if ((err = mp_init_multi(&p, &g, &tmp, NULL)) != CRYPT_OK)               { goto error; }
+   if ((err = mp_init_multi(&p, &g, &tmp, LTC_NULL)) != CRYPT_OK)               { goto error; }
 
    for (x = 0; ltc_dh_sets[x].size != 0; x++) {
       /* tfm has a problem with larger sizes */
@@ -45,7 +45,7 @@ static int s_prime_test(void)
    err = CRYPT_OK;
 error:
 done:
-   mp_clear_multi(tmp, g, p, NULL);
+   mp_clear_multi(tmp, g, p, LTC_NULL);
    return err;
 }
 

--- a/tests/ecc_test.c
+++ b/tests/ecc_test.c
@@ -127,7 +127,7 @@ static int s_ecc_test_shamir(void)
    int x, y, z;
    unsigned char buf[ECC_BUF_SIZE];
 
-   DO(mp_init_multi(&kA, &kB, &rA, &rB, &modulus, &a, &mu, &ma, NULL));
+   DO(mp_init_multi(&kA, &kB, &rA, &rB, &modulus, &a, &mu, &ma, LTC_NULL));
    LTC_ARGCHK((G  = ltc_ecc_new_point()) != NULL);
    LTC_ARGCHK((A  = ltc_ecc_new_point()) != NULL);
    LTC_ARGCHK((B  = ltc_ecc_new_point()) != NULL);
@@ -193,7 +193,7 @@ static int s_ecc_test_shamir(void)
   ltc_ecc_del_point(B);
   ltc_ecc_del_point(A);
   ltc_ecc_del_point(G);
-  mp_clear_multi(kA, kB, rA, rB, modulus, a, mu, ma, NULL);
+  mp_clear_multi(kA, kB, rA, rB, modulus, a, mu, ma, LTC_NULL);
   return 0;
 }
 #endif
@@ -207,7 +207,7 @@ static int s_ecc_issue108(void)
    const ltc_ecc_curve* dp;
 
    /* init */
-   if ((err = mp_init_multi(&modulus, &order, &a, NULL)) != CRYPT_OK) { return err; }
+   if ((err = mp_init_multi(&modulus, &order, &a, LTC_NULL)) != CRYPT_OK) { return err; }
    Q      = ltc_ecc_new_point();
    Result = ltc_ecc_new_point();
 
@@ -229,7 +229,7 @@ static int s_ecc_issue108(void)
 done:
    ltc_ecc_del_point(Result);
    ltc_ecc_del_point(Q);
-   mp_clear_multi(modulus, order, a, NULL);
+   mp_clear_multi(modulus, order, a, LTC_NULL);
    return err;
 }
 
@@ -292,12 +292,12 @@ static int s_ecc_test_mp(void)
    int        i, err, primality;
    char buf[4096];
 
-   DO(mp_init_multi(&modulus, &order, &a, NULL));
+   DO(mp_init_multi(&modulus, &order, &a, LTC_NULL));
 
    G   = ltc_ecc_new_point();
    GG  = ltc_ecc_new_point();
    if (G == NULL || GG == NULL) {
-      mp_clear_multi(modulus, order, NULL);
+      mp_clear_multi(modulus, order, LTC_NULL);
       ltc_ecc_del_point(G);
       ltc_ecc_del_point(GG);
       return CRYPT_MEM;
@@ -344,7 +344,7 @@ static int s_ecc_test_mp(void)
 done:
    ltc_ecc_del_point(GG);
    ltc_ecc_del_point(G);
-   mp_clear_multi(order, modulus, a, NULL);
+   mp_clear_multi(order, modulus, a, LTC_NULL);
    return err;
 }
 

--- a/tests/misc_test.c
+++ b/tests/misc_test.c
@@ -34,5 +34,6 @@ int misc_test(void)
 #ifdef LTC_SSH
    ssh_test();
 #endif
+   no_null_termination_check_test();
    return 0;
 }

--- a/tests/multi_test.c
+++ b/tests/multi_test.c
@@ -26,19 +26,19 @@ int multi_test(void)
    len = sizeof(buf[0]);
    hash_memory(find_hash("sha256"), (unsigned char*)"hello", 5, buf[0], &len);
    len2 = sizeof(buf[0]);
-   hash_memory_multi(find_hash("sha256"), buf[1], &len2, (unsigned char*)"hello", 5, NULL);
+   hash_memory_multi(find_hash("sha256"), buf[1], &len2, (unsigned char*)"hello", 5, LTC_NULL);
    if (len != len2 || memcmp(buf[0], buf[1], len)) {
       printf("Failed: %d %lu %lu\n", __LINE__, len, len2);
       return CRYPT_FAIL_TESTVECTOR;
    }
    len2 = sizeof(buf[0]);
-   hash_memory_multi(find_hash("sha256"), buf[1], &len2, (unsigned char*)"he", 2UL, "llo", 3UL, NULL, 0);
+   hash_memory_multi(find_hash("sha256"), buf[1], &len2, (unsigned char*)"he", 2UL, "llo", 3UL, LTC_NULL);
    if (len != len2 || memcmp(buf[0], buf[1], len)) {
       printf("Failed: %d %lu %lu\n", __LINE__, len, len2);
       return CRYPT_FAIL_TESTVECTOR;
    }
    len2 = sizeof(buf[0]);
-   hash_memory_multi(find_hash("sha256"), buf[1], &len2, (unsigned char*)"h", 1UL, "e", 1UL, "l", 1UL, "l", 1UL, "o", 1UL, NULL);
+   hash_memory_multi(find_hash("sha256"), buf[1], &len2, (unsigned char*)"h", 1UL, "e", 1UL, "l", 1UL, "l", 1UL, "o", 1UL, LTC_NULL);
    if (len != len2 || memcmp(buf[0], buf[1], len)) {
       printf("Failed: %d %lu %lu\n", __LINE__, len, len2);
       return CRYPT_FAIL_TESTVECTOR;
@@ -48,19 +48,19 @@ int multi_test(void)
    len = sizeof(buf[0]);
    hmac_memory(find_hash("sha256"), key, 16, (unsigned char*)"hello", 5, buf[0], &len);
    len2 = sizeof(buf[0]);
-   hmac_memory_multi(find_hash("sha256"), key, 16, buf[1], &len2, (unsigned char*)"hello", 5UL, NULL);
+   hmac_memory_multi(find_hash("sha256"), key, 16, buf[1], &len2, (unsigned char*)"hello", 5UL, LTC_NULL);
    if (len != len2 || memcmp(buf[0], buf[1], len)) {
       printf("Failed: %d %lu %lu\n", __LINE__, len, len2);
       return CRYPT_FAIL_TESTVECTOR;
    }
    len2 = sizeof(buf[0]);
-   hmac_memory_multi(find_hash("sha256"), key, 16, buf[1], &len2, (unsigned char*)"he", 2UL, "llo", 3UL, NULL);
+   hmac_memory_multi(find_hash("sha256"), key, 16, buf[1], &len2, (unsigned char*)"he", 2UL, "llo", 3UL, LTC_NULL);
    if (len != len2 || memcmp(buf[0], buf[1], len)) {
       printf("Failed: %d %lu %lu\n", __LINE__, len, len2);
       return CRYPT_FAIL_TESTVECTOR;
    }
    len2 = sizeof(buf[0]);
-   hmac_memory_multi(find_hash("sha256"), key, 16, buf[1], &len2, (unsigned char*)"h", 1UL, "e", 1UL, "l", 1UL, "l", 1UL, "o", 1UL, NULL);
+   hmac_memory_multi(find_hash("sha256"), key, 16, buf[1], &len2, (unsigned char*)"h", 1UL, "e", 1UL, "l", 1UL, "l", 1UL, "o", 1UL, LTC_NULL);
    if (len != len2 || memcmp(buf[0], buf[1], len)) {
       printf("Failed: %d %lu %lu\n", __LINE__, len, len2);
       return CRYPT_FAIL_TESTVECTOR;
@@ -71,19 +71,19 @@ int multi_test(void)
    len = sizeof(buf[0]);
    omac_memory(find_cipher("aes"), key, 16, (unsigned char*)"hello", 5, buf[0], &len);
    len2 = sizeof(buf[0]);
-   omac_memory_multi(find_cipher("aes"), key, 16, buf[1], &len2, (unsigned char*)"hello", 5UL, NULL);
+   omac_memory_multi(find_cipher("aes"), key, 16, buf[1], &len2, (unsigned char*)"hello", 5UL, LTC_NULL);
    if (len != len2 || memcmp(buf[0], buf[1], len)) {
       printf("Failed: %d %lu %lu\n", __LINE__, len, len2);
       return CRYPT_FAIL_TESTVECTOR;
    }
    len2 = sizeof(buf[0]);
-   omac_memory_multi(find_cipher("aes"), key, 16, buf[1], &len2, (unsigned char*)"he", 2UL, "llo", 3UL, NULL);
+   omac_memory_multi(find_cipher("aes"), key, 16, buf[1], &len2, (unsigned char*)"he", 2UL, "llo", 3UL, LTC_NULL);
    if (len != len2 || memcmp(buf[0], buf[1], len)) {
       printf("Failed: %d %lu %lu\n", __LINE__, len, len2);
       return CRYPT_FAIL_TESTVECTOR;
    }
    len2 = sizeof(buf[0]);
-   omac_memory_multi(find_cipher("aes"), key, 16, buf[1], &len2, (unsigned char*)"h", 1UL, "e", 1UL, "l", 1UL, "l", 1UL, "o", 1UL, NULL);
+   omac_memory_multi(find_cipher("aes"), key, 16, buf[1], &len2, (unsigned char*)"h", 1UL, "e", 1UL, "l", 1UL, "l", 1UL, "o", 1UL, LTC_NULL);
    if (len != len2 || memcmp(buf[0], buf[1], len)) {
       printf("Failed: %d %lu %lu\n", __LINE__, len, len2);
       return CRYPT_FAIL_TESTVECTOR;
@@ -94,19 +94,19 @@ int multi_test(void)
    len = sizeof(buf[0]);
    pmac_memory(find_cipher("aes"), key, 16, (unsigned char*)"hello", 5, buf[0], &len);
    len2 = sizeof(buf[0]);
-   pmac_memory_multi(find_cipher("aes"), key, 16, buf[1], &len2, (unsigned char*)"hello", 5, NULL);
+   pmac_memory_multi(find_cipher("aes"), key, 16, buf[1], &len2, (unsigned char*)"hello", 5, LTC_NULL);
    if (len != len2 || memcmp(buf[0], buf[1], len)) {
       printf("Failed: %d %lu %lu\n", __LINE__, len, len2);
       return CRYPT_FAIL_TESTVECTOR;
    }
    len2 = sizeof(buf[0]);
-   pmac_memory_multi(find_cipher("aes"), key, 16, buf[1], &len2, (unsigned char*)"he", 2UL, "llo", 3UL, NULL);
+   pmac_memory_multi(find_cipher("aes"), key, 16, buf[1], &len2, (unsigned char*)"he", 2UL, "llo", 3UL, LTC_NULL);
    if (len != len2 || memcmp(buf[0], buf[1], len)) {
       printf("Failed: %d %lu %lu\n", __LINE__, len, len2);
       return CRYPT_FAIL_TESTVECTOR;
    }
    len2 = sizeof(buf[0]);
-   pmac_memory_multi(find_cipher("aes"), key, 16, buf[1], &len2, (unsigned char*)"h", 1UL, "e", 1UL, "l", 1UL, "l", 1UL, "o", 1UL, NULL);
+   pmac_memory_multi(find_cipher("aes"), key, 16, buf[1], &len2, (unsigned char*)"h", 1UL, "e", 1UL, "l", 1UL, "l", 1UL, "o", 1UL, LTC_NULL);
    if (len != len2 || memcmp(buf[0], buf[1], len)) {
       printf("Failed: %d %lu %lu\n", __LINE__, len, len2);
       return CRYPT_FAIL_TESTVECTOR;
@@ -117,19 +117,19 @@ int multi_test(void)
    len = sizeof(buf[0]);
    xcbc_memory(find_cipher("aes"), key, 16, (unsigned char*)"hello", 5, buf[0], &len);
    len2 = sizeof(buf[0]);
-   xcbc_memory_multi(find_cipher("aes"), key, 16, buf[1], &len2, (unsigned char*)"hello", 5, NULL);
+   xcbc_memory_multi(find_cipher("aes"), key, 16, buf[1], &len2, (unsigned char*)"hello", 5, LTC_NULL);
    if (len != len2 || memcmp(buf[0], buf[1], len)) {
       printf("Failed: %d %lu %lu\n", __LINE__, len, len2);
       return CRYPT_FAIL_TESTVECTOR;
    }
    len2 = sizeof(buf[0]);
-   xcbc_memory_multi(find_cipher("aes"), key, 16, buf[1], &len2, (unsigned char*)"he", 2UL, "llo", 3UL, NULL);
+   xcbc_memory_multi(find_cipher("aes"), key, 16, buf[1], &len2, (unsigned char*)"he", 2UL, "llo", 3UL, LTC_NULL);
    if (len != len2 || memcmp(buf[0], buf[1], len)) {
       printf("Failed: %d %lu %lu\n", __LINE__, len, len2);
       return CRYPT_FAIL_TESTVECTOR;
    }
    len2 = sizeof(buf[0]);
-   xcbc_memory_multi(find_cipher("aes"), key, 16, buf[1], &len2, (unsigned char*)"h", 1UL, "e", 1UL, "l", 1UL, "l", 1UL, "o", 1UL, NULL);
+   xcbc_memory_multi(find_cipher("aes"), key, 16, buf[1], &len2, (unsigned char*)"h", 1UL, "e", 1UL, "l", 1UL, "l", 1UL, "o", 1UL, LTC_NULL);
    if (len != len2 || memcmp(buf[0], buf[1], len)) {
       printf("Failed: %d %lu %lu\n", __LINE__, len, len2);
       return CRYPT_FAIL_TESTVECTOR;
@@ -140,19 +140,19 @@ int multi_test(void)
    len = sizeof(buf[0]);
    f9_memory(find_cipher("aes"), key, 16, (unsigned char*)"hello", 5, buf[0], &len);
    len2 = sizeof(buf[0]);
-   f9_memory_multi(find_cipher("aes"), key, 16, buf[1], &len2, (unsigned char*)"hello", 5, NULL);
+   f9_memory_multi(find_cipher("aes"), key, 16, buf[1], &len2, (unsigned char*)"hello", 5, LTC_NULL);
    if (len != len2 || memcmp(buf[0], buf[1], len)) {
       printf("Failed: %d %lu %lu\n", __LINE__, len, len2);
       return CRYPT_FAIL_TESTVECTOR;
    }
    len2 = sizeof(buf[0]);
-   f9_memory_multi(find_cipher("aes"), key, 16, buf[1], &len2, (unsigned char*)"he", 2UL, "llo", 3UL, NULL);
+   f9_memory_multi(find_cipher("aes"), key, 16, buf[1], &len2, (unsigned char*)"he", 2UL, "llo", 3UL, LTC_NULL);
    if (len != len2 || memcmp(buf[0], buf[1], len)) {
       printf("Failed: %d %lu %lu\n", __LINE__, len, len2);
       return CRYPT_FAIL_TESTVECTOR;
    }
    len2 = sizeof(buf[0]);
-   f9_memory_multi(find_cipher("aes"), key, 16, buf[1], &len2, (unsigned char*)"h", 1UL, "e", 1UL, "l", 1UL, "l", 1UL, "o", 1UL, NULL);
+   f9_memory_multi(find_cipher("aes"), key, 16, buf[1], &len2, (unsigned char*)"h", 1UL, "e", 1UL, "l", 1UL, "l", 1UL, "o", 1UL, LTC_NULL);
    if (len != len2 || memcmp(buf[0], buf[1], len)) {
       printf("Failed: %d %lu %lu\n", __LINE__, len, len2);
       return CRYPT_FAIL_TESTVECTOR;
@@ -167,19 +167,19 @@ int multi_test(void)
    len = sizeof(buf[0]);
    poly1305_memory(key, 32, (unsigned char*)"hello", 5, buf[0], &len);
    len2 = sizeof(buf[0]);
-   poly1305_memory_multi(key, 32, buf[1], &len2, (unsigned char*)"hello", 5, NULL);
+   poly1305_memory_multi(key, 32, buf[1], &len2, (unsigned char*)"hello", 5, LTC_NULL);
    if (len != len2 || memcmp(buf[0], buf[1], len)) {
       printf("Failed: %d %lu %lu\n", __LINE__, len, len2);
       return CRYPT_FAIL_TESTVECTOR;
    }
    len2 = sizeof(buf[0]);
-   poly1305_memory_multi(key, 32, buf[1], &len2, (unsigned char*)"he", 2UL, "llo", 3UL, NULL);
+   poly1305_memory_multi(key, 32, buf[1], &len2, (unsigned char*)"he", 2UL, "llo", 3UL, LTC_NULL);
    if (len != len2 || memcmp(buf[0], buf[1], len)) {
       printf("Failed: %d %lu %lu\n", __LINE__, len, len2);
       return CRYPT_FAIL_TESTVECTOR;
    }
    len2 = sizeof(buf[0]);
-   poly1305_memory_multi(key, 32, buf[1], &len2, (unsigned char*)"h", 1UL, "e", 1UL, "l", 1UL, "l", 1UL, "o", 1UL, NULL);
+   poly1305_memory_multi(key, 32, buf[1], &len2, (unsigned char*)"h", 1UL, "e", 1UL, "l", 1UL, "l", 1UL, "o", 1UL, LTC_NULL);
    if (len != len2 || memcmp(buf[0], buf[1], len)) {
       printf("Failed: %d %lu %lu\n", __LINE__, len, len2);
       return CRYPT_FAIL_TESTVECTOR;
@@ -190,19 +190,19 @@ int multi_test(void)
    len = 32;
    blake2smac_memory(key, 16, (unsigned char*)"hello", 5, buf[0], &len);
    len2 = 32;
-   blake2smac_memory_multi(key, 16, buf[1], &len2, (unsigned char*)"hello", 5, NULL);
+   blake2smac_memory_multi(key, 16, buf[1], &len2, (unsigned char*)"hello", 5, LTC_NULL);
    if (len != len2 || memcmp(buf[0], buf[1], len)) {
       printf("Failed: %d %lu %lu\n", __LINE__, len, len2);
       return CRYPT_FAIL_TESTVECTOR;
    }
    len2 = 32;
-   blake2smac_memory_multi(key, 16, buf[1], &len2, (unsigned char*)"he", 2UL, "llo", 3UL, NULL);
+   blake2smac_memory_multi(key, 16, buf[1], &len2, (unsigned char*)"he", 2UL, "llo", 3UL, LTC_NULL);
    if (len != len2 || memcmp(buf[0], buf[1], len)) {
       printf("Failed: %d %lu %lu\n", __LINE__, len, len2);
       return CRYPT_FAIL_TESTVECTOR;
    }
    len2 = 32;
-   blake2smac_memory_multi(key, 16, buf[1], &len2, (unsigned char*)"h", 1UL, "e", 1UL, "l", 1UL, "l", 1UL, "o", 1UL, NULL);
+   blake2smac_memory_multi(key, 16, buf[1], &len2, (unsigned char*)"h", 1UL, "e", 1UL, "l", 1UL, "l", 1UL, "o", 1UL, LTC_NULL);
    if (len != len2 || memcmp(buf[0], buf[1], len)) {
       printf("Failed: %d %lu %lu\n", __LINE__, len, len2);
       return CRYPT_FAIL_TESTVECTOR;
@@ -213,19 +213,19 @@ int multi_test(void)
    len = 64;
    blake2bmac_memory(key, 16, (unsigned char*)"hello", 5, buf[0], &len);
    len2 = 64;
-   blake2bmac_memory_multi(key, 16, buf[1], &len2, (unsigned char*)"hello", 5, NULL);
+   blake2bmac_memory_multi(key, 16, buf[1], &len2, (unsigned char*)"hello", 5, LTC_NULL);
    if (len != len2 || memcmp(buf[0], buf[1], len)) {
       printf("Failed: %d %lu %lu\n", __LINE__, len, len2);
       return CRYPT_FAIL_TESTVECTOR;
    }
    len2 = 64;
-   blake2bmac_memory_multi(key, 16, buf[1], &len2, (unsigned char*)"he", 2UL, "llo", 3UL, NULL);
+   blake2bmac_memory_multi(key, 16, buf[1], &len2, (unsigned char*)"he", 2UL, "llo", 3UL, LTC_NULL);
    if (len != len2 || memcmp(buf[0], buf[1], len)) {
       printf("Failed: %d %lu %lu\n", __LINE__, len, len2);
       return CRYPT_FAIL_TESTVECTOR;
    }
    len2 = 64;
-   blake2bmac_memory_multi(key, 16, buf[1], &len2, (unsigned char*)"h", 1UL, "e", 1UL, "l", 1UL, "l", 1UL, "o", 1UL, NULL);
+   blake2bmac_memory_multi(key, 16, buf[1], &len2, (unsigned char*)"h", 1UL, "e", 1UL, "l", 1UL, "l", 1UL, "o", 1UL, LTC_NULL);
    if (len != len2 || memcmp(buf[0], buf[1], len)) {
       printf("Failed: %d %lu %lu\n", __LINE__, len, len2);
       return CRYPT_FAIL_TESTVECTOR;

--- a/tests/no_null_termination_check_test.c
+++ b/tests/no_null_termination_check_test.c
@@ -1,0 +1,12 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis */
+/* SPDX-License-Identifier: Unlicense */
+
+#define LTC_NO_NULL_TERMINATION_CHECK
+#include "tomcrypt.h"
+
+#define NNTCT_NULL ((void *)0)
+
+int no_null_termination_check_test(void)
+{
+   return crypt_fsa(NNTCT_NULL, NNTCT_NULL, NNTCT_NULL, NNTCT_NULL, NNTCT_NULL, NNTCT_NULL, 0);
+}

--- a/tests/pkcs_1_eme_test.c
+++ b/tests/pkcs_1_eme_test.c
@@ -49,7 +49,7 @@ int pkcs_1_eme_test(void)
         DOX(stat == 1?CRYPT_OK:CRYPT_FAIL_TESTVECTOR, s->name);
     } /* for */
 
-    mp_clear_multi(key->d,  key->e, key->N, key->dQ, key->dP, key->qP, key->p, key->q, NULL);
+    mp_clear_multi(key->d,  key->e, key->N, key->dQ, key->dP, key->qP, key->p, key->q, LTC_NULL);
   } /* for */
 
   unregister_prng(no_prng_desc);

--- a/tests/pkcs_1_emsa_test.c
+++ b/tests/pkcs_1_emsa_test.c
@@ -46,7 +46,7 @@ int pkcs_1_emsa_test(void)
         DOX(stat == 1?CRYPT_OK:CRYPT_FAIL_TESTVECTOR, s->name);
     } /* for */
 
-    mp_clear_multi(key->d,  key->e, key->N, key->dQ, key->dP, key->qP, key->p, key->q, NULL);
+    mp_clear_multi(key->d,  key->e, key->N, key->dQ, key->dP, key->qP, key->p, key->q, LTC_NULL);
   } /* for */
 
   return 0;

--- a/tests/pkcs_1_oaep_test.c
+++ b/tests/pkcs_1_oaep_test.c
@@ -49,7 +49,7 @@ int pkcs_1_oaep_test(void)
         DOX(stat == 1?CRYPT_OK:CRYPT_FAIL_TESTVECTOR, s->name);
     } /* for */
 
-    mp_clear_multi(key->d,  key->e, key->N, key->dQ, key->dP, key->qP, key->p, key->q, NULL);
+    mp_clear_multi(key->d,  key->e, key->N, key->dQ, key->dP, key->qP, key->p, key->q, LTC_NULL);
   } /* for */
 
   unregister_prng(no_prng_desc);

--- a/tests/pkcs_1_pss_test.c
+++ b/tests/pkcs_1_pss_test.c
@@ -50,7 +50,7 @@ int pkcs_1_pss_test(void)
         DOX(stat == 1?CRYPT_OK:CRYPT_FAIL_TESTVECTOR, s->name);
     } /* for */
 
-    mp_clear_multi(key->d,  key->e, key->N, key->dQ, key->dP, key->qP, key->p, key->q, NULL);
+    mp_clear_multi(key->d,  key->e, key->N, key->dQ, key->dP, key->qP, key->p, key->q, LTC_NULL);
   } /* for */
 
   unregister_prng(no_prng_desc);

--- a/tests/ssh_test.c
+++ b/tests/ssh_test.c
@@ -127,7 +127,7 @@ static int s_ssh_encoding_test(void)
 
 
    /* mpint */
-   if ((err = mp_init_multi(&zero, &v, NULL)) != CRYPT_OK) {
+   if ((err = mp_init_multi(&zero, &v, LTC_NULL)) != CRYPT_OK) {
       return err;
    }
 
@@ -155,7 +155,7 @@ static int s_ssh_encoding_test(void)
                                 LTC_SSHDATA_EOL,   NULL));
    COMPARE_TESTVECTOR(buffer, buflen, mpint3, sizeof(mpint3), "enc-mpint",  3);
 
-   mp_clear_multi(v, zero, NULL);
+   mp_clear_multi(v, zero, LTC_NULL);
 
 
    /* name-list */
@@ -269,7 +269,7 @@ static int s_ssh_decoding_test(void)
    ENSURE(strlen("testing") + 4 == len);
 
    /* mpint */
-   if ((err = mp_init_multi(&u, &v, NULL)) != CRYPT_OK) {
+   if ((err = mp_init_multi(&u, &v, LTC_NULL)) != CRYPT_OK) {
       return err;
    }
 
@@ -295,7 +295,7 @@ static int s_ssh_decoding_test(void)
    ENSURE(mp_cmp_d(v, 0x80) == LTC_MP_EQ);
    ENSURE(sizeof(mpint3) == len);
 
-   mp_clear_multi(v, u, NULL);
+   mp_clear_multi(v, u, LTC_NULL);
 
    /* name-list */
    zeromem(strbuf, BUFSIZE);

--- a/tests/tomcrypt_test.h
+++ b/tests/tomcrypt_test.h
@@ -42,6 +42,7 @@ int x25519_test(void);
 int ed25519_test(void);
 int ssh_test(void);
 int bcrypt_test(void);
+int no_null_termination_check_test(void);
 
 #ifdef LTC_PKCS_1
 struct ltc_prng_descriptor* no_prng_desc_get(void);


### PR DESCRIPTION
Introduce `LTC_NULL_TERMINATED` and re-work some internals.

This will potentially trigger compiler warnings in user-code that didn't exist before (which are no real problem).
Users who can't or don't want to fix their code can still compile warning-free by defining `LTC_NO_NULL_TERMINATION_CHECK` before including `tomcrypt.h`.

Check commit messages for further details.
