### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,18 @@ The entire set of the variables is only supported in `makefile`, `makefile.share
 
 In case you have to use one of the other makefiles, check in the file which variables are supported.
 
+## Installing libtomcrypt (vcpkg)
+
+Alternatively, you can build and install libtomcrypt using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install libtomcrypt
+
+The libtomcrypt port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ### Examples
 
 You want to install the static library to the default paths


### PR DESCRIPTION
`libtomcrypt` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `libtomcrypt` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `libtomcrypt`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/libtomcrypt/portfile.cmake). We try to keep the library maintained as close as possible to the original library. 😊