### PR TITLE
Added gcm_reset() to gcm_memory() to avoid key leakage

### DIFF
--- a/src/encauth/gcm/gcm_memory.c
+++ b/src/encauth/gcm/gcm_memory.c
@@ -106,6 +106,7 @@ int gcm_memory(      int           cipher,
        err = CRYPT_INVALID_ARG;
     }
 LTC_ERR:
+    gcm_reset(gcm);
     XFREE(orig);
     return err;
 }


### PR DESCRIPTION
<!--

Thank you for your pull request.

If this fixes an existing github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.

-->

In current design of GCM encryption scheme, the memory space for gcm_state only gets freed at the end of gcm_memory(), which might have a potential risk of key leakage during a crash. A call of `gcm_reset()` was added to prevent this leakage.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

* [ N/A] documentation is added or updated
* [ N/A] tests are added or updated
