### PR TITLE
fix pkcs_1_v1_5_decode() when empty message

### DIFF
--- a/src/pk/pkcs1/pkcs_1_oaep_encode.c
+++ b/src/pk/pkcs1/pkcs_1_oaep_encode.c
@@ -33,7 +33,7 @@ int pkcs_1_oaep_encode(const unsigned char *msg,    unsigned long msglen,
    unsigned long hLen, x, y, modulus_len;
    int           err;
 
-   LTC_ARGCHK(msg    != NULL);
+   LTC_ARGCHK((msglen == 0) || (msg != NULL));
    LTC_ARGCHK(out    != NULL);
    LTC_ARGCHK(outlen != NULL);
 
@@ -95,9 +95,11 @@ int pkcs_1_oaep_encode(const unsigned char *msg,    unsigned long msglen,
    /* 0x01 byte */
    DB[x++] = 0x01;
 
-   /* message (length = msglen) */
-   XMEMCPY(DB+x, msg, msglen);
-   x += msglen;
+   if (msglen != 0) {
+      /* message (length = msglen) */
+      XMEMCPY(DB+x, msg, msglen);
+      x += msglen;
+   }
 
    /* now choose a random seed */
    if (prng_descriptor[prng_idx].read(seed, hLen, prng) != hLen) {

--- a/src/pk/pkcs1/pkcs_1_v1_5_decode.c
+++ b/src/pk/pkcs1/pkcs_1_v1_5_decode.c
@@ -58,7 +58,7 @@ int pkcs_1_v1_5_decode(const unsigned char *msg,
     }
     ps_len = i++ - 2;
 
-    if (i >= modulus_len) {
+    if (i > modulus_len) {
       /* There was no octet with hexadecimal value 0x00 to separate ps from m.
        */
       result = CRYPT_INVALID_PACKET;

--- a/src/pk/pkcs1/pkcs_1_v1_5_encode.c
+++ b/src/pk/pkcs1/pkcs_1_v1_5_encode.c
@@ -35,6 +35,10 @@ int pkcs_1_v1_5_encode(const unsigned char *msg,
   unsigned char *ps;
   int result;
 
+  LTC_ARGCHK((msglen == 0) || (msg != NULL));
+  LTC_ARGCHK(out    != NULL);
+  LTC_ARGCHK(outlen != NULL);
+
   /* valid block_type? */
   if ((block_type != LTC_PKCS_1_EMSA) &&
       (block_type != LTC_PKCS_1_EME)) {
@@ -88,7 +92,9 @@ int pkcs_1_v1_5_encode(const unsigned char *msg,
   out[0]          = 0x00;
   out[1]          = (unsigned char)block_type;  /* block_type 1 or 2 */
   out[2 + ps_len] = 0x00;
-  XMEMCPY(&out[2 + ps_len + 1], msg, msglen);
+  if (msglen != 0) {
+    XMEMCPY(&out[2 + ps_len + 1], msg, msglen);
+  }
   *outlen = modulus_len;
 
   result  = CRYPT_OK;

--- a/src/pk/rsa/rsa_decrypt_key.c
+++ b/src/pk/rsa/rsa_decrypt_key.c
@@ -33,6 +33,7 @@ int rsa_decrypt_key_ex(const unsigned char *in,             unsigned long  inlen
   int           err;
   unsigned char *tmp;
 
+  LTC_ARGCHK(in     != NULL);
   LTC_ARGCHK(out    != NULL);
   LTC_ARGCHK(outlen != NULL);
   LTC_ARGCHK(key    != NULL);

--- a/src/pk/rsa/rsa_encrypt_key.c
+++ b/src/pk/rsa/rsa_encrypt_key.c
@@ -34,7 +34,7 @@ int rsa_encrypt_key_ex(const unsigned char *in,       unsigned long  inlen,
   unsigned long modulus_bitlen, modulus_bytelen, x;
   int           err;
 
-  LTC_ARGCHK(in     != NULL);
+  LTC_ARGCHK((inlen == 0) || (in != NULL));
   LTC_ARGCHK(out    != NULL);
   LTC_ARGCHK(outlen != NULL);
   LTC_ARGCHK(key    != NULL);

--- a/tests/rsa_test.c
+++ b/tests/rsa_test.c
@@ -500,7 +500,7 @@ print_hex("q", tmp, len);
 
    /* encrypt the key (without lparam) */
    for (cnt = 0; cnt < 4; cnt++) {
-   for (rsa_msgsize = 1; rsa_msgsize <= 86; rsa_msgsize++) {
+   for (rsa_msgsize = 0; rsa_msgsize <= 86; rsa_msgsize++) {
       /* make a random key/msg */
       ENSURE(yarrow_read(in, rsa_msgsize, &yarrow_prng) == rsa_msgsize);
 
@@ -523,10 +523,10 @@ print_hex("q", tmp, len);
    }
 
    /* encrypt the key (with lparam) */
-   for (rsa_msgsize = 1; rsa_msgsize <= 86; rsa_msgsize++) {
+   for (rsa_msgsize = 0; rsa_msgsize <= 86; rsa_msgsize++) {
       len  = sizeof(out);
       len2 = rsa_msgsize;
-      DO(rsa_encrypt_key(in, rsa_msgsize, out, &len, lparam, sizeof(lparam), &yarrow_prng, prng_idx, hash_idx, &key));
+      DO(rsa_encrypt_key(rsa_msgsize ? in : NULL, rsa_msgsize, out, &len, lparam, sizeof(lparam), &yarrow_prng, prng_idx, hash_idx, &key));
       /* change a byte */
       out[8] ^= 1;
       SHOULD_FAIL(rsa_decrypt_key(out, len, tmp, &len2, lparam, sizeof(lparam), hash_idx, &stat2, &key));
@@ -542,7 +542,7 @@ print_hex("q", tmp, len);
    }
 
    /* encrypt the key PKCS #1 v1.5 (payload from 1 to 117 bytes) */
-   for (rsa_msgsize = 1; rsa_msgsize <= 117; rsa_msgsize++) {
+   for (rsa_msgsize = 0; rsa_msgsize <= 117; rsa_msgsize++) {
       len  = sizeof(out);
       len2 = rsa_msgsize;
       /* make a random key/msg */


### PR DESCRIPTION
In case of EME-PKCS1-v1_5 decoding, the encoded message format is as follow : EM = 0x00 || 0x02 || PS || 0x00 || M. When using an empty message, the 0x00 octet that separates the padding string and message is located at the end. Thus, update the condition to pass the check in case of empty message.

This fixes the following AOSP cts test:
Module: CtsKeystoreTestCases
Test: testEmptyPlaintextEncryptsAndDecrypts
Link: https://android.googlesource.com/platform/cts/+/refs/tags/android-cts-12.0_r6/tests/tests/keystore/src/android/keystore/cts/CipherTest.java

<!--

Thank you for your pull request.

If this fixes an existing github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.

-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

* [x] documentation is added or updated
* [x] tests are added or updated
