### PR TITLE
Simplify AES-NI detection logic

### DIFF
--- a/src/headers/tomcrypt_cfg.h
+++ b/src/headers/tomcrypt_cfg.h
@@ -91,9 +91,9 @@ LTC_EXPORT int   LTC_CALL XSTRCMP(const char *s1, const char *s2);
    #define ENDIAN_LITTLE
    #define ENDIAN_64BITWORD
    #define LTC_FAST
-   #if defined(__SSE4_1__)
-      #if __SSE4_1__ == 1
-         #define LTC_AMD64_SSE4_1
+   #if defined(__SSE4_1__) && defined(__AES__) && defined(LTC_AES_NI)
+      #if (__SSE4_1__ == 1) && (__AES__ == 1)
+         #define LTC_HAS_AES_NI
       #endif
    #endif
 #endif

--- a/src/headers/tomcrypt_cipher.h
+++ b/src/headers/tomcrypt_cipher.h
@@ -719,7 +719,7 @@ extern const struct ltc_cipher_descriptor rijndael_desc;
 extern const struct ltc_cipher_descriptor rijndael_enc_desc;
 #endif
 
-#if defined(LTC_AES_NI) && defined(LTC_AMD64_SSE4_1)
+#if defined(LTC_HAS_AES_NI)
 int aesni_is_supported(void);
 int aesni_setup(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey);
 int aesni_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const symmetric_key *skey);

--- a/src/headers/tomcrypt_custom.h
+++ b/src/headers/tomcrypt_custom.h
@@ -179,7 +179,7 @@
 #define LTC_RC6
 #define LTC_SAFERP
 #define LTC_RIJNDAEL
-#ifndef LTC_NO_AES_NI
+#if !defined(LTC_NO_AES_NI)
    #define LTC_AES_NI
 #endif
 #define LTC_XTEA

--- a/src/headers/tomcrypt_private.h
+++ b/src/headers/tomcrypt_private.h
@@ -98,10 +98,6 @@ typedef struct
 
 /* tomcrypt_cipher.h */
 
-#if defined(LTC_AES_NI) && defined(LTC_AMD64_SSE4_1)
-#define LTC_HAS_AES_NI
-#endif
-
 void blowfish_enc(ulong32 *data, unsigned long blocks, const symmetric_key *skey);
 int blowfish_expand(const unsigned char *key, int keylen,
                     const unsigned char *data, int datalen,

--- a/src/misc/crypt/crypt.c
+++ b/src/misc/crypt/crypt.c
@@ -422,7 +422,7 @@ const char *crypt_build_settings =
 #if defined(LTC_ADLER32)
     " ADLER32 "
 #endif
-#if defined(LTC_AES_NI) && defined(LTC_AMD64_SSE4_1)
+#if defined(LTC_AES_NI) && defined(LTC_HAS_AES_NI)
     " AES-NI "
 #endif
 #if defined(LTC_BASE64)


### PR DESCRIPTION
Based on the patch provided by @thesamesam via [0], but slighly modified.

@thesamesam could you maybe test whether this patch is fine as well?

[0] https://github.com/DCIT/perl-CryptX/pull/99
