### PR TITLE
fix XCALLOC() against GCC 14 -Wcalloc-transposed-args

### DIFF
--- a/src/pk/asn1/der/sequence/der_decode_sequence_flexi.c
+++ b/src/pk/asn1/der/sequence/der_decode_sequence_flexi.c
@@ -268,7 +268,7 @@ static int s_der_decode_sequence_flexi(const unsigned char *in, unsigned long *i
             }
             l->size = len;
 
-            if ((l->data = XCALLOC(sizeof(wchar_t), l->size)) == NULL) {
+            if ((l->data = XCALLOC(l->size, sizeof(wchar_t))) == NULL) {
                err = CRYPT_MEM;
                goto error;
             }

--- a/src/pk/asn1/der/sequence/der_decode_sequence_multi.c
+++ b/src/pk/asn1/der/sequence/der_decode_sequence_multi.c
@@ -77,7 +77,7 @@ static int s_der_decode_sequence_va(const unsigned char *in, unsigned long inlen
       return CRYPT_NOP;
    }
 
-   list = XCALLOC(sizeof(*list), x);
+   list = XCALLOC(x, sizeof(*list));
    if (list == NULL) {
       return CRYPT_MEM;
    }

--- a/src/pk/asn1/der/sequence/der_encode_sequence_multi.c
+++ b/src/pk/asn1/der/sequence/der_encode_sequence_multi.c
@@ -80,7 +80,7 @@ int der_encode_sequence_multi(unsigned char *out, unsigned long *outlen, ...)
       return CRYPT_NOP;
    }
 
-   list = XCALLOC(sizeof(*list), x);
+   list = XCALLOC(x, sizeof(*list));
    if (list == NULL) {
       return CRYPT_MEM;
    }


### PR DESCRIPTION
Fix use of XCALLOC() macro against GCC 14 directive -Wcalloc-transposed-args that makes GCC to complain with an warning/error trace message like the below when 1st argument is given by sizeof().

`warning: 'calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Wcalloc-transposed-args]`

No functional changes.

We experienced this issue building OP-TEE OS (https://github.com/OP-TE/optee_os.git, that host libtomcrypt library) with latest Yocto *Styhead* that uses GCC 14.1.

<!--

Thank you for your pull request.

If this fixes an existing github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.

-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

* [ ] documentation is added or updated
* [ ] tests are added or updated
