### PR TITLE
fix unused variable warning in hashes/tiger

### DIFF
--- a/src/hashes/tiger.c
+++ b/src/hashes/tiger.c
@@ -794,6 +794,7 @@ int tiger_done(hash_state * md, unsigned char *out)
 int s_tiger_test(unsigned int idx)
 {
  #ifndef LTC_TEST
+    LTC_UNUSED_PARAM(idx);
     return CRYPT_NOP;
  #else
   static const struct {

--- a/src/hashes/tiger.c
+++ b/src/hashes/tiger.c
@@ -791,7 +791,7 @@ int tiger_done(hash_state * md, unsigned char *out)
   Self-test the hash
   @return CRYPT_OK if successful, CRYPT_NOP if self-tests have been disabled
 */
-int s_tiger_test(unsigned int idx)
+static int s_tiger_test(unsigned int idx)
 {
  #ifndef LTC_TEST
     LTC_UNUSED_PARAM(idx);


### PR DESCRIPTION
Just cosmestics