### PR TITLE
introducing macro LTC_NO_WIN32_BCRYPT

### DIFF
--- a/src/headers/tomcrypt_cfg.h
+++ b/src/headers/tomcrypt_cfg.h
@@ -312,7 +312,10 @@ typedef unsigned long ltc_mp_digit;
 #   endif
 #endif
 
-#if defined(_MSC_VER) && defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0600 && !defined(LTC_WIN32_BCRYPT)
+/* Define `LTC_NO_WIN32_BCRYPT` in the user code
+ * before including `tomcrypt.h` to disable this functionality.
+ */
+#if defined(_MSC_VER) && defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0600 && !defined(LTC_NO_WIN32_BCRYPT)
 #   define LTC_WIN32_BCRYPT
 #endif
 


### PR DESCRIPTION
Forcing the use of `BCryptGenRandom` with newer MS Visual Studio makes me troubles with my CryptX module.

See https://www.cpantesters.org/cpan/report/00af9ff6-6e86-1014-b515-6e66cb952333

Defining LTC_NO_WIN32_BCRYPT avoids using `BCryptGenRandom`