### PR TITLE
fix: tests/cipher_hash_test.c failed to use aes_enc_test

### DIFF
--- a/tests/cipher_hash_test.c
+++ b/tests/cipher_hash_test.c
@@ -20,7 +20,13 @@ int cipher_hash_test(void)
    }
    DO(rijndael_test());
 #endif
+#if defined(LTC_RIJNDAEL)
+#ifndef ENCRYPT_ONLY
+   DO(aes_test());
+#else
    DO(aes_enc_test());
+#endif
+#endif
 
    /* test stream ciphers */
 #ifdef LTC_CHACHA


### PR DESCRIPTION
Depending on build circumstances, the AES test function is either
aes_test() or aes_enc_test().
