### PR TITLE
Make the definition of LTC_WIN32_BCRYPT private

### DIFF
--- a/src/headers/tomcrypt_cfg.h
+++ b/src/headers/tomcrypt_cfg.h
@@ -312,10 +312,6 @@ typedef unsigned long ltc_mp_digit;
 #   endif
 #endif
 
-#if defined(_MSC_VER) && defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0600 && !defined(LTC_WIN32_BCRYPT)
-#   define LTC_WIN32_BCRYPT
-#endif
-
 /* Define `LTC_NO_NULL_TERMINATION_CHECK` in the user code
  * before including `tomcrypt.h` to disable this functionality.
  */

--- a/src/headers/tomcrypt_private.h
+++ b/src/headers/tomcrypt_private.h
@@ -682,3 +682,14 @@ int which ## _export(unsigned char *out, unsigned long *outlen, prng_state *prng
 #else
    #define LTC_BYTE(x, n) (((x) >> (8 * (n))) & 255)
 #endif
+
+/*
+ * On Windows, choose whether to use CryptGenRandom() [older Windows versions]
+ * or BCryptGenRandom() [newer Windows versions].
+ * If CryptGenRandom() is desired, define LTC_NO_WIN32_BCRYPT when building.
+ */
+#if defined(_MSC_VER) && defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0600
+   #if !defined(LTC_NO_WIN32_BCRYPT)
+      #define LTC_WIN32_BCRYPT
+   #endif
+#endif


### PR DESCRIPTION
1. It's internal anyway, so doesn't quite need to be reflected in a
   public header file.
2. This makes it easy for someone build this library to choose not
   to use BCryptGenRandom() by simply definining LTC_NO_WIN32_BCRYPT,
   which was hard to reflect in an unmodified public header file.

Alternative to #653
