### PR TITLE
Fix compiler warning

### DIFF
--- a/src/encauth/ccm/ccm_add_nonce.c
+++ b/src/encauth/ccm/ccm_add_nonce.c
@@ -58,6 +58,9 @@ int ccm_add_nonce(ccm_state *ccm,
       ccm->PAD[x++] = 0;
    }
    for (; y < ccm->L; y++) {
+      if (x >= sizeof(ccm->PAD)) {
+         return CRYPT_INVALID_ARG;
+      }
       ccm->PAD[x++] = (unsigned char)((len >> 24) & 255);
       len <<= 8;
    }


### PR DESCRIPTION
Repeated from 97edea362a34cb89b0e83bb503bde9e13ae817ba

```
src/encauth/ccm/ccm_add_nonce.c: In function ‘ccm_add_nonce’:
src/encauth/ccm/ccm_add_nonce.c:61:21: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
   61 |       ccm->PAD[x++] = (unsigned char)((len >> 24) & 255);
      |       ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ./src/headers/tomcrypt.h:82,
                 from ./src/headers/tomcrypt_private.h:4,
                 from src/encauth/ccm/ccm_add_nonce.c:3:
./src/headers/tomcrypt_mac.h:410:24: note: at offset 16 into destination object ‘PAD’ of size 16
  410 |    unsigned char       PAD[16],              /* flags | Nonce N | l(m) */
```

<!--

Thank you for your pull request.

If this fixes an existing github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.

-->