### PR TITLE
Constify math descriptors

### DIFF
--- a/demos/tv_gen.c
+++ b/demos/tv_gen.c
@@ -678,11 +678,11 @@ static void ecc_gen(void)
         fprintf(out, "%s\n", ltc_ecc_curves[x].OID);
         mp_set(k, 1);
 
-        mp_read_radix(order,   (char *)ltc_ecc_curves[x].order, 16);
-        mp_read_radix(modulus, (char *)ltc_ecc_curves[x].prime, 16);
-        mp_read_radix(a,       (char *)ltc_ecc_curves[x].A,     16);
-        mp_read_radix(G->x,    (char *)ltc_ecc_curves[x].Gx,    16);
-        mp_read_radix(G->y,    (char *)ltc_ecc_curves[x].Gy,    16);
+        mp_read_radix(order,   ltc_ecc_curves[x].order, 16);
+        mp_read_radix(modulus, ltc_ecc_curves[x].prime, 16);
+        mp_read_radix(a,       ltc_ecc_curves[x].A,     16);
+        mp_read_radix(G->x,    ltc_ecc_curves[x].Gx,    16);
+        mp_read_radix(G->y,    ltc_ecc_curves[x].Gy,    16);
         mp_set(G->z, 1);
 
         while (mp_cmp(k, order) == LTC_MP_LT) {

--- a/doc/crypt.tex
+++ b/doc/crypt.tex
@@ -9537,7 +9537,7 @@ it hasn't proven hard to write \textit{glue} to use math libraries so far.  The 
 /** math descriptor */
 typedef struct {
    /** Name of the math provider */
-   char *name;
+   const char *name;
 
    /** Bits per digit, amount of bits must fit in an unsigned long */
    int  bits_per_digit;
@@ -9555,7 +9555,7 @@ typedef struct {
      @param  src    The number to copy from
      @return CRYPT_OK on success
    */
-   int (*init_copy)(void **dst, void *src);
+   int (*init_copy)(void **dst, const void *src);
 
    /** deinit
       @param   a    The number to free
@@ -9570,14 +9570,14 @@ typedef struct {
       @param   dst   The destination
       @return CRYPT_OK on success
    */
-   int (*neg)(void *src, void *dst);
+   int (*neg)(const void *src, void *dst);
 
    /** copy
       @param   src   The number to copy from
       @param   dst   The number to write to
       @return CRYPT_OK on success
    */
-   int (*copy)(void *src, void *dst);
+   int (*copy)(const void *src, void *dst);
 
 /* ---- trivial low level functions ---- */
 
@@ -9593,20 +9593,20 @@ typedef struct {
                 only fetches up to bits_per_digit from the number
       @return   The lower bits_per_digit of the integer (unsigned)
    */
-   unsigned long (*get_int)(void *a);
+   unsigned long (*get_int)(const void *a);
 
    /** get digit n
      @param a  The number to read from
      @param n  The number of the digit to fetch
      @return  The bits_per_digit  sized n'th digit of a
    */
-   ltc_mp_digit (*get_digit)(void *a, int n);
+   ltc_mp_digit (*get_digit)(const void *a, int n);
 
    /** Get the number of digits that represent the number
      @param a   The number to count
      @return The number of digits used to represent the number
    */
-   int (*get_digit_count)(void *a);
+   int (*get_digit_count)(const void *a);
 
    /** compare two integers
      @param a   The left side integer
@@ -9615,7 +9615,7 @@ typedef struct {
              LTC_MP_GT if a > b and
              LTC_MP_EQ otherwise.  (signed comparison)
    */
-   int (*compare)(void *a, void *b);
+   int (*compare)(const void *a, const void *b);
 
    /** compare against int
      @param a   The left side integer
@@ -9624,19 +9624,19 @@ typedef struct {
              LTC_MP_GT if a > b and
              LTC_MP_EQ otherwise.  (signed comparison)
    */
-   int (*compare_d)(void *a, unsigned long n);
+   int (*compare_d)(const void *a, unsigned long n);
 
    /** Count the number of bits used to represent the integer
      @param a   The integer to count
      @return The number of bits required to represent the integer
    */
-   int (*count_bits)(void * a);
+   int (*count_bits)(const void * a);
 
    /** Count the number of LSB bits which are zero
      @param a   The integer to count
      @return The number of contiguous zero LSB bits
    */
-   int (*count_lsb_bits)(void *a);
+   int (*count_lsb_bits)(const void *a);
 
    /** Compute a power of two
      @param a  The integer to store the power in
@@ -9661,20 +9661,20 @@ typedef struct {
      @param radix The radix the integer is to be represented in (2-64)
      @return CRYPT_OK on success
    */
-   int (*write_radix)(void *a, char *str, int radix);
+   int (*write_radix)(const void *a, char *str, int radix);
 
    /** get size as unsigned char string
      @param a  The integer to get the size (when stored in array of octets)
      @return   The length of the integer in octets
    */
-   unsigned long (*unsigned_size)(void *a);
+   unsigned long (*unsigned_size)(const void *a);
 
    /** store an integer as an array of octets
      @param src   The integer to store
      @param dst   The buffer to store the integer in
      @return CRYPT_OK on success
    */
-   int (*unsigned_write)(void *src, unsigned char *dst);
+   int (*unsigned_write)(const void *src, unsigned char *dst);
 
    /** read an array of octets and store as integer
      @param dst   The integer to load
@@ -9682,9 +9682,9 @@ typedef struct {
      @param len   The number of octets
      @return CRYPT_OK on success
    */
-   int (*unsigned_read)(         void *dst,
-                        unsigned char *src,
-                        unsigned long  len);
+   int (*unsigned_read)(               void *dst,
+                        const unsigned char *src,
+                              unsigned long  len);
 
 /* ---- basic math ---- */
 
@@ -9694,7 +9694,7 @@ typedef struct {
      @param c   The destination of "a + b"
      @return CRYPT_OK on success
    */
-   int (*add)(void *a, void *b, void *c);
+   int (*add)(const void *a, const void *b, void *c);
 
    /** add two integers
      @param a   The first source integer
@@ -9703,7 +9703,7 @@ typedef struct {
      @param c   The destination of "a + b"
      @return CRYPT_OK on success
    */
-   int (*addi)(void *a, unsigned long b, void *c);
+   int (*addi)(const void *a, unsigned long b, void *c);
 
    /** subtract two integers
      @param a   The first source integer
@@ -9711,7 +9711,7 @@ typedef struct {
      @param c   The destination of "a - b"
      @return CRYPT_OK on success
    */
-   int (*sub)(void *a, void *b, void *c);
+   int (*sub)(const void *a, const void *b, void *c);
 
    /** subtract two integers
      @param a   The first source integer
@@ -9720,7 +9720,7 @@ typedef struct {
      @param c   The destination of "a - b"
      @return CRYPT_OK on success
    */
-   int (*subi)(void *a, unsigned long b, void *c);
+   int (*subi)(const void *a, unsigned long b, void *c);
 
    /** multiply two integers
      @param a   The first source integer
@@ -9729,7 +9729,7 @@ typedef struct {
      @param c   The destination of "a * b"
      @return CRYPT_OK on success
    */
-   int (*mul)(void *a, void *b, void *c);
+   int (*mul)(const void *a, const void *b, void *c);
 
    /** multiply two integers
      @param a   The first source integer
@@ -9738,14 +9738,14 @@ typedef struct {
      @param c   The destination of "a * b"
      @return CRYPT_OK on success
    */
-   int (*muli)(void *a, unsigned long b, void *c);
+   int (*muli)(const void *a, unsigned long b, void *c);
 
    /** Square an integer
      @param a    The integer to square
      @param b    The destination
      @return CRYPT_OK on success
    */
-   int (*sqr)(void *a, void *b);
+   int (*sqr)(const void *a, void *b);
 
    /** Divide an integer
      @param a    The dividend
@@ -9754,14 +9754,14 @@ typedef struct {
      @param d    The remainder (can be NULL to signify don't care)
      @return CRYPT_OK on success
    */
-   int (*mpdiv)(void *a, void *b, void *c, void *d);
+   int (*mpdiv)(const void *a, const void *b, void *c, void *d);
 
    /** divide by two
       @param  a   The integer to divide (shift right)
       @param  b   The destination
       @return CRYPT_OK on success
    */
-   int (*div_2)(void *a, void *b);
+   int (*div_2)(const void *a, void *b);
 
    /** Get remainder (small value)
       @param  a    The integer to reduce
@@ -9769,7 +9769,7 @@ typedef struct {
       @param  c    The destination for the residue
       @return CRYPT_OK on success
    */
-   int (*modi)(void *a, unsigned long b, unsigned long *c);
+   int (*modi)(const void *a, unsigned long b, unsigned long *c);
 
    /** gcd
       @param  a     The first integer
@@ -9777,7 +9777,7 @@ typedef struct {
       @param  c     The destination for (a, b)
       @return CRYPT_OK on success
    */
-   int (*gcd)(void *a, void *b, void *c);
+   int (*gcd)(const void *a, const void *b, void *c);
 
    /** lcm
       @param  a     The first integer
@@ -9785,7 +9785,7 @@ typedef struct {
       @param  c     The destination for [a, b]
       @return CRYPT_OK on success
    */
-   int (*lcm)(void *a, void *b, void *c);
+   int (*lcm)(const void *a, const void *b, void *c);
 
    /** Modular multiplication
       @param  a     The first source
@@ -9794,7 +9794,7 @@ typedef struct {
       @param  d     The destination (a*b mod c)
       @return CRYPT_OK on success
    */
-   int (*mulmod)(void *a, void *b, void *c, void *d);
+   int (*mulmod)(const void *a, const void *b, const void *c, void *d);
 
    /** Modular squaring
       @param  a     The first source
@@ -9802,7 +9802,7 @@ typedef struct {
       @param  c     The destination (a*a mod b)
       @return CRYPT_OK on success
    */
-   int (*sqrmod)(void *a, void *b, void *c);
+   int (*sqrmod)(const void *a, const void *b, void *c);
 
    /** Modular inversion
       @param  a     The value to invert
@@ -9810,7 +9810,7 @@ typedef struct {
       @param  c     The destination (1/a mod b)
       @return CRYPT_OK on success
    */
-   int (*invmod)(void *, void *, void *);
+   int (*invmod)(const void *a, const void *b, void *c);
 
 /* ---- reduction ---- */
 
@@ -9819,14 +9819,14 @@ typedef struct {
        @param b  The destination for the reduction digit
        @return CRYPT_OK on success
    */
-   int (*montgomery_setup)(void *a, void **b);
+   int (*montgomery_setup)(const void *a, void **b);
 
    /** get normalization value
        @param a   The destination for the normalization value
        @param b   The modulus
        @return  CRYPT_OK on success
    */
-   int (*montgomery_normalization)(void *a, void *b);
+   int (*montgomery_normalization)(void *a, const void *b);
 
    /** reduce a number
        @param a   The number [and dest] to reduce
@@ -9834,7 +9834,7 @@ typedef struct {
        @param c   The value "b" from montgomery_setup()
        @return CRYPT_OK on success
    */
-   int (*montgomery_reduce)(void *a, void *b, void *c);
+   int (*montgomery_reduce)(void *a, const void *b, void *c);
 
    /** clean up  (frees memory)
        @param a   The value "b" from montgomery_setup()
@@ -9851,7 +9851,7 @@ typedef struct {
        @param d    The destination
        @return CRYPT_OK on success
    */
-   int (*exptmod)(void *a, void *b, void *c, void *d);
+   int (*exptmod)(const void *a, const void *b, const void *c, void *d);
 
    /** Primality testing
        @param a     The integer to test
@@ -9859,7 +9859,7 @@ typedef struct {
        @param c     The destination of the result (FP_YES if prime)
        @return CRYPT_OK on success
    */
-   int (*isprime)(void *a, int b, int *c);
+   int (*isprime)(const void *a, int b, int *c);
 
 /* ----  (optional) ecc point math ---- */
 
@@ -9867,42 +9867,48 @@ typedef struct {
        @param k   The integer to multiply the point by
        @param G   The point to multiply
        @param R   The destination for kG
+       @param a   ECC curve parameter a
        @param modulus  The modulus for the field
        @param map Boolean indicated whether to map back to affine or not
                   (can be ignored if you work in affine only)
        @return CRYPT_OK on success
    */
-   int (*ecc_ptmul)(     void *k,
-                    ecc_point *G,
-                    ecc_point *R,
-                         void *modulus,
+   int (*ecc_ptmul)(     const void *k,
+                    const ecc_point *G,
+                          ecc_point *R,
+                         const void *a,
+                         const void *modulus,
                           int  map);
 
    /** ECC GF(p) point addition
        @param P    The first point
        @param Q    The second point
        @param R    The destination of P + Q
+       @param ma   The curve parameter "a" in montgomery form
        @param modulus  The modulus
        @param mp   The "b" value from montgomery_setup()
        @return CRYPT_OK on success
    */
-   int (*ecc_ptadd)(ecc_point *P,
-                    ecc_point *Q,
-                    ecc_point *R,
-                         void *modulus,
-                         void *mp);
+   int (*ecc_ptadd)(const ecc_point *P,
+                    const ecc_point *Q,
+                          ecc_point *R,
+                         const void *ma,
+                         const void *modulus,
+                               void *mp);
 
    /** ECC GF(p) point double
        @param P    The first point
        @param R    The destination of 2P
+       @param ma   The curve parameter "a" in montgomery form
        @param modulus  The modulus
        @param mp   The "b" value from montgomery_setup()
        @return CRYPT_OK on success
    */
-   int (*ecc_ptdbl)(ecc_point *P,
-                    ecc_point *R,
-                         void *modulus,
-                         void *mp);
+   int (*ecc_ptdbl)(const ecc_point *P,
+                          ecc_point *R,
+                         const void *ma,
+                         const void *modulus,
+                               void *mp);
 
    /** ECC mapping from projective to affine,
        currently uses (x,y,z) => (x/z^2, y/z^3, 1)
@@ -9914,7 +9920,7 @@ typedef struct {
                ecc_point only has three integers (x,y,z) so if
                you use a different mapping you have to make it fit.
    */
-   int (*ecc_map)(ecc_point *P, void *modulus, void *mp);
+   int (*ecc_map)(ecc_point *P, const void *modulus, void *mp);
 
    /** Computes kA*A + kB*B = C using Shamir's Trick
        @param A        First point to multiply
@@ -9925,10 +9931,10 @@ typedef struct {
        @param modulus  Modulus for curve
        @return CRYPT_OK on success
    */
-   int (*ecc_mul2add)(ecc_point *A, void *kA,
-                      ecc_point *B, void *kB,
-                      ecc_point *C,
-                           void *modulus);
+   int (*ecc_mul2add)(const ecc_point *A, void *kA,
+                      const ecc_point *B, void *kB,
+                            ecc_point *C,
+                           const void *modulus);
 
 /* ---- (optional) rsa optimized math (for internal CRT) ---- */
 
@@ -9959,7 +9965,7 @@ typedef struct {
    */
    int (*rsa_me)(const unsigned char *in,   unsigned long inlen,
                        unsigned char *out,  unsigned long *outlen, int which,
-                       rsa_key *key);
+                 const rsa_key *key);
 
 /* ---- basic math continued ---- */
 
@@ -9970,7 +9976,7 @@ typedef struct {
       @param  d     The destination (a + b mod c)
       @return CRYPT_OK on success
    */
-   int (*addmod)(void *a, void *b, void *c, void *d);
+   int (*addmod)(const void *a, const void *b, const void *c, void *d);
 
    /** Modular substraction
       @param  a     The first source
@@ -9979,7 +9985,7 @@ typedef struct {
       @param  d     The destination (a - b mod c)
       @return CRYPT_OK on success
    */
-   int (*submod)(void *a, void *b, void *c, void *d);
+   int (*submod)(const void *a, const void *b, const void *c, void *d);
 
 /* ---- misc stuff ---- */
 

--- a/src/headers/tomcrypt_math.h
+++ b/src/headers/tomcrypt_math.h
@@ -48,7 +48,7 @@ typedef struct {
      @param  src    The number to copy from
      @return CRYPT_OK on success
    */
-   int (*init_copy)(void **dst, void *src);
+   int (*init_copy)(void **dst, const void *src);
 
    /** deinit
       @param   a    The number to free
@@ -63,14 +63,14 @@ typedef struct {
       @param   dst   The destination
       @return CRYPT_OK on success
    */
-   int (*neg)(void *src, void *dst);
+   int (*neg)(const void *src, void *dst);
 
    /** copy
       @param   src   The number to copy from
       @param   dst   The number to write to
       @return CRYPT_OK on success
    */
-   int (*copy)(void *src, void *dst);
+   int (*copy)(const void *src, void *dst);
 
 /* ---- trivial low level functions ---- */
 
@@ -86,20 +86,20 @@ typedef struct {
                 only fetches up to bits_per_digit from the number
       @return   The lower bits_per_digit of the integer (unsigned)
    */
-   unsigned long (*get_int)(void *a);
+   unsigned long (*get_int)(const void *a);
 
    /** get digit n
      @param a  The number to read from
      @param n  The number of the digit to fetch
      @return  The bits_per_digit  sized n'th digit of a
    */
-   ltc_mp_digit (*get_digit)(void *a, int n);
+   ltc_mp_digit (*get_digit)(const void *a, int n);
 
    /** Get the number of digits that represent the number
      @param a   The number to count
      @return The number of digits used to represent the number
    */
-   int (*get_digit_count)(void *a);
+   int (*get_digit_count)(const void *a);
 
    /** compare two integers
      @param a   The left side integer
@@ -108,7 +108,7 @@ typedef struct {
              LTC_MP_GT if a > b and
              LTC_MP_EQ otherwise.  (signed comparison)
    */
-   int (*compare)(void *a, void *b);
+   int (*compare)(const void *a, const void *b);
 
    /** compare against int
      @param a   The left side integer
@@ -117,19 +117,19 @@ typedef struct {
              LTC_MP_GT if a > b and
              LTC_MP_EQ otherwise.  (signed comparison)
    */
-   int (*compare_d)(void *a, ltc_mp_digit n);
+   int (*compare_d)(const void *a, ltc_mp_digit n);
 
    /** Count the number of bits used to represent the integer
      @param a   The integer to count
      @return The number of bits required to represent the integer
    */
-   int (*count_bits)(void * a);
+   int (*count_bits)(const void * a);
 
    /** Count the number of LSB bits which are zero
      @param a   The integer to count
      @return The number of contiguous zero LSB bits
    */
-   int (*count_lsb_bits)(void *a);
+   int (*count_lsb_bits)(const void *a);
 
    /** Compute a power of two
      @param a  The integer to store the power in
@@ -154,20 +154,20 @@ typedef struct {
      @param radix The radix the integer is to be represented in (2-64)
      @return CRYPT_OK on success
    */
-   int (*write_radix)(void *a, char *str, int radix);
+   int (*write_radix)(const void *a, char *str, int radix);
 
    /** get size as unsigned char string
      @param a  The integer to get the size (when stored in array of octets)
      @return   The length of the integer in octets
    */
-   unsigned long (*unsigned_size)(void *a);
+   unsigned long (*unsigned_size)(const void *a);
 
    /** store an integer as an array of octets
      @param src   The integer to store
      @param dst   The buffer to store the integer in
      @return CRYPT_OK on success
    */
-   int (*unsigned_write)(void *src, unsigned char *dst);
+   int (*unsigned_write)(const void *src, unsigned char *dst);
 
    /** read an array of octets and store as integer
      @param dst   The integer to load
@@ -175,9 +175,9 @@ typedef struct {
      @param len   The number of octets
      @return CRYPT_OK on success
    */
-   int (*unsigned_read)(         void *dst,
-                        unsigned char *src,
-                        unsigned long  len);
+   int (*unsigned_read)(               void *dst,
+                        const unsigned char *src,
+                              unsigned long  len);
 
 /* ---- basic math ---- */
 
@@ -187,7 +187,7 @@ typedef struct {
      @param c   The destination of "a + b"
      @return CRYPT_OK on success
    */
-   int (*add)(void *a, void *b, void *c);
+   int (*add)(const void *a, const void *b, void *c);
 
    /** add two integers
      @param a   The first source integer
@@ -196,7 +196,7 @@ typedef struct {
      @param c   The destination of "a + b"
      @return CRYPT_OK on success
    */
-   int (*addi)(void *a, ltc_mp_digit b, void *c);
+   int (*addi)(const void *a, ltc_mp_digit b, void *c);
 
    /** subtract two integers
      @param a   The first source integer
@@ -204,7 +204,7 @@ typedef struct {
      @param c   The destination of "a - b"
      @return CRYPT_OK on success
    */
-   int (*sub)(void *a, void *b, void *c);
+   int (*sub)(const void *a, const void *b, void *c);
 
    /** subtract two integers
      @param a   The first source integer
@@ -213,7 +213,7 @@ typedef struct {
      @param c   The destination of "a - b"
      @return CRYPT_OK on success
    */
-   int (*subi)(void *a, ltc_mp_digit b, void *c);
+   int (*subi)(const void *a, ltc_mp_digit b, void *c);
 
    /** multiply two integers
      @param a   The first source integer
@@ -222,7 +222,7 @@ typedef struct {
      @param c   The destination of "a * b"
      @return CRYPT_OK on success
    */
-   int (*mul)(void *a, void *b, void *c);
+   int (*mul)(const void *a, const void *b, void *c);
 
    /** multiply two integers
      @param a   The first source integer
@@ -231,14 +231,14 @@ typedef struct {
      @param c   The destination of "a * b"
      @return CRYPT_OK on success
    */
-   int (*muli)(void *a, ltc_mp_digit b, void *c);
+   int (*muli)(const void *a, ltc_mp_digit b, void *c);
 
    /** Square an integer
      @param a    The integer to square
      @param b    The destination
      @return CRYPT_OK on success
    */
-   int (*sqr)(void *a, void *b);
+   int (*sqr)(const void *a, void *b);
 
    /** Square root (mod prime)
      @param a    The integer to compute square root mod prime from
@@ -246,7 +246,7 @@ typedef struct {
      @param c    The destination
      @return CRYPT_OK on success
    */
-   int (*sqrtmod_prime)(void *a, void *b, void *c);
+   int (*sqrtmod_prime)(const void *a, const void *b, void *c);
 
    /** Divide an integer
      @param a    The dividend
@@ -255,14 +255,14 @@ typedef struct {
      @param d    The remainder (can be NULL to signify don't care)
      @return CRYPT_OK on success
    */
-   int (*mpdiv)(void *a, void *b, void *c, void *d);
+   int (*mpdiv)(const void *a, const void *b, void *c, void *d);
 
    /** divide by two
       @param  a   The integer to divide (shift right)
       @param  b   The destination
       @return CRYPT_OK on success
    */
-   int (*div_2)(void *a, void *b);
+   int (*div_2)(const void *a, void *b);
 
    /** Get remainder (small value)
       @param  a    The integer to reduce
@@ -270,7 +270,7 @@ typedef struct {
       @param  c    The destination for the residue
       @return CRYPT_OK on success
    */
-   int (*modi)(void *a, ltc_mp_digit b, ltc_mp_digit *c);
+   int (*modi)(const void *a, ltc_mp_digit b, ltc_mp_digit *c);
 
    /** gcd
       @param  a     The first integer
@@ -278,7 +278,7 @@ typedef struct {
       @param  c     The destination for (a, b)
       @return CRYPT_OK on success
    */
-   int (*gcd)(void *a, void *b, void *c);
+   int (*gcd)(const void *a, const void *b, void *c);
 
    /** lcm
       @param  a     The first integer
@@ -286,7 +286,7 @@ typedef struct {
       @param  c     The destination for [a, b]
       @return CRYPT_OK on success
    */
-   int (*lcm)(void *a, void *b, void *c);
+   int (*lcm)(const void *a, const void *b, void *c);
 
    /** Modular multiplication
       @param  a     The first source
@@ -295,7 +295,7 @@ typedef struct {
       @param  d     The destination (a*b mod c)
       @return CRYPT_OK on success
    */
-   int (*mulmod)(void *a, void *b, void *c, void *d);
+   int (*mulmod)(const void *a, const void *b, const void *c, void *d);
 
    /** Modular squaring
       @param  a     The first source
@@ -303,7 +303,7 @@ typedef struct {
       @param  c     The destination (a*a mod b)
       @return CRYPT_OK on success
    */
-   int (*sqrmod)(void *a, void *b, void *c);
+   int (*sqrmod)(const void *a, const void *b, void *c);
 
    /** Modular inversion
       @param  a     The value to invert
@@ -311,7 +311,7 @@ typedef struct {
       @param  c     The destination (1/a mod b)
       @return CRYPT_OK on success
    */
-   int (*invmod)(void *, void *, void *);
+   int (*invmod)(const void *a, const void *b, void *c);
 
 /* ---- reduction ---- */
 
@@ -320,14 +320,14 @@ typedef struct {
        @param b  The destination for the reduction digit
        @return CRYPT_OK on success
    */
-   int (*montgomery_setup)(void *a, void **b);
+   int (*montgomery_setup)(const void *a, void **b);
 
    /** get normalization value
        @param a   The destination for the normalization value
        @param b   The modulus
        @return  CRYPT_OK on success
    */
-   int (*montgomery_normalization)(void *a, void *b);
+   int (*montgomery_normalization)(void *a, const void *b);
 
    /** reduce a number
        @param a   The number [and dest] to reduce
@@ -335,7 +335,7 @@ typedef struct {
        @param c   The value "b" from montgomery_setup()
        @return CRYPT_OK on success
    */
-   int (*montgomery_reduce)(void *a, void *b, void *c);
+   int (*montgomery_reduce)(void *a, const void *b, void *c);
 
    /** clean up  (frees memory)
        @param a   The value "b" from montgomery_setup()
@@ -352,7 +352,7 @@ typedef struct {
        @param d    The destination
        @return CRYPT_OK on success
    */
-   int (*exptmod)(void *a, void *b, void *c, void *d);
+   int (*exptmod)(const void *a, const void *b, const void *c, void *d);
 
    /** Primality testing
        @param a     The integer to test
@@ -360,7 +360,7 @@ typedef struct {
        @param c     The destination of the result (FP_YES if prime)
        @return CRYPT_OK on success
    */
-   int (*isprime)(void *a, int b, int *c);
+   int (*isprime)(const void *a, int b, int *c);
 
 /* ----  (optional) ecc point math ---- */
 
@@ -374,11 +374,11 @@ typedef struct {
                   (can be ignored if you work in affine only)
        @return CRYPT_OK on success
    */
-   int (*ecc_ptmul)(     void *k,
+   int (*ecc_ptmul)(     const void *k,
                     const ecc_point *G,
                           ecc_point *R,
-                               void *a,
-                               void *modulus,
+                         const void *a,
+                         const void *modulus,
                                 int  map);
 
    /** ECC GF(p) point addition
@@ -393,8 +393,8 @@ typedef struct {
    int (*ecc_ptadd)(const ecc_point *P,
                     const ecc_point *Q,
                           ecc_point *R,
-                               void *ma,
-                               void *modulus,
+                         const void *ma,
+                         const void *modulus,
                                void *mp);
 
    /** ECC GF(p) point double
@@ -407,8 +407,8 @@ typedef struct {
    */
    int (*ecc_ptdbl)(const ecc_point *P,
                           ecc_point *R,
-                               void *ma,
-                               void *modulus,
+                         const void *ma,
+                         const void *modulus,
                                void *mp);
 
    /** ECC mapping from projective to affine,
@@ -421,7 +421,7 @@ typedef struct {
                ecc_point only has three integers (x,y,z) so if
                you use a different mapping you have to make it fit.
    */
-   int (*ecc_map)(ecc_point *P, void *modulus, void *mp);
+   int (*ecc_map)(ecc_point *P, const void *modulus, void *mp);
 
    /** Computes kA*A + kB*B = C using Shamir's Trick
        @param A        First point to multiply
@@ -436,8 +436,8 @@ typedef struct {
    int (*ecc_mul2add)(const ecc_point *A, void *kA,
                       const ecc_point *B, void *kB,
                             ecc_point *C,
-                                 void *ma,
-                                 void *modulus);
+                           const void *ma,
+                           const void *modulus);
 
 /* ---- (optional) rsa optimized math (for internal CRT) ---- */
 
@@ -479,7 +479,7 @@ typedef struct {
       @param  d     The destination (a + b mod c)
       @return CRYPT_OK on success
    */
-   int (*addmod)(void *a, void *b, void *c, void *d);
+   int (*addmod)(const void *a, const void *b, const void *c, void *d);
 
    /** Modular substraction
       @param  a     The first source
@@ -488,7 +488,7 @@ typedef struct {
       @param  d     The destination (a - b mod c)
       @return CRYPT_OK on success
    */
-   int (*submod)(void *a, void *b, void *c, void *d);
+   int (*submod)(const void *a, const void *b, const void *c, void *d);
 
 /* ---- misc stuff ---- */
 

--- a/src/headers/tomcrypt_private.h
+++ b/src/headers/tomcrypt_private.h
@@ -422,7 +422,7 @@ void       ltc_ecc_del_point(ecc_point *p);
 int        ltc_ecc_set_point_xyz(ltc_mp_digit x, ltc_mp_digit y, ltc_mp_digit z, ecc_point *p);
 int        ltc_ecc_copy_point(const ecc_point *src, ecc_point *dst);
 int        ltc_ecc_is_point(const ltc_ecc_dp *dp, void *x, void *y);
-int        ltc_ecc_is_point_at_infinity(const ecc_point *P, void *modulus, int *retval);
+int        ltc_ecc_is_point_at_infinity(const ecc_point *P, const void *modulus, int *retval);
 int        ltc_ecc_import_point(const unsigned char *in, unsigned long inlen, void *prime, void *a, void *b, void *x, void *y);
 int        ltc_ecc_export_point(unsigned char *out, unsigned long *outlen, void *x, void *y, unsigned long size, int compressed);
 int        ltc_ecc_verify_key(const ecc_key *key);
@@ -430,10 +430,12 @@ int        ltc_ecc_verify_key(const ecc_key *key);
 /* point ops (mp == montgomery digit) */
 #if !defined(LTC_MECC_ACCEL) || defined(LTM_DESC) || defined(GMP_DESC)
 /* R = 2P */
-int ltc_ecc_projective_dbl_point(const ecc_point *P, ecc_point *R, void *ma, void *modulus, void *mp);
+int ltc_ecc_projective_dbl_point(const ecc_point *P, ecc_point *R,
+                                 const void *ma, const void *modulus, void *mp);
 
 /* R = P + Q */
-int ltc_ecc_projective_add_point(const ecc_point *P, const ecc_point *Q, ecc_point *R, void *ma, void *modulus, void *mp);
+int ltc_ecc_projective_add_point(const ecc_point *P, const ecc_point *Q, ecc_point *R,
+                                 const void *ma, const void *modulus, void *mp);
 #endif
 
 #if defined(LTC_MECC_FP)
@@ -451,30 +453,31 @@ void ltc_ecc_fp_tablelock(int lock);
 #endif
 
 /* R = kG */
-int ltc_ecc_mulmod(void *k, const ecc_point *G, ecc_point *R, void *a, void *modulus, int map);
+int ltc_ecc_mulmod(const void *k, const ecc_point *G, ecc_point *R,
+                   const void *a, const void *modulus, int map);
 
 #ifdef LTC_ECC_SHAMIR
 /* kA*A + kB*B = C */
 int ltc_ecc_mul2add(const ecc_point *A, void *kA,
                     const ecc_point *B, void *kB,
                           ecc_point *C,
-                               void *ma,
-                               void *modulus);
+                         const void *ma,
+                         const void *modulus);
 
 #ifdef LTC_MECC_FP
 /* Shamir's trick with optimized point multiplication using fixed point cache */
 int ltc_ecc_fp_mul2add(const ecc_point *A, void *kA,
                        const ecc_point *B, void *kB,
                              ecc_point *C,
-                                  void *ma,
-                                  void *modulus);
+                            const void *ma,
+                            const void *modulus);
 #endif
 
 #endif
 
 
 /* map P to affine from projective */
-int ltc_ecc_map(ecc_point *P, void *modulus, void *mp);
+int ltc_ecc_map(ecc_point *P, const void *modulus, void *mp);
 #endif /* LTC_MECC */
 
 #ifdef LTC_MDSA

--- a/src/math/gmp_desc.c
+++ b/src/math/gmp_desc.c
@@ -17,7 +17,7 @@ static int init(void **a)
    if (*a == NULL) {
       return CRYPT_MEM;
    }
-   mpz_init(((__mpz_struct *)*a));
+   mpz_init(*a);
    return CRYPT_OK;
 }
 
@@ -28,7 +28,7 @@ static void deinit(void *a)
    XFREE(a);
 }
 
-static int neg(void *a, void *b)
+static int neg(const void *a, void *b)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -36,7 +36,7 @@ static int neg(void *a, void *b)
    return CRYPT_OK;
 }
 
-static int copy(void *a, void *b)
+static int copy(const void *a, void *b)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -44,7 +44,7 @@ static int copy(void *a, void *b)
    return CRYPT_OK;
 }
 
-static int init_copy(void **a, void *b)
+static int init_copy(void **a, const void *b)
 {
    if (init(a) != CRYPT_OK) {
       return CRYPT_MEM;
@@ -56,29 +56,29 @@ static int init_copy(void **a, void *b)
 static int set_int(void *a, ltc_mp_digit b)
 {
    LTC_ARGCHK(a != NULL);
-   mpz_set_ui(((__mpz_struct *)a), b);
+   mpz_set_ui(a, b);
    return CRYPT_OK;
 }
 
-static unsigned long get_int(void *a)
+static unsigned long get_int(const void *a)
 {
    LTC_ARGCHK(a != NULL);
    return mpz_get_ui(a);
 }
 
-static ltc_mp_digit get_digit(void *a, int n)
+static ltc_mp_digit get_digit(const void *a, int n)
 {
    LTC_ARGCHK(a != NULL);
    return mpz_getlimbn(a, n);
 }
 
-static int get_digit_count(void *a)
+static int get_digit_count(const void *a)
 {
    LTC_ARGCHK(a != NULL);
    return mpz_size(a);
 }
 
-static int compare(void *a, void *b)
+static int compare(const void *a, const void *b)
 {
    int ret;
    LTC_ARGCHK(a != NULL);
@@ -93,11 +93,11 @@ static int compare(void *a, void *b)
    }
 }
 
-static int compare_d(void *a, ltc_mp_digit b)
+static int compare_d(const void *a, ltc_mp_digit b)
 {
    int ret;
    LTC_ARGCHK(a != NULL);
-   ret = mpz_cmp_ui(((__mpz_struct *)a), b);
+   ret = mpz_cmp_ui((__mpz_struct *)a, b);
    if (ret < 0) {
       return LTC_MP_LT;
    } else if (ret > 0) {
@@ -107,13 +107,13 @@ static int compare_d(void *a, ltc_mp_digit b)
    }
 }
 
-static int count_bits(void *a)
+static int count_bits(const void *a)
 {
    LTC_ARGCHK(a != NULL);
    return mpz_sizeinbase(a, 2);
 }
 
-static int count_lsb_bits(void *a)
+static int count_lsb_bits(const void *a)
 {
    LTC_ARGCHK(a != NULL);
    return mpz_scan1(a, 0);
@@ -176,7 +176,7 @@ static int read_radix(void *a, const char *b, int radix)
 }
 
 /* write one */
-static int write_radix(void *a, char *b, int radix)
+static int write_radix(const void *a, char *b, int radix)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -190,26 +190,26 @@ static int write_radix(void *a, char *b, int radix)
 }
 
 /* get size as unsigned char string */
-static unsigned long unsigned_size(void *a)
+static unsigned long unsigned_size(const void *a)
 {
    unsigned long t;
    LTC_ARGCHK(a != NULL);
    t = mpz_sizeinbase(a, 2);
-   if (mpz_cmp_ui(((__mpz_struct *)a), 0) == 0) return 0;
+   if (mpz_cmp_ui((__mpz_struct *)a, 0) == 0) return 0;
    return (t>>3) + ((t&7)?1:0);
 }
 
 /* store */
-static int unsigned_write(void *a, unsigned char *b)
+static int unsigned_write(const void *a, unsigned char *b)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
-   mpz_export(b, NULL, 1, 1, 1, 0, ((__mpz_struct*)a));
+   mpz_export(b, NULL, 1, 1, 1, 0, a);
    return CRYPT_OK;
 }
 
 /* read */
-static int unsigned_read(void *a, unsigned char *b, unsigned long len)
+static int unsigned_read(void *a, const unsigned char *b, unsigned long len)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -218,7 +218,7 @@ static int unsigned_read(void *a, unsigned char *b, unsigned long len)
 }
 
 /* add */
-static int add(void *a, void *b, void *c)
+static int add(const void *a, const void *b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -227,7 +227,7 @@ static int add(void *a, void *b, void *c)
    return CRYPT_OK;
 }
 
-static int addi(void *a, ltc_mp_digit b, void *c)
+static int addi(const void *a, ltc_mp_digit b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(c != NULL);
@@ -236,7 +236,7 @@ static int addi(void *a, ltc_mp_digit b, void *c)
 }
 
 /* sub */
-static int sub(void *a, void *b, void *c)
+static int sub(const void *a, const void *b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -245,7 +245,7 @@ static int sub(void *a, void *b, void *c)
    return CRYPT_OK;
 }
 
-static int subi(void *a, ltc_mp_digit b, void *c)
+static int subi(const void *a, ltc_mp_digit b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(c != NULL);
@@ -254,7 +254,7 @@ static int subi(void *a, ltc_mp_digit b, void *c)
 }
 
 /* mul */
-static int mul(void *a, void *b, void *c)
+static int mul(const void *a, const void *b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -263,7 +263,7 @@ static int mul(void *a, void *b, void *c)
    return CRYPT_OK;
 }
 
-static int muli(void *a, ltc_mp_digit b, void *c)
+static int muli(const void *a, ltc_mp_digit b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(c != NULL);
@@ -272,7 +272,7 @@ static int muli(void *a, ltc_mp_digit b, void *c)
 }
 
 /* sqr */
-static int sqr(void *a, void *b)
+static int sqr(const void *a, void *b)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -281,7 +281,7 @@ static int sqr(void *a, void *b)
 }
 
 /* sqrtmod_prime */
-static int sqrtmod_prime(void *n, void *prime, void *ret)
+static int sqrtmod_prime(const void *n, const void *prime, void *ret)
 {
    int res, legendre, i;
    mpz_t t1, C, Q, S, Z, M, T, R, two;
@@ -291,11 +291,11 @@ static int sqrtmod_prime(void *n, void *prime, void *ret)
    LTC_ARGCHK(ret   != NULL);
 
    /* first handle the simple cases */
-   if (mpz_cmp_ui(((__mpz_struct *)n), 0) == 0) {
+   if (mpz_cmp_ui((__mpz_struct *)n, 0) == 0) {
       mpz_set_ui(ret, 0);
       return CRYPT_OK;
    }
-   if (mpz_cmp_ui(((__mpz_struct *)prime), 2) == 0)     return CRYPT_ERROR; /* prime must be odd */
+   if (mpz_cmp_ui((__mpz_struct *)prime, 2) == 0)       return CRYPT_ERROR; /* prime must be odd */
    legendre = mpz_legendre(n, prime);
    if (legendre == -1)                                  return CRYPT_ERROR; /* quadratic non-residue mod prime */
 
@@ -358,7 +358,7 @@ static int sqrtmod_prime(void *n, void *prime, void *ret)
       mpz_set(t1, T);
       i = 0;
       while (1) {
-         if (mpz_cmp_ui(((__mpz_struct *)t1), 1) == 0) break;
+         if (mpz_cmp_ui(t1, 1) == 0) break;
          mpz_powm(t1, t1, two, prime);
          i++;
       }
@@ -394,7 +394,7 @@ cleanup:
 }
 
 /* div */
-static int divide(void *a, void *b, void *c, void *d)
+static int divide(const void *a, const void *b, void *c, void *d)
 {
    mpz_t tmp;
    LTC_ARGCHK(a != NULL);
@@ -413,7 +413,7 @@ static int divide(void *a, void *b, void *c, void *d)
    return CRYPT_OK;
 }
 
-static int div_2(void *a, void *b)
+static int div_2(const void *a, void *b)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -422,7 +422,7 @@ static int div_2(void *a, void *b)
 }
 
 /* modi */
-static int modi(void *a, ltc_mp_digit b, ltc_mp_digit *c)
+static int modi(const void *a, ltc_mp_digit b, ltc_mp_digit *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(c != NULL);
@@ -432,7 +432,7 @@ static int modi(void *a, ltc_mp_digit b, ltc_mp_digit *c)
 }
 
 /* gcd */
-static int gcd(void *a, void *b, void *c)
+static int gcd(const void *a, const void *b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -442,7 +442,7 @@ static int gcd(void *a, void *b, void *c)
 }
 
 /* lcm */
-static int lcm(void *a, void *b, void *c)
+static int lcm(const void *a, const void *b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -451,7 +451,7 @@ static int lcm(void *a, void *b, void *c)
    return CRYPT_OK;
 }
 
-static int addmod(void *a, void *b, void *c, void *d)
+static int addmod(const void *a, const void *b, const void *c, void *d)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -462,7 +462,7 @@ static int addmod(void *a, void *b, void *c, void *d)
    return CRYPT_OK;
 }
 
-static int submod(void *a, void *b, void *c, void *d)
+static int submod(const void *a, const void *b, const void *c, void *d)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -473,7 +473,7 @@ static int submod(void *a, void *b, void *c, void *d)
    return CRYPT_OK;
 }
 
-static int mulmod(void *a, void *b, void *c, void *d)
+static int mulmod(const void *a, const void *b, const void *c, void *d)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -484,7 +484,7 @@ static int mulmod(void *a, void *b, void *c, void *d)
    return CRYPT_OK;
 }
 
-static int sqrmod(void *a, void *b, void *c)
+static int sqrmod(const void *a, const void *b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -495,7 +495,7 @@ static int sqrmod(void *a, void *b, void *c)
 }
 
 /* invmod */
-static int invmod(void *a, void *b, void *c)
+static int invmod(const void *a, const void *b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -505,7 +505,7 @@ static int invmod(void *a, void *b, void *c)
 }
 
 /* setup */
-static int montgomery_setup(void *a, void **b)
+static int montgomery_setup(const void *a, void **b)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -514,7 +514,7 @@ static int montgomery_setup(void *a, void **b)
 }
 
 /* get normalization value */
-static int montgomery_normalization(void *a, void *b)
+static int montgomery_normalization(void *a, const void *b)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -523,7 +523,7 @@ static int montgomery_normalization(void *a, void *b)
 }
 
 /* reduce */
-static int montgomery_reduce(void *a, void *b, void *c)
+static int montgomery_reduce(void *a, const void *b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -538,7 +538,7 @@ static void montgomery_deinit(void *a)
   LTC_UNUSED_PARAM(a);
 }
 
-static int exptmod(void *a, void *b, void *c, void *d)
+static int exptmod(const void *a, const void *b, const void *c, void *d)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -548,7 +548,7 @@ static int exptmod(void *a, void *b, void *c, void *d)
    return CRYPT_OK;
 }
 
-static int isprime(void *a, int b, int *c)
+static int isprime(const void *a, int b, int *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(c != NULL);

--- a/src/math/ltm_desc.c
+++ b/src/math/ltm_desc.c
@@ -75,21 +75,21 @@ static void deinit(void *a)
    XFREE(a);
 }
 
-static int neg(void *a, void *b)
+static int neg(const void *a, void *b)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
    return mpi_to_ltc_error(mp_neg(a, b));
 }
 
-static int copy(void *a, void *b)
+static int copy(const void *a, void *b)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
    return mpi_to_ltc_error(mp_copy(a, b));
 }
 
-static int init_copy(void **a, void *b)
+static int init_copy(void **a, const void *b)
 {
    int err;
    LTC_ARGCHK(a  != NULL);
@@ -110,7 +110,7 @@ static int set_int(void *a, ltc_mp_digit b)
 #endif
 }
 
-static unsigned long get_int(void *a)
+static unsigned long get_int(const void *a)
 {
    LTC_ARGCHK(a != NULL);
 #ifdef BN_MP_GET_INT_C
@@ -120,23 +120,23 @@ static unsigned long get_int(void *a)
 #endif
 }
 
-static ltc_mp_digit get_digit(void *a, int n)
+static ltc_mp_digit get_digit(const void *a, int n)
 {
-   mp_int *A;
+   const mp_int *A;
    LTC_ARGCHK(a != NULL);
    A = a;
    return (n >= A->used || n < 0) ? 0 : A->dp[n];
 }
 
-static int get_digit_count(void *a)
+static int get_digit_count(const void *a)
 {
-   mp_int *A;
+   const mp_int *A;
    LTC_ARGCHK(a != NULL);
    A = a;
    return A->used;
 }
 
-static int compare(void *a, void *b)
+static int compare(const void *a, const void *b)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -148,7 +148,7 @@ static int compare(void *a, void *b)
    }
 }
 
-static int compare_d(void *a, ltc_mp_digit b)
+static int compare_d(const void *a, ltc_mp_digit b)
 {
    LTC_ARGCHK(a != NULL);
    switch (mp_cmp_d(a, b)) {
@@ -159,13 +159,13 @@ static int compare_d(void *a, ltc_mp_digit b)
    }
 }
 
-static int count_bits(void *a)
+static int count_bits(const void *a)
 {
    LTC_ARGCHK(a != NULL);
    return mp_count_bits(a);
 }
 
-static int count_lsb_bits(void *a)
+static int count_lsb_bits(const void *a)
 {
    LTC_ARGCHK(a != NULL);
    return mp_cnt_lsb(a);
@@ -189,7 +189,7 @@ static int read_radix(void *a, const char *b, int radix)
 }
 
 /* write one */
-static int write_radix(void *a, char *b, int radix)
+static int write_radix(const void *a, char *b, int radix)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -201,7 +201,7 @@ static int write_radix(void *a, char *b, int radix)
 }
 
 /* get size as unsigned char string */
-static unsigned long unsigned_size(void *a)
+static unsigned long unsigned_size(const void *a)
 {
    LTC_ARGCHK(a != NULL);
 #ifdef BN_MP_UNSIGNED_BIN_SIZE_C
@@ -212,7 +212,7 @@ static unsigned long unsigned_size(void *a)
 }
 
 /* store */
-static int unsigned_write(void *a, unsigned char *b)
+static int unsigned_write(const void *a, unsigned char *b)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -224,7 +224,7 @@ static int unsigned_write(void *a, unsigned char *b)
 }
 
 /* read */
-static int unsigned_read(void *a, unsigned char *b, unsigned long len)
+static int unsigned_read(void *a, const unsigned char *b, unsigned long len)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -236,7 +236,7 @@ static int unsigned_read(void *a, unsigned char *b, unsigned long len)
 }
 
 /* add */
-static int add(void *a, void *b, void *c)
+static int add(const void *a, const void *b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -244,7 +244,7 @@ static int add(void *a, void *b, void *c)
    return mpi_to_ltc_error(mp_add(a, b, c));
 }
 
-static int addi(void *a, ltc_mp_digit b, void *c)
+static int addi(const void *a, ltc_mp_digit b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(c != NULL);
@@ -252,7 +252,7 @@ static int addi(void *a, ltc_mp_digit b, void *c)
 }
 
 /* sub */
-static int sub(void *a, void *b, void *c)
+static int sub(const void *a, const void *b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -260,7 +260,7 @@ static int sub(void *a, void *b, void *c)
    return mpi_to_ltc_error(mp_sub(a, b, c));
 }
 
-static int subi(void *a, ltc_mp_digit b, void *c)
+static int subi(const void *a, ltc_mp_digit b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(c != NULL);
@@ -268,7 +268,7 @@ static int subi(void *a, ltc_mp_digit b, void *c)
 }
 
 /* mul */
-static int mul(void *a, void *b, void *c)
+static int mul(const void *a, const void *b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -276,7 +276,7 @@ static int mul(void *a, void *b, void *c)
    return mpi_to_ltc_error(mp_mul(a, b, c));
 }
 
-static int muli(void *a, ltc_mp_digit b, void *c)
+static int muli(const void *a, ltc_mp_digit b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(c != NULL);
@@ -284,7 +284,7 @@ static int muli(void *a, ltc_mp_digit b, void *c)
 }
 
 /* sqr */
-static int sqr(void *a, void *b)
+static int sqr(const void *a, void *b)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -292,7 +292,7 @@ static int sqr(void *a, void *b)
 }
 
 /* sqrtmod_prime */
-static int sqrtmod_prime(void *a, void *b, void *c)
+static int sqrtmod_prime(const void *a, const void *b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -301,14 +301,14 @@ static int sqrtmod_prime(void *a, void *b, void *c)
 }
 
 /* div */
-static int divide(void *a, void *b, void *c, void *d)
+static int divide(const void *a, const void *b, void *c, void *d)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
    return mpi_to_ltc_error(mp_div(a, b, c, d));
 }
 
-static int div_2(void *a, void *b)
+static int div_2(const void *a, void *b)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -316,7 +316,7 @@ static int div_2(void *a, void *b)
 }
 
 /* modi */
-static int modi(void *a, ltc_mp_digit b, ltc_mp_digit *c)
+static int modi(const void *a, ltc_mp_digit b, ltc_mp_digit *c)
 {
    mp_digit tmp;
    int      err;
@@ -332,7 +332,7 @@ static int modi(void *a, ltc_mp_digit b, ltc_mp_digit *c)
 }
 
 /* gcd */
-static int gcd(void *a, void *b, void *c)
+static int gcd(const void *a, const void *b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -341,7 +341,7 @@ static int gcd(void *a, void *b, void *c)
 }
 
 /* lcm */
-static int lcm(void *a, void *b, void *c)
+static int lcm(const void *a, const void *b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -349,7 +349,7 @@ static int lcm(void *a, void *b, void *c)
    return mpi_to_ltc_error(mp_lcm(a, b, c));
 }
 
-static int addmod(void *a, void *b, void *c, void *d)
+static int addmod(const void *a, const void *b, const void *c, void *d)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -358,7 +358,7 @@ static int addmod(void *a, void *b, void *c, void *d)
    return mpi_to_ltc_error(mp_addmod(a,b,c,d));
 }
 
-static int submod(void *a, void *b, void *c, void *d)
+static int submod(const void *a, const void *b, const void *c, void *d)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -367,7 +367,7 @@ static int submod(void *a, void *b, void *c, void *d)
    return mpi_to_ltc_error(mp_submod(a,b,c,d));
 }
 
-static int mulmod(void *a, void *b, void *c, void *d)
+static int mulmod(const void *a, const void *b, const void *c, void *d)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -376,7 +376,7 @@ static int mulmod(void *a, void *b, void *c, void *d)
    return mpi_to_ltc_error(mp_mulmod(a,b,c,d));
 }
 
-static int sqrmod(void *a, void *b, void *c)
+static int sqrmod(const void *a, const void *b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -385,7 +385,7 @@ static int sqrmod(void *a, void *b, void *c)
 }
 
 /* invmod */
-static int invmod(void *a, void *b, void *c)
+static int invmod(const void *a, const void *b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -394,7 +394,7 @@ static int invmod(void *a, void *b, void *c)
 }
 
 /* setup */
-static int montgomery_setup(void *a, void **b)
+static int montgomery_setup(const void *a, void **b)
 {
    int err;
    LTC_ARGCHK(a != NULL);
@@ -403,14 +403,14 @@ static int montgomery_setup(void *a, void **b)
    if (*b == NULL) {
       return CRYPT_MEM;
    }
-   if ((err = mpi_to_ltc_error(mp_montgomery_setup(a, (mp_digit *)*b))) != CRYPT_OK) {
+   if ((err = mpi_to_ltc_error(mp_montgomery_setup(a, *b))) != CRYPT_OK) {
       XFREE(*b);
    }
    return err;
 }
 
 /* get normalization value */
-static int montgomery_normalization(void *a, void *b)
+static int montgomery_normalization(void *a, const void *b)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -418,7 +418,7 @@ static int montgomery_normalization(void *a, void *b)
 }
 
 /* reduce */
-static int montgomery_reduce(void *a, void *b, void *c)
+static int montgomery_reduce(void *a, const void *b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -432,7 +432,7 @@ static void montgomery_deinit(void *a)
    XFREE(a);
 }
 
-static int exptmod(void *a, void *b, void *c, void *d)
+static int exptmod(const void *a, const void *b, const void *c, void *d)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -441,7 +441,7 @@ static int exptmod(void *a, void *b, void *c, void *d)
    return mpi_to_ltc_error(mp_exptmod(a,b,c,d));
 }
 
-static int isprime(void *a, int b, int *c)
+static int isprime(const void *a, int b, int *c)
 {
    int err;
 #if defined(PRIVATE_MP_WARRAY) || defined(BN_MP_PRIME_IS_PRIME_C)

--- a/src/math/tfm_desc.c
+++ b/src/math/tfm_desc.c
@@ -51,15 +51,18 @@ static void deinit(void *a)
    XFREE(a);
 }
 
-static int neg(void *a, void *b)
+static int neg(const void *a, void *b)
 {
+   /* fp_neg() is a macro that accesses the internals of the b */
+   fp_int *tmpb = b;
+
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
-   fp_neg(((fp_int*)a), ((fp_int*)b));
+   fp_neg(a, tmpb);
    return CRYPT_OK;
 }
 
-static int copy(void *a, void *b)
+static int copy(const void *a, void *b)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -67,7 +70,7 @@ static int copy(void *a, void *b)
    return CRYPT_OK;
 }
 
-static int init_copy(void **a, void *b)
+static int init_copy(void **a, const void *b)
 {
    if (init(a) != CRYPT_OK) {
       return CRYPT_MEM;
@@ -83,31 +86,31 @@ static int set_int(void *a, ltc_mp_digit b)
    return CRYPT_OK;
 }
 
-static unsigned long get_int(void *a)
+static unsigned long get_int(const void *a)
 {
-   fp_int *A;
+   const fp_int *A;
    LTC_ARGCHK(a != NULL);
    A = a;
    return A->used > 0 ? A->dp[0] : 0;
 }
 
-static ltc_mp_digit get_digit(void *a, int n)
+static ltc_mp_digit get_digit(const void *a, int n)
 {
-   fp_int *A;
+   const fp_int *A;
    LTC_ARGCHK(a != NULL);
    A = a;
    return (n >= A->used || n < 0) ? 0 : A->dp[n];
 }
 
-static int get_digit_count(void *a)
+static int get_digit_count(const void *a)
 {
-   fp_int *A;
+   const fp_int *A;
    LTC_ARGCHK(a != NULL);
    A = a;
    return A->used;
 }
 
-static int compare(void *a, void *b)
+static int compare(const void *a, const void *b)
 {
    int ret;
    LTC_ARGCHK(a != NULL);
@@ -121,7 +124,7 @@ static int compare(void *a, void *b)
    return 0;
 }
 
-static int compare_d(void *a, ltc_mp_digit b)
+static int compare_d(const void *a, ltc_mp_digit b)
 {
    int ret;
    LTC_ARGCHK(a != NULL);
@@ -134,13 +137,13 @@ static int compare_d(void *a, ltc_mp_digit b)
    return 0;
 }
 
-static int count_bits(void *a)
+static int count_bits(const void *a)
 {
    LTC_ARGCHK(a != NULL);
    return fp_count_bits(a);
 }
 
-static int count_lsb_bits(void *a)
+static int count_lsb_bits(const void *a)
 {
    LTC_ARGCHK(a != NULL);
    return fp_cnt_lsb(a);
@@ -160,11 +163,11 @@ static int read_radix(void *a, const char *b, int radix)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
-   return tfm_to_ltc_error(fp_read_radix(a, (char *)b, radix));
+   return tfm_to_ltc_error(fp_read_radix(a, b, radix));
 }
 
 /* write one */
-static int write_radix(void *a, char *b, int radix)
+static int write_radix(const void *a, char *b, int radix)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -172,14 +175,14 @@ static int write_radix(void *a, char *b, int radix)
 }
 
 /* get size as unsigned char string */
-static unsigned long unsigned_size(void *a)
+static unsigned long unsigned_size(const void *a)
 {
    LTC_ARGCHK(a != NULL);
    return fp_unsigned_bin_size(a);
 }
 
 /* store */
-static int unsigned_write(void *a, unsigned char *b)
+static int unsigned_write(const void *a, unsigned char *b)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -188,7 +191,7 @@ static int unsigned_write(void *a, unsigned char *b)
 }
 
 /* read */
-static int unsigned_read(void *a, unsigned char *b, unsigned long len)
+static int unsigned_read(void *a, const unsigned char *b, unsigned long len)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -197,7 +200,7 @@ static int unsigned_read(void *a, unsigned char *b, unsigned long len)
 }
 
 /* add */
-static int add(void *a, void *b, void *c)
+static int add(const void *a, const void *b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -206,7 +209,7 @@ static int add(void *a, void *b, void *c)
    return CRYPT_OK;
 }
 
-static int addi(void *a, ltc_mp_digit b, void *c)
+static int addi(const void *a, ltc_mp_digit b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(c != NULL);
@@ -215,7 +218,7 @@ static int addi(void *a, ltc_mp_digit b, void *c)
 }
 
 /* sub */
-static int sub(void *a, void *b, void *c)
+static int sub(const void *a, const void *b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -224,7 +227,7 @@ static int sub(void *a, void *b, void *c)
    return CRYPT_OK;
 }
 
-static int subi(void *a, ltc_mp_digit b, void *c)
+static int subi(const void *a, ltc_mp_digit b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(c != NULL);
@@ -233,7 +236,7 @@ static int subi(void *a, ltc_mp_digit b, void *c)
 }
 
 /* mul */
-static int mul(void *a, void *b, void *c)
+static int mul(const void *a, const void *b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -242,7 +245,7 @@ static int mul(void *a, void *b, void *c)
    return CRYPT_OK;
 }
 
-static int muli(void *a, ltc_mp_digit b, void *c)
+static int muli(const void *a, ltc_mp_digit b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(c != NULL);
@@ -251,7 +254,7 @@ static int muli(void *a, ltc_mp_digit b, void *c)
 }
 
 /* sqr */
-static int sqr(void *a, void *b)
+static int sqr(const void *a, void *b)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -262,14 +265,14 @@ static int sqr(void *a, void *b)
 /* sqrtmod_prime - NOT SUPPORTED */
 
 /* div */
-static int divide(void *a, void *b, void *c, void *d)
+static int divide(const void *a, const void *b, void *c, void *d)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
    return tfm_to_ltc_error(fp_div(a, b, c, d));
 }
 
-static int div_2(void *a, void *b)
+static int div_2(const void *a, void *b)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -278,7 +281,7 @@ static int div_2(void *a, void *b)
 }
 
 /* modi */
-static int modi(void *a, ltc_mp_digit b, ltc_mp_digit *c)
+static int modi(const void *a, ltc_mp_digit b, ltc_mp_digit *c)
 {
    fp_digit tmp;
    int      err;
@@ -294,7 +297,7 @@ static int modi(void *a, ltc_mp_digit b, ltc_mp_digit *c)
 }
 
 /* gcd */
-static int gcd(void *a, void *b, void *c)
+static int gcd(const void *a, const void *b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -304,7 +307,7 @@ static int gcd(void *a, void *b, void *c)
 }
 
 /* lcm */
-static int lcm(void *a, void *b, void *c)
+static int lcm(const void *a, const void *b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -313,7 +316,7 @@ static int lcm(void *a, void *b, void *c)
    return CRYPT_OK;
 }
 
-static int addmod(void *a, void *b, void *c, void *d)
+static int addmod(const void *a, const void *b, const void *c, void *d)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -322,7 +325,7 @@ static int addmod(void *a, void *b, void *c, void *d)
    return tfm_to_ltc_error(fp_addmod(a,b,c,d));
 }
 
-static int submod(void *a, void *b, void *c, void *d)
+static int submod(const void *a, const void *b, const void *c, void *d)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -331,7 +334,7 @@ static int submod(void *a, void *b, void *c, void *d)
    return tfm_to_ltc_error(fp_submod(a,b,c,d));
 }
 
-static int mulmod(void *a, void *b, void *c, void *d)
+static int mulmod(const void *a, const void *b, const void *c, void *d)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -340,7 +343,7 @@ static int mulmod(void *a, void *b, void *c, void *d)
    return tfm_to_ltc_error(fp_mulmod(a,b,c,d));
 }
 
-static int sqrmod(void *a, void *b, void *c)
+static int sqrmod(const void *a, const void *b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -349,7 +352,7 @@ static int sqrmod(void *a, void *b, void *c)
 }
 
 /* invmod */
-static int invmod(void *a, void *b, void *c)
+static int invmod(const void *a, const void *b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -358,7 +361,7 @@ static int invmod(void *a, void *b, void *c)
 }
 
 /* setup */
-static int montgomery_setup(void *a, void **b)
+static int montgomery_setup(const void *a, void **b)
 {
    int err;
    LTC_ARGCHK(a != NULL);
@@ -367,14 +370,14 @@ static int montgomery_setup(void *a, void **b)
    if (*b == NULL) {
       return CRYPT_MEM;
    }
-   if ((err = tfm_to_ltc_error(fp_montgomery_setup(a, (fp_digit *)*b))) != CRYPT_OK) {
+   if ((err = tfm_to_ltc_error(fp_montgomery_setup(a, *b))) != CRYPT_OK) {
       XFREE(*b);
    }
    return err;
 }
 
 /* get normalization value */
-static int montgomery_normalization(void *a, void *b)
+static int montgomery_normalization(void *a, const void *b)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
@@ -383,12 +386,13 @@ static int montgomery_normalization(void *a, void *b)
 }
 
 /* reduce */
-static int montgomery_reduce(void *a, void *b, void *c)
+static int montgomery_reduce(void *a, const void *b, void *c)
 {
+   fp_digit *tmpc = c;
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
    LTC_ARGCHK(c != NULL);
-   fp_montgomery_reduce(a, b, *((fp_digit *)c));
+   fp_montgomery_reduce(a, b, *tmpc);
    return CRYPT_OK;
 }
 
@@ -398,16 +402,16 @@ static void montgomery_deinit(void *a)
    XFREE(a);
 }
 
-static int exptmod(void *a, void *b, void *c, void *d)
+static int exptmod(const void *a, const void *b, const void *c, void *d)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
    LTC_ARGCHK(c != NULL);
    LTC_ARGCHK(d != NULL);
-   return tfm_to_ltc_error(fp_exptmod(a,b,c,d));
+   return tfm_to_ltc_error(fp_exptmod(a,(void *)b,c,d));
 }
 
-static int isprime(void *a, int b, int *c)
+static int isprime(const void *a, int b, int *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(c != NULL);
@@ -420,7 +424,7 @@ static int isprime(void *a, int b, int *c)
 
 #if defined(LTC_MECC) && defined(LTC_MECC_ACCEL)
 
-static int tfm_ecc_projective_dbl_point(const ecc_point *P, ecc_point *R, void *ma, void *modulus, void *Mp)
+static int tfm_ecc_projective_dbl_point(const ecc_point *P, ecc_point *R, const void *ma, const void *modulus, void *Mp)
 {
    fp_int t1, t2;
    fp_digit mp;
@@ -575,7 +579,7 @@ static int tfm_ecc_projective_dbl_point(const ecc_point *P, ecc_point *R, void *
    @param Mp       The "b" value from montgomery_setup()
    @return CRYPT_OK on success
 */
-static int tfm_ecc_projective_add_point(const ecc_point *P, const ecc_point *Q, ecc_point *R, void *ma, void *modulus, void *Mp)
+static int tfm_ecc_projective_add_point(const ecc_point *P, const ecc_point *Q, ecc_point *R, const void *ma, const void *modulus, void *Mp)
 {
    fp_int  t1, t2, x, y, z;
    fp_digit mp;

--- a/src/math/tfm_desc.c
+++ b/src/math/tfm_desc.c
@@ -8,6 +8,20 @@
 
 #include <tfm.h>
 
+#if !defined(TFM_VERSION_3)
+# if 0                          /* Enable if desirable */
+#  warning "pre-constification TFM used (TFM_VERSION_3 undefined)"
+# endif
+# define TFM_UNCONST(type) (type)
+#elif TFM_VERSION <= TFM_VERSION_3(0, 13, 89)
+# if 0                          /* Enable if desirable */
+#  warning "pre-constification TFM used (older version detected)"
+# endif
+# define TFM_UNCONST(type) (type)
+#else
+# define TFM_UNCONST(type)
+#endif
+
 static const struct {
     int tfm_code, ltc_code;
 } tfm_to_ltc_codes[] = {
@@ -115,7 +129,7 @@ static int compare(const void *a, const void *b)
    int ret;
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
-   ret = fp_cmp(a, b);
+   ret = fp_cmp(TFM_UNCONST(void *)a, TFM_UNCONST(void *)b);
    switch (ret) {
       case FP_LT: return LTC_MP_LT;
       case FP_EQ: return LTC_MP_EQ;
@@ -128,7 +142,7 @@ static int compare_d(const void *a, ltc_mp_digit b)
 {
    int ret;
    LTC_ARGCHK(a != NULL);
-   ret = fp_cmp_d(a, b);
+   ret = fp_cmp_d(TFM_UNCONST(void *)a, b);
    switch (ret) {
       case FP_LT: return LTC_MP_LT;
       case FP_EQ: return LTC_MP_EQ;
@@ -140,13 +154,13 @@ static int compare_d(const void *a, ltc_mp_digit b)
 static int count_bits(const void *a)
 {
    LTC_ARGCHK(a != NULL);
-   return fp_count_bits(a);
+   return fp_count_bits(TFM_UNCONST(void *)a);
 }
 
 static int count_lsb_bits(const void *a)
 {
    LTC_ARGCHK(a != NULL);
-   return fp_cnt_lsb(a);
+   return fp_cnt_lsb(TFM_UNCONST(void *)a);
 }
 
 static int twoexpt(void *a, int n)
@@ -171,14 +185,14 @@ static int write_radix(const void *a, char *b, int radix)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
-   return tfm_to_ltc_error(fp_toradix(a, b, radix));
+   return tfm_to_ltc_error(fp_toradix(TFM_UNCONST(void *)a, b, radix));
 }
 
 /* get size as unsigned char string */
 static unsigned long unsigned_size(const void *a)
 {
    LTC_ARGCHK(a != NULL);
-   return fp_unsigned_bin_size(a);
+   return fp_unsigned_bin_size(TFM_UNCONST(void *)a);
 }
 
 /* store */
@@ -186,7 +200,7 @@ static int unsigned_write(const void *a, unsigned char *b)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
-   fp_to_unsigned_bin(a, b);
+   fp_to_unsigned_bin(TFM_UNCONST(void *)a, b);
    return CRYPT_OK;
 }
 
@@ -205,7 +219,7 @@ static int add(const void *a, const void *b, void *c)
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
    LTC_ARGCHK(c != NULL);
-   fp_add(a, b, c);
+   fp_add(TFM_UNCONST(void *)a, TFM_UNCONST(void *)b, c);
    return CRYPT_OK;
 }
 
@@ -213,7 +227,7 @@ static int addi(const void *a, ltc_mp_digit b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(c != NULL);
-   fp_add_d(a, b, c);
+   fp_add_d(TFM_UNCONST(void *)a, b, c);
    return CRYPT_OK;
 }
 
@@ -223,7 +237,7 @@ static int sub(const void *a, const void *b, void *c)
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
    LTC_ARGCHK(c != NULL);
-   fp_sub(a, b, c);
+   fp_sub(TFM_UNCONST(void *)a, TFM_UNCONST(void *)b, c);
    return CRYPT_OK;
 }
 
@@ -231,7 +245,7 @@ static int subi(const void *a, ltc_mp_digit b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(c != NULL);
-   fp_sub_d(a, b, c);
+   fp_sub_d(TFM_UNCONST(void *)a, b, c);
    return CRYPT_OK;
 }
 
@@ -241,7 +255,7 @@ static int mul(const void *a, const void *b, void *c)
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
    LTC_ARGCHK(c != NULL);
-   fp_mul(a, b, c);
+   fp_mul(TFM_UNCONST(void *)a, TFM_UNCONST(void *)b, c);
    return CRYPT_OK;
 }
 
@@ -249,7 +263,7 @@ static int muli(const void *a, ltc_mp_digit b, void *c)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(c != NULL);
-   fp_mul_d(a, b, c);
+   fp_mul_d(TFM_UNCONST(void *)a, b, c);
    return CRYPT_OK;
 }
 
@@ -258,7 +272,7 @@ static int sqr(const void *a, void *b)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
-   fp_sqr(a, b);
+   fp_sqr(TFM_UNCONST(void *)a, b);
    return CRYPT_OK;
 }
 
@@ -269,14 +283,14 @@ static int divide(const void *a, const void *b, void *c, void *d)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
-   return tfm_to_ltc_error(fp_div(a, b, c, d));
+   return tfm_to_ltc_error(fp_div(TFM_UNCONST(void *)a, TFM_UNCONST(void *)b, c, d));
 }
 
 static int div_2(const void *a, void *b)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
-   fp_div_2(a, b);
+   fp_div_2(TFM_UNCONST(void *)a, b);
    return CRYPT_OK;
 }
 
@@ -289,7 +303,7 @@ static int modi(const void *a, ltc_mp_digit b, ltc_mp_digit *c)
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(c != NULL);
 
-   if ((err = tfm_to_ltc_error(fp_mod_d(a, b, &tmp))) != CRYPT_OK) {
+   if ((err = tfm_to_ltc_error(fp_mod_d(TFM_UNCONST(void *)a, b, &tmp))) != CRYPT_OK) {
       return err;
    }
    *c = tmp;
@@ -302,7 +316,7 @@ static int gcd(const void *a, const void *b, void *c)
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
    LTC_ARGCHK(c != NULL);
-   fp_gcd(a, b, c);
+   fp_gcd(TFM_UNCONST(void *)a, TFM_UNCONST(void *)b, c);
    return CRYPT_OK;
 }
 
@@ -312,7 +326,7 @@ static int lcm(const void *a, const void *b, void *c)
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
    LTC_ARGCHK(c != NULL);
-   fp_lcm(a, b, c);
+   fp_lcm(TFM_UNCONST(void *)a, TFM_UNCONST(void *)b, c);
    return CRYPT_OK;
 }
 
@@ -322,7 +336,7 @@ static int addmod(const void *a, const void *b, const void *c, void *d)
    LTC_ARGCHK(b != NULL);
    LTC_ARGCHK(c != NULL);
    LTC_ARGCHK(d != NULL);
-   return tfm_to_ltc_error(fp_addmod(a,b,c,d));
+   return tfm_to_ltc_error(fp_addmod(TFM_UNCONST(void *)a,TFM_UNCONST(void *)b,TFM_UNCONST(void *)c,d));
 }
 
 static int submod(const void *a, const void *b, const void *c, void *d)
@@ -331,7 +345,7 @@ static int submod(const void *a, const void *b, const void *c, void *d)
    LTC_ARGCHK(b != NULL);
    LTC_ARGCHK(c != NULL);
    LTC_ARGCHK(d != NULL);
-   return tfm_to_ltc_error(fp_submod(a,b,c,d));
+   return tfm_to_ltc_error(fp_submod(TFM_UNCONST(void *)a,TFM_UNCONST(void *)b,TFM_UNCONST(void *)c,d));
 }
 
 static int mulmod(const void *a, const void *b, const void *c, void *d)
@@ -340,7 +354,7 @@ static int mulmod(const void *a, const void *b, const void *c, void *d)
    LTC_ARGCHK(b != NULL);
    LTC_ARGCHK(c != NULL);
    LTC_ARGCHK(d != NULL);
-   return tfm_to_ltc_error(fp_mulmod(a,b,c,d));
+   return tfm_to_ltc_error(fp_mulmod(TFM_UNCONST(void *)a,TFM_UNCONST(void *)b,TFM_UNCONST(void *)c,d));
 }
 
 static int sqrmod(const void *a, const void *b, void *c)
@@ -348,7 +362,7 @@ static int sqrmod(const void *a, const void *b, void *c)
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
    LTC_ARGCHK(c != NULL);
-   return tfm_to_ltc_error(fp_sqrmod(a,b,c));
+   return tfm_to_ltc_error(fp_sqrmod(TFM_UNCONST(void *)a,TFM_UNCONST(void *)b,c));
 }
 
 /* invmod */
@@ -357,7 +371,7 @@ static int invmod(const void *a, const void *b, void *c)
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
    LTC_ARGCHK(c != NULL);
-   return tfm_to_ltc_error(fp_invmod(a, b, c));
+   return tfm_to_ltc_error(fp_invmod(TFM_UNCONST(void *)a, TFM_UNCONST(void *)b, c));
 }
 
 /* setup */
@@ -370,7 +384,7 @@ static int montgomery_setup(const void *a, void **b)
    if (*b == NULL) {
       return CRYPT_MEM;
    }
-   if ((err = tfm_to_ltc_error(fp_montgomery_setup(a, *b))) != CRYPT_OK) {
+   if ((err = tfm_to_ltc_error(fp_montgomery_setup(TFM_UNCONST(void *)a, *b))) != CRYPT_OK) {
       XFREE(*b);
    }
    return err;
@@ -381,7 +395,7 @@ static int montgomery_normalization(void *a, const void *b)
 {
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
-   fp_montgomery_calc_normalization(a, b);
+   fp_montgomery_calc_normalization(a, TFM_UNCONST(void *)b);
    return CRYPT_OK;
 }
 
@@ -392,7 +406,7 @@ static int montgomery_reduce(void *a, const void *b, void *c)
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);
    LTC_ARGCHK(c != NULL);
-   fp_montgomery_reduce(a, b, *tmpc);
+   fp_montgomery_reduce(a, TFM_UNCONST(void *)b, *tmpc);
    return CRYPT_OK;
 }
 
@@ -408,7 +422,7 @@ static int exptmod(const void *a, const void *b, const void *c, void *d)
    LTC_ARGCHK(b != NULL);
    LTC_ARGCHK(c != NULL);
    LTC_ARGCHK(d != NULL);
-   return tfm_to_ltc_error(fp_exptmod(a,(void *)b,c,d));
+   return tfm_to_ltc_error(fp_exptmod(TFM_UNCONST(void *)a,TFM_UNCONST(void *)b,TFM_UNCONST(void *)c,d));
 }
 
 static int isprime(const void *a, int b, int *c)
@@ -418,7 +432,7 @@ static int isprime(const void *a, int b, int *c)
    if (b == 0) {
        b = LTC_MILLER_RABIN_REPS;
    } /* if */
-   *c = (fp_isprime_ex(a, b) == FP_YES) ? LTC_MP_YES : LTC_MP_NO;
+   *c = (fp_isprime_ex(TFM_UNCONST(void *)a, b) == FP_YES) ? LTC_MP_YES : LTC_MP_NO;
    return CRYPT_OK;
 }
 
@@ -457,114 +471,114 @@ static int tfm_ecc_projective_dbl_point(const ecc_point *P, ecc_point *R, const 
 
    /* t1 = Z * Z */
    fp_sqr(R->z, &t1);
-   fp_montgomery_reduce(&t1, modulus, mp);
+   fp_montgomery_reduce(&t1, TFM_UNCONST(void *)modulus, mp);
    /* Z = Y * Z */
    fp_mul(R->z, R->y, R->z);
-   fp_montgomery_reduce(R->z, modulus, mp);
+   fp_montgomery_reduce(R->z, TFM_UNCONST(void *)modulus, mp);
    /* Z = 2Z */
    fp_add(R->z, R->z, R->z);
-   if (fp_cmp(R->z, modulus) != FP_LT) {
-      fp_sub(R->z, modulus, R->z);
+   if (fp_cmp(R->z, TFM_UNCONST(void *)modulus) != FP_LT) {
+      fp_sub(R->z, TFM_UNCONST(void *)modulus, R->z);
    }
 
    if (ma == NULL) { /* special case for curves with a == -3 (10% faster than general case) */
       /* T2 = X - T1 */
       fp_sub(R->x, &t1, &t2);
       if (fp_cmp_d(&t2, 0) == LTC_MP_LT) {
-         fp_add(&t2, modulus, &t2);
+         fp_add(&t2, TFM_UNCONST(void *)modulus, &t2);
       }
       /* T1 = X + T1 */
       fp_add(&t1, R->x, &t1);
-      if (fp_cmp(&t1, modulus) != FP_LT) {
-         fp_sub(&t1, modulus, &t1);
+      if (fp_cmp(&t1, TFM_UNCONST(void *)modulus) != FP_LT) {
+         fp_sub(&t1, TFM_UNCONST(void *)modulus, &t1);
       }
       /* T2 = T1 * T2 */
       fp_mul(&t1, &t2, &t2);
-      fp_montgomery_reduce(&t2, modulus, mp);
+      fp_montgomery_reduce(&t2, TFM_UNCONST(void *)modulus, mp);
       /* T1 = 2T2 */
       fp_add(&t2, &t2, &t1);
-      if (fp_cmp(&t1, modulus) != FP_LT) {
-         fp_sub(&t1, modulus, &t1);
+      if (fp_cmp(&t1, TFM_UNCONST(void *)modulus) != FP_LT) {
+         fp_sub(&t1, TFM_UNCONST(void *)modulus, &t1);
       }
       /* T1 = T1 + T2 */
       fp_add(&t1, &t2, &t1);
-      if (fp_cmp(&t1, modulus) != FP_LT) {
-         fp_sub(&t1, modulus, &t1);
+      if (fp_cmp(&t1, TFM_UNCONST(void *)modulus) != FP_LT) {
+         fp_sub(&t1, TFM_UNCONST(void *)modulus, &t1);
       }
    }
    else {
       /* T2 = T1 * T1 */
       fp_sqr(&t1, &t2);
-      fp_montgomery_reduce(&t2, modulus, mp);
+      fp_montgomery_reduce(&t2, TFM_UNCONST(void *)modulus, mp);
       /* T1 = T2 * a */
-      fp_mul(&t2, ma, &t1);
-      fp_montgomery_reduce(&t1, modulus, mp);
+      fp_mul(&t2, TFM_UNCONST(void *)ma, &t1);
+      fp_montgomery_reduce(&t1, TFM_UNCONST(void *)modulus, mp);
       /* T2 = X * X */
       fp_sqr(R->x, &t2);
-      fp_montgomery_reduce(&t2, modulus, mp);
+      fp_montgomery_reduce(&t2, TFM_UNCONST(void *)modulus, mp);
       /* T1 = T1 + T2 */
       fp_add(&t1, &t2, &t1);
-      if (fp_cmp(&t1, modulus) != FP_LT) {
-         fp_sub(&t1, modulus, &t1);
+      if (fp_cmp(&t1, TFM_UNCONST(void *)modulus) != FP_LT) {
+         fp_sub(&t1, TFM_UNCONST(void *)modulus, &t1);
       }
       /* T1 = T1 + T2 */
       fp_add(&t1, &t2, &t1);
-      if (fp_cmp(&t1, modulus) != FP_LT) {
-         fp_sub(&t1, modulus, &t1);
+      if (fp_cmp(&t1, TFM_UNCONST(void *)modulus) != FP_LT) {
+         fp_sub(&t1, TFM_UNCONST(void *)modulus, &t1);
       }
       /* T1 = T1 + T2 */
       fp_add(&t1, &t2, &t1);
-      if (fp_cmp(&t1, modulus) != FP_LT) {
-         fp_sub(&t1, modulus, &t1);
+      if (fp_cmp(&t1, TFM_UNCONST(void *)modulus) != FP_LT) {
+         fp_sub(&t1, TFM_UNCONST(void *)modulus, &t1);
       }
    }
 
    /* Y = 2Y */
    fp_add(R->y, R->y, R->y);
-   if (fp_cmp(R->y, modulus) != FP_LT) {
-      fp_sub(R->y, modulus, R->y);
+   if (fp_cmp(R->y, TFM_UNCONST(void *)modulus) != FP_LT) {
+      fp_sub(R->y, TFM_UNCONST(void *)modulus, R->y);
    }
    /* Y = Y * Y */
    fp_sqr(R->y, R->y);
-   fp_montgomery_reduce(R->y, modulus, mp);
+   fp_montgomery_reduce(R->y, TFM_UNCONST(void *)modulus, mp);
    /* T2 = Y * Y */
    fp_sqr(R->y, &t2);
-   fp_montgomery_reduce(&t2, modulus, mp);
+   fp_montgomery_reduce(&t2, TFM_UNCONST(void *)modulus, mp);
    /* T2 = T2/2 */
    if (fp_isodd(&t2)) {
-      fp_add(&t2, modulus, &t2);
+      fp_add(&t2, TFM_UNCONST(void *)modulus, &t2);
    }
    fp_div_2(&t2, &t2);
    /* Y = Y * X */
    fp_mul(R->y, R->x, R->y);
-   fp_montgomery_reduce(R->y, modulus, mp);
+   fp_montgomery_reduce(R->y, TFM_UNCONST(void *)modulus, mp);
 
    /* X  = T1 * T1 */
    fp_sqr(&t1, R->x);
-   fp_montgomery_reduce(R->x, modulus, mp);
+   fp_montgomery_reduce(R->x, TFM_UNCONST(void *)modulus, mp);
    /* X = X - Y */
    fp_sub(R->x, R->y, R->x);
    if (fp_cmp_d(R->x, 0) == FP_LT) {
-      fp_add(R->x, modulus, R->x);
+      fp_add(R->x, TFM_UNCONST(void *)modulus, R->x);
    }
    /* X = X - Y */
    fp_sub(R->x, R->y, R->x);
    if (fp_cmp_d(R->x, 0) == FP_LT) {
-      fp_add(R->x, modulus, R->x);
+      fp_add(R->x, TFM_UNCONST(void *)modulus, R->x);
    }
 
    /* Y = Y - X */
    fp_sub(R->y, R->x, R->y);
    if (fp_cmp_d(R->y, 0) == FP_LT) {
-      fp_add(R->y, modulus, R->y);
+      fp_add(R->y, TFM_UNCONST(void *)modulus, R->y);
    }
    /* Y = Y * T1 */
    fp_mul(R->y, &t1, R->y);
-   fp_montgomery_reduce(R->y, modulus, mp);
+   fp_montgomery_reduce(R->y, TFM_UNCONST(void *)modulus, mp);
    /* Y = Y - T2 */
    fp_sub(R->y, &t2, R->y);
    if (fp_cmp_d(R->y, 0) == FP_LT) {
-      fp_add(R->y, modulus, R->y);
+      fp_add(R->y, TFM_UNCONST(void *)modulus, R->y);
    }
 
    return CRYPT_OK;
@@ -618,7 +632,7 @@ static int tfm_ecc_projective_add_point(const ecc_point *P, const ecc_point *Q, 
    }
 
    /* should we dbl instead? */
-   fp_sub(modulus, Q->y, &t1);
+   fp_sub(TFM_UNCONST(void *)modulus, Q->y, &t1);
    if ( (fp_cmp(P->x, Q->x) == FP_EQ) &&
         (Q->z != NULL && fp_cmp(P->z, Q->z) == FP_EQ) &&
         (fp_cmp(P->y, Q->y) == FP_EQ || fp_cmp(P->y, &t1) == FP_EQ)) {
@@ -633,116 +647,116 @@ static int tfm_ecc_projective_add_point(const ecc_point *P, const ecc_point *Q, 
    if (Q->z != NULL) {
       /* T1 = Z' * Z' */
       fp_sqr(Q->z, &t1);
-      fp_montgomery_reduce(&t1, modulus, mp);
+      fp_montgomery_reduce(&t1, TFM_UNCONST(void *)modulus, mp);
       /* X = X * T1 */
       fp_mul(&t1, &x, &x);
-      fp_montgomery_reduce(&x, modulus, mp);
+      fp_montgomery_reduce(&x, TFM_UNCONST(void *)modulus, mp);
       /* T1 = Z' * T1 */
       fp_mul(Q->z, &t1, &t1);
-      fp_montgomery_reduce(&t1, modulus, mp);
+      fp_montgomery_reduce(&t1, TFM_UNCONST(void *)modulus, mp);
       /* Y = Y * T1 */
       fp_mul(&t1, &y, &y);
-      fp_montgomery_reduce(&y, modulus, mp);
+      fp_montgomery_reduce(&y, TFM_UNCONST(void *)modulus, mp);
    }
 
    /* T1 = Z*Z */
    fp_sqr(&z, &t1);
-   fp_montgomery_reduce(&t1, modulus, mp);
+   fp_montgomery_reduce(&t1, TFM_UNCONST(void *)modulus, mp);
    /* T2 = X' * T1 */
    fp_mul(Q->x, &t1, &t2);
-   fp_montgomery_reduce(&t2, modulus, mp);
+   fp_montgomery_reduce(&t2, TFM_UNCONST(void *)modulus, mp);
    /* T1 = Z * T1 */
    fp_mul(&z, &t1, &t1);
-   fp_montgomery_reduce(&t1, modulus, mp);
+   fp_montgomery_reduce(&t1, TFM_UNCONST(void *)modulus, mp);
    /* T1 = Y' * T1 */
    fp_mul(Q->y, &t1, &t1);
-   fp_montgomery_reduce(&t1, modulus, mp);
+   fp_montgomery_reduce(&t1, TFM_UNCONST(void *)modulus, mp);
 
    /* Y = Y - T1 */
    fp_sub(&y, &t1, &y);
    if (fp_cmp_d(&y, 0) == FP_LT) {
-      fp_add(&y, modulus, &y);
+      fp_add(&y, TFM_UNCONST(void *)modulus, &y);
    }
    /* T1 = 2T1 */
    fp_add(&t1, &t1, &t1);
-   if (fp_cmp(&t1, modulus) != FP_LT) {
-      fp_sub(&t1, modulus, &t1);
+   if (fp_cmp(&t1, TFM_UNCONST(void *)modulus) != FP_LT) {
+      fp_sub(&t1, TFM_UNCONST(void *)modulus, &t1);
    }
    /* T1 = Y + T1 */
    fp_add(&t1, &y, &t1);
-   if (fp_cmp(&t1, modulus) != FP_LT) {
-      fp_sub(&t1, modulus, &t1);
+   if (fp_cmp(&t1, TFM_UNCONST(void *)modulus) != FP_LT) {
+      fp_sub(&t1, TFM_UNCONST(void *)modulus, &t1);
    }
    /* X = X - T2 */
    fp_sub(&x, &t2, &x);
    if (fp_cmp_d(&x, 0) == FP_LT) {
-      fp_add(&x, modulus, &x);
+      fp_add(&x, TFM_UNCONST(void *)modulus, &x);
    }
    /* T2 = 2T2 */
    fp_add(&t2, &t2, &t2);
-   if (fp_cmp(&t2, modulus) != FP_LT) {
-      fp_sub(&t2, modulus, &t2);
+   if (fp_cmp(&t2, TFM_UNCONST(void *)modulus) != FP_LT) {
+      fp_sub(&t2, TFM_UNCONST(void *)modulus, &t2);
    }
    /* T2 = X + T2 */
    fp_add(&t2, &x, &t2);
-   if (fp_cmp(&t2, modulus) != FP_LT) {
-      fp_sub(&t2, modulus, &t2);
+   if (fp_cmp(&t2, TFM_UNCONST(void *)modulus) != FP_LT) {
+      fp_sub(&t2, TFM_UNCONST(void *)modulus, &t2);
    }
 
    /* if Z' != 1 */
    if (Q->z != NULL) {
       /* Z = Z * Z' */
       fp_mul(&z, Q->z, &z);
-      fp_montgomery_reduce(&z, modulus, mp);
+      fp_montgomery_reduce(&z, TFM_UNCONST(void *)modulus, mp);
    }
 
    /* Z = Z * X */
    fp_mul(&z, &x, &z);
-   fp_montgomery_reduce(&z, modulus, mp);
+   fp_montgomery_reduce(&z, TFM_UNCONST(void *)modulus, mp);
 
    /* T1 = T1 * X  */
    fp_mul(&t1, &x, &t1);
-   fp_montgomery_reduce(&t1, modulus, mp);
+   fp_montgomery_reduce(&t1, TFM_UNCONST(void *)modulus, mp);
    /* X = X * X */
    fp_sqr(&x, &x);
-   fp_montgomery_reduce(&x, modulus, mp);
+   fp_montgomery_reduce(&x, TFM_UNCONST(void *)modulus, mp);
    /* T2 = T2 * x */
    fp_mul(&t2, &x, &t2);
-   fp_montgomery_reduce(&t2, modulus, mp);
+   fp_montgomery_reduce(&t2, TFM_UNCONST(void *)modulus, mp);
    /* T1 = T1 * X  */
    fp_mul(&t1, &x, &t1);
-   fp_montgomery_reduce(&t1, modulus, mp);
+   fp_montgomery_reduce(&t1, TFM_UNCONST(void *)modulus, mp);
 
    /* X = Y*Y */
    fp_sqr(&y, &x);
-   fp_montgomery_reduce(&x, modulus, mp);
+   fp_montgomery_reduce(&x, TFM_UNCONST(void *)modulus, mp);
    /* X = X - T2 */
    fp_sub(&x, &t2, &x);
    if (fp_cmp_d(&x, 0) == FP_LT) {
-      fp_add(&x, modulus, &x);
+      fp_add(&x, TFM_UNCONST(void *)modulus, &x);
    }
 
    /* T2 = T2 - X */
    fp_sub(&t2, &x, &t2);
    if (fp_cmp_d(&t2, 0) == FP_LT) {
-      fp_add(&t2, modulus, &t2);
+      fp_add(&t2, TFM_UNCONST(void *)modulus, &t2);
    }
    /* T2 = T2 - X */
    fp_sub(&t2, &x, &t2);
    if (fp_cmp_d(&t2, 0) == FP_LT) {
-      fp_add(&t2, modulus, &t2);
+      fp_add(&t2, TFM_UNCONST(void *)modulus, &t2);
    }
    /* T2 = T2 * Y */
    fp_mul(&t2, &y, &t2);
-   fp_montgomery_reduce(&t2, modulus, mp);
+   fp_montgomery_reduce(&t2, TFM_UNCONST(void *)modulus, mp);
    /* Y = T2 - T1 */
    fp_sub(&t2, &t1, &y);
    if (fp_cmp_d(&y, 0) == FP_LT) {
-      fp_add(&y, modulus, &y);
+      fp_add(&y, TFM_UNCONST(void *)modulus, &y);
    }
    /* Y = Y/2 */
    if (fp_isodd(&y)) {
-      fp_add(&y, modulus, &y);
+      fp_add(&y, TFM_UNCONST(void *)modulus, &y);
    }
    fp_div_2(&y, &y);
 

--- a/src/misc/ssh/ssh_decode_sequence_multi.c
+++ b/src/misc/ssh/ssh_decode_sequence_multi.c
@@ -142,7 +142,7 @@ int ssh_decode_sequence_multi(const unsigned char *in, unsigned long *inlen, ...
                err = CRYPT_INVALID_PACKET;
                goto error;
             } else {
-               if ((err = mp_read_unsigned_bin(vdata, (unsigned char *)in, size)) != CRYPT_OK)          { goto error; }
+               if ((err = mp_read_unsigned_bin(vdata, in, size)) != CRYPT_OK)                           { goto error; }
             }
             in += size;
             break;

--- a/src/pk/dsa/dsa_set.c
+++ b/src/pk/dsa/dsa_set.c
@@ -30,9 +30,9 @@ int dsa_set_pqg(const unsigned char *p,  unsigned long plen,
    /* init key */
    if ((err = dsa_int_init(key)) != CRYPT_OK) return err;
 
-   if ((err = mp_read_unsigned_bin(key->p, (unsigned char *)p , plen)) != CRYPT_OK) { goto LBL_ERR; }
-   if ((err = mp_read_unsigned_bin(key->g, (unsigned char *)g , glen)) != CRYPT_OK) { goto LBL_ERR; }
-   if ((err = mp_read_unsigned_bin(key->q, (unsigned char *)q , qlen)) != CRYPT_OK) { goto LBL_ERR; }
+   if ((err = mp_read_unsigned_bin(key->p, p , plen)) != CRYPT_OK)                  { goto LBL_ERR; }
+   if ((err = mp_read_unsigned_bin(key->g, g , glen)) != CRYPT_OK)                  { goto LBL_ERR; }
+   if ((err = mp_read_unsigned_bin(key->q, q , qlen)) != CRYPT_OK)                  { goto LBL_ERR; }
 
    key->qord = mp_unsigned_bin_size(key->q);
 
@@ -75,12 +75,12 @@ int dsa_set_key(const unsigned char *in, unsigned long inlen, int type, dsa_key 
 
    if (type == PK_PRIVATE) {
       key->type = PK_PRIVATE;
-      if ((err = mp_read_unsigned_bin(key->x, (unsigned char *)in, inlen)) != CRYPT_OK) { goto LBL_ERR; }
+      if ((err = mp_read_unsigned_bin(key->x, in, inlen)) != CRYPT_OK)                  { goto LBL_ERR; }
       if ((err = mp_exptmod(key->g, key->x, key->p, key->y)) != CRYPT_OK)               { goto LBL_ERR; }
    }
    else {
       key->type = PK_PUBLIC;
-      if ((err = mp_read_unsigned_bin(key->y, (unsigned char *)in, inlen)) != CRYPT_OK) { goto LBL_ERR; }
+      if ((err = mp_read_unsigned_bin(key->y, in, inlen)) != CRYPT_OK)                  { goto LBL_ERR; }
    }
 
    if ((err = dsa_int_validate_xy(key, &stat)) != CRYPT_OK)                             { goto LBL_ERR; }

--- a/src/pk/dsa/dsa_sign_hash.c
+++ b/src/pk/dsa/dsa_sign_hash.c
@@ -80,7 +80,7 @@ retry:
    inlen = MIN(inlen, (unsigned long)(key->qord));
 
    /* now find s = (in + xr)/k mod q */
-   if ((err = mp_read_unsigned_bin(tmp, (unsigned char *)in, inlen)) != CRYPT_OK)      { goto error; }
+   if ((err = mp_read_unsigned_bin(tmp, in, inlen)) != CRYPT_OK)                       { goto error; }
    if ((err = mp_mul(key->x, r, s)) != CRYPT_OK)                                       { goto error; }
    if ((err = mp_add(s, tmp, s)) != CRYPT_OK)                                          { goto error; }
    if ((err = mp_mulmod(s, kinv, key->q, s)) != CRYPT_OK)                              { goto error; }

--- a/src/pk/dsa/dsa_verify_hash.c
+++ b/src/pk/dsa/dsa_verify_hash.c
@@ -53,7 +53,7 @@ int dsa_verify_hash_raw(         void   *r,          void   *s,
    if ((err = mp_invmod(s, key->q, w)) != CRYPT_OK)                                       { goto error; }
 
    /* u1 = m * w mod q */
-   if ((err = mp_read_unsigned_bin(u1, (unsigned char *)hash, hashlen)) != CRYPT_OK)      { goto error; }
+   if ((err = mp_read_unsigned_bin(u1, hash, hashlen)) != CRYPT_OK)                       { goto error; }
    if ((err = mp_mulmod(u1, w, key->q, u1)) != CRYPT_OK)                                  { goto error; }
 
    /* u2 = r*w mod q */

--- a/src/pk/ecc/ecc_ansi_x963_import.c
+++ b/src/pk/ecc/ecc_ansi_x963_import.c
@@ -43,7 +43,7 @@ int ecc_ansi_x963_import_ex(const unsigned char *in, unsigned long inlen, ecc_ke
    }
 
    /* load public key */
-   if ((err = ecc_set_key((unsigned char *)in, inlen, PK_PUBLIC, key)) != CRYPT_OK) { return err; }
+   if ((err = ecc_set_key(in, inlen, PK_PUBLIC, key)) != CRYPT_OK)                  { return err; }
 
    /* we're done */
    return CRYPT_OK;

--- a/src/pk/ecc/ecc_recover_key.c
+++ b/src/pk/ecc/ecc_recover_key.c
@@ -81,8 +81,8 @@ int ecc_recover_key(const unsigned char *sig,  unsigned long siglen,
          err = CRYPT_INVALID_PACKET;
          goto error;
       }
-      if ((err = mp_read_unsigned_bin(r, (unsigned char *)sig,   i)) != CRYPT_OK)                       { goto error; }
-      if ((err = mp_read_unsigned_bin(s, (unsigned char *)sig+i, i)) != CRYPT_OK)                       { goto error; }
+      if ((err = mp_read_unsigned_bin(r, sig,   i)) != CRYPT_OK)                                        { goto error; }
+      if ((err = mp_read_unsigned_bin(s, sig+i, i)) != CRYPT_OK)                                        { goto error; }
    }
    else if (sigformat == LTC_ECCSIG_ETH27) {
       /* Ethereum (v,r,s) format */
@@ -102,8 +102,8 @@ int ecc_recover_key(const unsigned char *sig,  unsigned long siglen,
          goto error;
       }
       recid = i;
-      if ((err = mp_read_unsigned_bin(r, (unsigned char *)sig,  32)) != CRYPT_OK)                       { goto error; }
-      if ((err = mp_read_unsigned_bin(s, (unsigned char *)sig+32, 32)) != CRYPT_OK)                     { goto error; }
+      if ((err = mp_read_unsigned_bin(r, sig,  32)) != CRYPT_OK)                                        { goto error; }
+      if ((err = mp_read_unsigned_bin(s, sig+32, 32)) != CRYPT_OK)                                      { goto error; }
    }
 #ifdef LTC_SSH
    else if (sigformat == LTC_ECCSIG_RFC5656) {
@@ -150,10 +150,10 @@ int ecc_recover_key(const unsigned char *sig,  unsigned long siglen,
    pbits = mp_count_bits(p);
    pbytes = (pbits+7) >> 3;
    if (pbits > hashlen*8) {
-      if ((err = mp_read_unsigned_bin(e, (unsigned char *)hash, hashlen)) != CRYPT_OK)                  { goto error; }
+      if ((err = mp_read_unsigned_bin(e, hash, hashlen)) != CRYPT_OK)                                   { goto error; }
    }
    else if (pbits % 8 == 0) {
-      if ((err = mp_read_unsigned_bin(e, (unsigned char *)hash, pbytes)) != CRYPT_OK)                   { goto error; }
+      if ((err = mp_read_unsigned_bin(e, hash, pbytes)) != CRYPT_OK)                                    { goto error; }
    }
    else {
       shift_right = 8 - pbits % 8;
@@ -162,7 +162,7 @@ int ecc_recover_key(const unsigned char *sig,  unsigned long siglen,
         ch = (hash[i] << (8-shift_right));
         buf[i] = buf[i] ^ (hash[i] >> shift_right);
       }
-      if ((err = mp_read_unsigned_bin(e, (unsigned char *)buf, pbytes)) != CRYPT_OK)                    { goto error; }
+      if ((err = mp_read_unsigned_bin(e, buf, pbytes)) != CRYPT_OK)                                     { goto error; }
    }
 
    /* decompress point from r=(x mod p) - BEWARE: requires sqrtmod_prime */

--- a/src/pk/ecc/ecc_set_key.c
+++ b/src/pk/ecc/ecc_set_key.c
@@ -20,7 +20,7 @@ int ecc_set_key(const unsigned char *in, unsigned long inlen, int type, ecc_key 
 
    if (type == PK_PRIVATE) {
       /* load private key */
-      if ((err = mp_read_unsigned_bin(key->k, (unsigned char *)in, inlen)) != CRYPT_OK) {
+      if ((err = mp_read_unsigned_bin(key->k, in, inlen)) != CRYPT_OK) {
          goto error;
       }
       if (mp_iszero(key->k) || (mp_cmp(key->k, key->dp.order) != LTC_MP_LT)) {

--- a/src/pk/ecc/ecc_sign_hash.c
+++ b/src/pk/ecc/ecc_sign_hash.c
@@ -55,10 +55,10 @@ int ecc_sign_hash_ex(const unsigned char *in,  unsigned long inlen,
    pbits = mp_count_bits(p);
    pbytes = (pbits+7) >> 3;
    if (pbits > inlen*8) {
-      if ((err = mp_read_unsigned_bin(e, (unsigned char *)in, inlen)) != CRYPT_OK)    { goto errnokey; }
+      if ((err = mp_read_unsigned_bin(e, in, inlen)) != CRYPT_OK)    { goto errnokey; }
    }
    else if (pbits % 8 == 0) {
-      if ((err = mp_read_unsigned_bin(e, (unsigned char *)in, pbytes)) != CRYPT_OK)   { goto errnokey; }
+      if ((err = mp_read_unsigned_bin(e, in, pbytes)) != CRYPT_OK)   { goto errnokey; }
    }
    else {
       shift_right = 8 - pbits % 8;
@@ -67,7 +67,7 @@ int ecc_sign_hash_ex(const unsigned char *in,  unsigned long inlen,
         ch = (in[i] << (8-shift_right));
         buf[i] = buf[i] ^ (in[i] >> shift_right);
       }
-      if ((err = mp_read_unsigned_bin(e, (unsigned char *)buf, pbytes)) != CRYPT_OK)  { goto errnokey; }
+      if ((err = mp_read_unsigned_bin(e, buf, pbytes)) != CRYPT_OK)  { goto errnokey; }
    }
 
    /* make up a key and export the public copy */

--- a/src/pk/ecc/ecc_verify_hash.c
+++ b/src/pk/ecc/ecc_verify_hash.c
@@ -75,8 +75,8 @@ int ecc_verify_hash_ex(const unsigned char *sig,  unsigned long siglen,
          err = CRYPT_INVALID_PACKET;
          goto error;
       }
-      if ((err = mp_read_unsigned_bin(r, (unsigned char *)sig,   i)) != CRYPT_OK)                       { goto error; }
-      if ((err = mp_read_unsigned_bin(s, (unsigned char *)sig+i, i)) != CRYPT_OK)                       { goto error; }
+      if ((err = mp_read_unsigned_bin(r, sig,   i)) != CRYPT_OK)                                        { goto error; }
+      if ((err = mp_read_unsigned_bin(s, sig+i, i)) != CRYPT_OK)                                        { goto error; }
    }
    else if (sigformat == LTC_ECCSIG_ETH27) {
       /* Ethereum (v,r,s) format */
@@ -88,8 +88,8 @@ int ecc_verify_hash_ex(const unsigned char *sig,  unsigned long siglen,
          err = CRYPT_INVALID_PACKET;
          goto error;
       }
-      if ((err = mp_read_unsigned_bin(r, (unsigned char *)sig,  32)) != CRYPT_OK)                       { goto error; }
-      if ((err = mp_read_unsigned_bin(s, (unsigned char *)sig+32, 32)) != CRYPT_OK)                     { goto error; }
+      if ((err = mp_read_unsigned_bin(r, sig,  32)) != CRYPT_OK)                                        { goto error; }
+      if ((err = mp_read_unsigned_bin(s, sig+32, 32)) != CRYPT_OK)                                      { goto error; }
    }
 #ifdef LTC_SSH
    else if (sigformat == LTC_ECCSIG_RFC5656) {
@@ -130,10 +130,10 @@ int ecc_verify_hash_ex(const unsigned char *sig,  unsigned long siglen,
    pbits = mp_count_bits(p);
    pbytes = (pbits+7) >> 3;
    if (pbits > hashlen*8) {
-      if ((err = mp_read_unsigned_bin(e, (unsigned char *)hash, hashlen)) != CRYPT_OK)                  { goto error; }
+      if ((err = mp_read_unsigned_bin(e, hash, hashlen)) != CRYPT_OK)                                   { goto error; }
    }
    else if (pbits % 8 == 0) {
-      if ((err = mp_read_unsigned_bin(e, (unsigned char *)hash, pbytes)) != CRYPT_OK)                   { goto error; }
+      if ((err = mp_read_unsigned_bin(e, hash, pbytes)) != CRYPT_OK)                                    { goto error; }
    }
    else {
       shift_right = 8 - pbits % 8;
@@ -142,7 +142,7 @@ int ecc_verify_hash_ex(const unsigned char *sig,  unsigned long siglen,
         ch = (hash[i] << (8-shift_right));
         buf[i] = buf[i] ^ (hash[i] >> shift_right);
       }
-      if ((err = mp_read_unsigned_bin(e, (unsigned char *)buf, pbytes)) != CRYPT_OK)                    { goto error; }
+      if ((err = mp_read_unsigned_bin(e, buf, pbytes)) != CRYPT_OK)                                     { goto error; }
    }
 
    /*  w  = s^-1 mod n */

--- a/src/pk/ecc/ltc_ecc_import_point.c
+++ b/src/pk/ecc/ltc_ecc_import_point.c
@@ -21,14 +21,14 @@ int ltc_ecc_import_point(const unsigned char *in, unsigned long inlen, void *pri
    if (in[0] == 0x04 && (inlen&1) && ((inlen-1)>>1) == size) {
       /* read uncompressed point */
       /* load x */
-      if ((err = mp_read_unsigned_bin(x, (unsigned char *)in+1, size)) != CRYPT_OK)      { goto cleanup; }
+      if ((err = mp_read_unsigned_bin(x, in+1, size)) != CRYPT_OK)                       { goto cleanup; }
       /* load y */
-      if ((err = mp_read_unsigned_bin(y, (unsigned char *)in+1+size, size)) != CRYPT_OK) { goto cleanup; }
+      if ((err = mp_read_unsigned_bin(y, in+1+size, size)) != CRYPT_OK)                  { goto cleanup; }
    }
    else if ((in[0] == 0x02 || in[0] == 0x03) && (inlen-1) == size && ltc_mp.sqrtmod_prime != NULL) {
       /* read compressed point - BEWARE: requires sqrtmod_prime */
       /* load x */
-      if ((err = mp_read_unsigned_bin(x, (unsigned char *)in+1, size)) != CRYPT_OK)      { goto cleanup; }
+      if ((err = mp_read_unsigned_bin(x, in+1, size)) != CRYPT_OK)                       { goto cleanup; }
       /* compute x^3 */
       if ((err = mp_sqr(x, t1)) != CRYPT_OK)                                             { goto cleanup; }
       if ((err = mp_mulmod(t1, x, prime, t1)) != CRYPT_OK)                               { goto cleanup; }

--- a/src/pk/ecc/ltc_ecc_is_point_at_infinity.c
+++ b/src/pk/ecc/ltc_ecc_is_point_at_infinity.c
@@ -9,7 +9,7 @@
  * a point at infinity is any point (x,y,0) such that y^2 == x^3, except (0,0,0)
  */
 
-int ltc_ecc_is_point_at_infinity(const ecc_point *P, void *modulus, int *retval)
+int ltc_ecc_is_point_at_infinity(const ecc_point *P, const void *modulus, int *retval)
 {
    int err;
    void  *x3, *y2;

--- a/src/pk/ecc/ltc_ecc_map.c
+++ b/src/pk/ecc/ltc_ecc_map.c
@@ -17,7 +17,7 @@
   @param mp       The "b" value from montgomery_setup()
   @return CRYPT_OK on success
 */
-int ltc_ecc_map(ecc_point *P, void *modulus, void *mp)
+int ltc_ecc_map(ecc_point *P, const void *modulus, void *mp)
 {
    void *t1, *t2;
    int   err;

--- a/src/pk/ecc/ltc_ecc_mul2add.c
+++ b/src/pk/ecc/ltc_ecc_mul2add.c
@@ -25,8 +25,8 @@
 int ltc_ecc_mul2add(const ecc_point *A, void *kA,
                     const ecc_point *B, void *kB,
                           ecc_point *C,
-                               void *ma,
-                               void *modulus)
+                         const void *ma,
+                         const void *modulus)
 {
   ecc_point     *precomp[16];
   unsigned       bitbufA, bitbufB, lenA, lenB, len, nA, nB, nibble;

--- a/src/pk/ecc/ltc_ecc_mulmod.c
+++ b/src/pk/ecc/ltc_ecc_mulmod.c
@@ -19,11 +19,12 @@
    @param k    The scalar to multiply by
    @param G    The base point
    @param R    [out] Destination for kG
+   @param a    ECC curve parameter a
    @param modulus  The modulus of the field the ECC curve is in
    @param map      Boolean whether to map back to affine or not (1==map, 0 == leave in projective)
    @return CRYPT_OK on success
 */
-int ltc_ecc_mulmod(void *k, const ecc_point *G, ecc_point *R, void *a, void *modulus, int map)
+int ltc_ecc_mulmod(const void *k, const ecc_point *G, ecc_point *R, const void *a, const void *modulus, int map)
 {
    ecc_point *tG, *M[8];
    int        i, j, err, inf;

--- a/src/pk/ecc/ltc_ecc_mulmod_timing.c
+++ b/src/pk/ecc/ltc_ecc_mulmod_timing.c
@@ -22,7 +22,7 @@
    @param map      Boolean whether to map back to affine or not (1==map, 0 == leave in projective)
    @return CRYPT_OK on success
 */
-int ltc_ecc_mulmod(void *k, const ecc_point *G, ecc_point *R, void *a, void *modulus, int map)
+int ltc_ecc_mulmod(const void *k, const ecc_point *G, ecc_point *R, const void *a, const void *modulus, int map)
 {
    ecc_point *tG, *M[3];
    int        i, j, err, inf;

--- a/src/pk/ecc/ltc_ecc_projective_add_point.c
+++ b/src/pk/ecc/ltc_ecc_projective_add_point.c
@@ -20,7 +20,8 @@
    @param mp       The "b" value from montgomery_setup()
    @return CRYPT_OK on success
 */
-int ltc_ecc_projective_add_point(const ecc_point *P, const ecc_point *Q, ecc_point *R, void *ma, void *modulus, void *mp)
+int ltc_ecc_projective_add_point(const ecc_point *P, const ecc_point *Q, ecc_point *R,
+                                 const void *ma, const void *modulus, void *mp)
 {
    void  *t1, *t2, *x, *y, *z;
    int    err, inf;

--- a/src/pk/ecc/ltc_ecc_projective_dbl_point.c
+++ b/src/pk/ecc/ltc_ecc_projective_dbl_point.c
@@ -37,7 +37,7 @@
    @param mp       The "b" value from montgomery_setup()
    @return CRYPT_OK on success
 */
-int ltc_ecc_projective_dbl_point(const ecc_point *P, ecc_point *R, void *ma, void *modulus, void *mp)
+int ltc_ecc_projective_dbl_point(const ecc_point *P, ecc_point *R, const void *ma, const void *modulus, void *mp)
 {
    void *t1, *t2;
    int   err, inf;

--- a/src/pk/rsa/rsa_exptmod.c
+++ b/src/pk/rsa/rsa_exptmod.c
@@ -53,7 +53,7 @@ int rsa_exptmod(const unsigned char *in,   unsigned long inlen,
 #endif /* LTC_RSA_BLINDING */
                                                            NULL)) != CRYPT_OK)
         { return err; }
-   if ((err = mp_read_unsigned_bin(tmp, (unsigned char *)in, (int)inlen)) != CRYPT_OK)
+   if ((err = mp_read_unsigned_bin(tmp, in, (int)inlen)) != CRYPT_OK)
         { goto error; }
 
 
@@ -130,7 +130,7 @@ int rsa_exptmod(const unsigned char *in,   unsigned long inlen,
       #ifdef LTC_RSA_CRT_HARDENING
       if (has_crt_parameters) {
          if ((err = mp_exptmod(tmp, key->e, key->N, tmpa)) != CRYPT_OK)                              { goto error; }
-         if ((err = mp_read_unsigned_bin(tmpb, (unsigned char *)in, (int)inlen)) != CRYPT_OK)        { goto error; }
+         if ((err = mp_read_unsigned_bin(tmpb, in, (int)inlen)) != CRYPT_OK)                         { goto error; }
          if (mp_cmp(tmpa, tmpb) != LTC_MP_EQ)                                     { err = CRYPT_ERROR; goto error; }
       }
       #endif

--- a/src/pk/rsa/rsa_make_key.c
+++ b/src/pk/rsa/rsa_make_key.c
@@ -130,7 +130,7 @@ int rsa_make_key_ubin_e(prng_state *prng, int wprng, int size,
       return err;
    }
 
-   if ((err = mp_read_unsigned_bin(tmp_e, (unsigned char *)e, elen)) == CRYPT_OK)
+   if ((err = mp_read_unsigned_bin(tmp_e, e, elen)) == CRYPT_OK)
      err = rsa_make_key_bn_e(prng, wprng, size, tmp_e, key);
 
    mp_clear(tmp_e);

--- a/src/pk/rsa/rsa_set.c
+++ b/src/pk/rsa/rsa_set.c
@@ -31,10 +31,10 @@ int rsa_set_key(const unsigned char *N,  unsigned long Nlen,
 
    if ((err = rsa_init(key)) != CRYPT_OK) return err;
 
-   if ((err = mp_read_unsigned_bin(key->N , (unsigned char *)N , Nlen)) != CRYPT_OK)    { goto LBL_ERR; }
-   if ((err = mp_read_unsigned_bin(key->e , (unsigned char *)e , elen)) != CRYPT_OK)    { goto LBL_ERR; }
+   if ((err = mp_read_unsigned_bin(key->N , N , Nlen)) != CRYPT_OK)                     { goto LBL_ERR; }
+   if ((err = mp_read_unsigned_bin(key->e , e , elen)) != CRYPT_OK)                     { goto LBL_ERR; }
    if (d && dlen) {
-      if ((err = mp_read_unsigned_bin(key->d , (unsigned char *)d , dlen)) != CRYPT_OK) { goto LBL_ERR; }
+      if ((err = mp_read_unsigned_bin(key->d , d , dlen)) != CRYPT_OK)                  { goto LBL_ERR; }
       key->type = PK_PRIVATE;
    }
    else {
@@ -72,8 +72,8 @@ int rsa_set_factors(const unsigned char *p,  unsigned long plen,
 
    if (key->type != PK_PRIVATE) return CRYPT_PK_TYPE_MISMATCH;
 
-   if ((err = mp_read_unsigned_bin(key->p , (unsigned char *)p , plen)) != CRYPT_OK) { goto LBL_ERR; }
-   if ((err = mp_read_unsigned_bin(key->q , (unsigned char *)q , qlen)) != CRYPT_OK) { goto LBL_ERR; }
+   if ((err = mp_read_unsigned_bin(key->p , p , plen)) != CRYPT_OK)                  { goto LBL_ERR; }
+   if ((err = mp_read_unsigned_bin(key->q , q , qlen)) != CRYPT_OK)                  { goto LBL_ERR; }
    return CRYPT_OK;
 
 LBL_ERR:
@@ -110,9 +110,9 @@ int rsa_set_crt_params(const unsigned char *dP, unsigned long dPlen,
 
    if (key->type != PK_PRIVATE) return CRYPT_PK_TYPE_MISMATCH;
 
-   if ((err = mp_read_unsigned_bin(key->dP, (unsigned char *)dP, dPlen)) != CRYPT_OK) { goto LBL_ERR; }
-   if ((err = mp_read_unsigned_bin(key->dQ, (unsigned char *)dQ, dQlen)) != CRYPT_OK) { goto LBL_ERR; }
-   if ((err = mp_read_unsigned_bin(key->qP, (unsigned char *)qP, qPlen)) != CRYPT_OK) { goto LBL_ERR; }
+   if ((err = mp_read_unsigned_bin(key->dP, dP, dPlen)) != CRYPT_OK)                  { goto LBL_ERR; }
+   if ((err = mp_read_unsigned_bin(key->dQ, dQ, dQlen)) != CRYPT_OK)                  { goto LBL_ERR; }
+   if ((err = mp_read_unsigned_bin(key->qP, qP, qPlen)) != CRYPT_OK)                  { goto LBL_ERR; }
    return CRYPT_OK;
 
 LBL_ERR:

--- a/src/pk/rsa/rsa_sign_hash.c
+++ b/src/pk/rsa/rsa_sign_hash.c
@@ -78,7 +78,8 @@ int rsa_sign_hash_ex(const unsigned char *in,       unsigned long  inlen,
     }
   } else {
     /* PKCS #1 v1.5 pad the hash */
-    unsigned char *tmpin;
+    unsigned char *tmpin = NULL;
+    const unsigned char *tmpin_ro;
 
     if (padding == LTC_PKCS_1_V1_5) {
       ltc_asn1_list digestinfo[2], siginfo[2];
@@ -111,14 +112,15 @@ int rsa_sign_hash_ex(const unsigned char *in,       unsigned long  inlen,
          XFREE(tmpin);
          return err;
       }
+      tmpin_ro = tmpin;
     } else {
       /* set the pointer and data-length to the input values */
-      tmpin = (unsigned char *)in;
+      tmpin_ro = in;
       y = inlen;
     }
 
     x = *outlen;
-    err = pkcs_1_v1_5_encode(tmpin, y, LTC_PKCS_1_EMSA, modulus_bitlen, NULL, 0, out, &x);
+    err = pkcs_1_v1_5_encode(tmpin_ro, y, LTC_PKCS_1_EMSA, modulus_bitlen, NULL, 0, out, &x);
 
     if (padding == LTC_PKCS_1_V1_5) {
       XFREE(tmpin);

--- a/src/stream/sober128/sober128_stream.c
+++ b/src/stream/sober128/sober128_stream.c
@@ -172,7 +172,7 @@ int sober128_stream_setup(sober128_state *st, const unsigned char *key, unsigned
    st->konst = INITKONST;
 
    for (i = 0; i < keylen; i += 4) {
-      k = BYTE2WORD((unsigned char *)&key[i]);
+      k = BYTE2WORD(&key[i]);
       ADDKEY(k);
       cycle(st->R);
       XORNL(nltap(st));
@@ -214,7 +214,7 @@ int sober128_stream_setiv(sober128_state *st, const unsigned char *iv, unsigned 
    }
 
    for (i = 0; i < ivlen; i += 4) {
-      k = BYTE2WORD((unsigned char *)&iv[i]);
+      k = BYTE2WORD(&iv[i]);
       ADDKEY(k);
       cycle(st->R);
       XORNL(nltap(st));

--- a/tests/bcrypt_test.c
+++ b/tests/bcrypt_test.c
@@ -125,7 +125,7 @@ int bcrypt_test(void)
       l = t->keylen;
       XMEMSET(key, 0, sizeof(key));
       DO(bcrypt_pbkdf_openbsd(t->password, t->passlen, (unsigned char*)t->salt, t->saltlen, t->rounds, idx, key, &l));
-      DO(do_compare_testvector(key, l, (unsigned char*)t->key, t->keylen, "OpenBSD testvectors", i));
+      DO(do_compare_testvector(key, l, t->key, t->keylen, "OpenBSD testvectors", i));
 
 #if defined(LTC_TEST_DBG) && LTC_TEST_DBG > 1
       printf("BCRYPT test #%d OK\n", i);

--- a/tests/der_test.c
+++ b/tests/der_test.c
@@ -620,7 +620,8 @@ static void der_set_test(void)
    static const unsigned char bin_str[] = { 1, 0, 0, 1 };
    static const unsigned long int_val   = 12345678UL;
 
-   unsigned char strs[10][10], outbuf[128];
+   char strs[10][10];
+   unsigned char outbuf[128];
    unsigned long x, val, outlen;
 
    /* make structure and encode it */
@@ -655,19 +656,19 @@ static void der_set_test(void)
       exit(EXIT_FAILURE);
    }
 
-   strcpy((char*)strs[0], "one");
-   strcpy((char*)strs[1], "one2");
-   strcpy((char*)strs[2], "two");
-   strcpy((char*)strs[3], "aaa");
-   strcpy((char*)strs[4], "aaaa");
-   strcpy((char*)strs[5], "aab");
-   strcpy((char*)strs[6], "aaab");
-   strcpy((char*)strs[7], "bbb");
-   strcpy((char*)strs[8], "bbba");
-   strcpy((char*)strs[9], "bbbb");
+   strcpy(strs[0], "one");
+   strcpy(strs[1], "one2");
+   strcpy(strs[2], "two");
+   strcpy(strs[3], "aaa");
+   strcpy(strs[4], "aaaa");
+   strcpy(strs[5], "aab");
+   strcpy(strs[6], "aaab");
+   strcpy(strs[7], "bbb");
+   strcpy(strs[8], "bbba");
+   strcpy(strs[9], "bbbb");
 
    for (x = 0; x < 10; x++) {
-       LTC_SET_ASN1(list, x, LTC_ASN1_PRINTABLE_STRING, strs[x], XSTRLEN((char*)strs[x]));
+       LTC_SET_ASN1(list, x, LTC_ASN1_PRINTABLE_STRING, strs[x], XSTRLEN(strs[x]));
    }
 
    outlen = sizeof(outbuf);
@@ -682,7 +683,7 @@ static void der_set_test(void)
 
    /* now compare */
    for (x = 1; x < 10; x++) {
-      if (!(XSTRLEN((char*)strs[x-1]) <= XSTRLEN((char*)strs[x])) && strcmp((char*)strs[x-1], (char*)strs[x]) >= 0) {
+      if (!(XSTRLEN(strs[x-1]) <= XSTRLEN(strs[x])) && strcmp(strs[x-1], strs[x]) >= 0) {
          fprintf(stderr, "error SET OF order at %lu is wrong\n", x);
          exit(EXIT_FAILURE);
       }
@@ -1626,30 +1627,32 @@ int der_test(void)
    unsigned char buf[3][2048];
    void *a, *b, *c, *d, *e, *f, *g;
 
-   static const unsigned char rsa_oid_der[] = { 0x06, 0x06, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d };
-   static const unsigned long rsa_oid[]     = { 1, 2, 840, 113549 };
+   const unsigned char rsa_oid_der[] = { 0x06, 0x06, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d };
+   const unsigned long rsa_oid[]     = { 1, 2, 840, 113549 };
 
-   static const unsigned char rsa_ia5[]     = "test1@rsa.com";
-   static const unsigned char rsa_ia5_der[] = { 0x16, 0x0d, 0x74, 0x65, 0x73, 0x74, 0x31,
+   const unsigned char rsa_ia5[]     = "test1@rsa.com";
+   const unsigned char rsa_ia5_der[] = { 0x16, 0x0d, 0x74, 0x65, 0x73, 0x74, 0x31,
                                                 0x40, 0x72, 0x73, 0x61, 0x2e, 0x63, 0x6f, 0x6d };
+   unsigned long rsa_ia5_len = XSTRLEN((char*)rsa_ia5);
 
-   static const unsigned char rsa_printable[] = "Test User 1";
-   static const unsigned char rsa_printable_der[] = { 0x13, 0x0b, 0x54, 0x65, 0x73, 0x74, 0x20, 0x55,
+   const unsigned char rsa_printable[] = "Test User 1";
+   const unsigned char rsa_printable_der[] = { 0x13, 0x0b, 0x54, 0x65, 0x73, 0x74, 0x20, 0x55,
                                                       0x73, 0x65, 0x72, 0x20, 0x31 };
+   unsigned long rsa_printable_len = XSTRLEN((char*)rsa_printable);
 
-   static const ltc_utctime   rsa_time1 = { 91, 5, 6, 16, 45, 40, 1, 7, 0 };
-   static const ltc_utctime   rsa_time2 = { 91, 5, 6, 23, 45, 40, 0, 0, 0 };
+   const ltc_utctime   rsa_time1 = { 91, 5, 6, 16, 45, 40, 1, 7, 0 };
+   const ltc_utctime   rsa_time2 = { 91, 5, 6, 23, 45, 40, 0, 0, 0 };
    ltc_utctime                tmp_time;
 
-   static const unsigned char rsa_time1_der[] = { 0x17, 0x11, 0x39, 0x31, 0x30, 0x35, 0x30, 0x36, 0x31, 0x36, 0x34, 0x35, 0x34, 0x30, 0x2D, 0x30, 0x37, 0x30, 0x30 };
-   static const unsigned char rsa_time2_der[] = { 0x17, 0x0d, 0x39, 0x31, 0x30, 0x35, 0x30, 0x36, 0x32, 0x33, 0x34, 0x35, 0x34, 0x30, 0x5a };
+   const unsigned char rsa_time1_der[] = { 0x17, 0x11, 0x39, 0x31, 0x30, 0x35, 0x30, 0x36, 0x31, 0x36, 0x34, 0x35, 0x34, 0x30, 0x2D, 0x30, 0x37, 0x30, 0x30 };
+   const unsigned char rsa_time2_der[] = { 0x17, 0x0d, 0x39, 0x31, 0x30, 0x35, 0x30, 0x36, 0x32, 0x33, 0x34, 0x35, 0x34, 0x30, 0x5a };
 
-   static const wchar_t utf8_1[]           = { 0x0041, 0x2262, 0x0391, 0x002E };
-   static const unsigned char utf8_1_der[] = { 0x0C, 0x07, 0x41, 0xE2, 0x89, 0xA2, 0xCE, 0x91, 0x2E };
-   static const wchar_t utf8_2[]           = { 0xD55C, 0xAD6D, 0xC5B4 };
-   static const unsigned char utf8_2_der[] = { 0x0C, 0x09, 0xED, 0x95, 0x9C, 0xEA, 0xB5, 0xAD, 0xEC, 0x96, 0xB4 };
-   static const wchar_t utf8_3[]           = { 0x05E9, 0x05DC, 0x05D5, 0x05DD };
-   static const unsigned char utf8_3_der[] = { 0x0C, 0x08, 0xD7, 0xA9, 0xD7, 0x9C, 0xD7, 0x95, 0xD7, 0x9D };
+   const wchar_t utf8_1[]           = { 0x0041, 0x2262, 0x0391, 0x002E };
+   const unsigned char utf8_1_der[] = { 0x0C, 0x07, 0x41, 0xE2, 0x89, 0xA2, 0xCE, 0x91, 0x2E };
+   const wchar_t utf8_2[]           = { 0xD55C, 0xAD6D, 0xC5B4 };
+   const unsigned char utf8_2_der[] = { 0x0C, 0x09, 0xED, 0x95, 0x9C, 0xEA, 0xB5, 0xAD, 0xEC, 0x96, 0xB4 };
+   const wchar_t utf8_3[]           = { 0x05E9, 0x05DC, 0x05D5, 0x05DD };
+   const unsigned char utf8_3_der[] = { 0x0C, 0x08, 0xD7, 0xA9, 0xD7, 0x9C, 0xD7, 0x95, 0xD7, 0x9D };
 
    unsigned char utf8_buf[32];
    wchar_t utf8_out[32];
@@ -1863,38 +1866,38 @@ int der_test(void)
 
 /* IA5 string */
    x = sizeof(buf[0]);
-   DO(der_encode_ia5_string(rsa_ia5, XSTRLEN((char*)rsa_ia5), buf[0], &x));
+   DO(der_encode_ia5_string(rsa_ia5, rsa_ia5_len, buf[0], &x));
    if (x != sizeof(rsa_ia5_der) || memcmp(buf[0], rsa_ia5_der, x)) {
       fprintf(stderr, "IA5 encode failed: %lu, %lu\n", x, (unsigned long)sizeof(rsa_ia5_der));
       return 1;
    }
-   DO(der_length_ia5_string(rsa_ia5, XSTRLEN((char*)rsa_ia5), &y));
+   DO(der_length_ia5_string(rsa_ia5, rsa_ia5_len, &y));
    if (y != x) {
       fprintf(stderr, "IA5 length failed to match: %lu, %lu\n", x, y);
       return 1;
    }
    y = sizeof(buf[1]);
    DO(der_decode_ia5_string(buf[0], x, buf[1], &y));
-   if (y != XSTRLEN((char*)rsa_ia5) || memcmp(buf[1], rsa_ia5, XSTRLEN((char*)rsa_ia5))) {
+   if (y != rsa_ia5_len || memcmp(buf[1], rsa_ia5, rsa_ia5_len)) {
        fprintf(stderr, "DER IA5 failed test vector\n");
        return 1;
    }
 
 /* Printable string */
    x = sizeof(buf[0]);
-   DO(der_encode_printable_string(rsa_printable, XSTRLEN((char*)rsa_printable), buf[0], &x));
+   DO(der_encode_printable_string(rsa_printable, rsa_printable_len, buf[0], &x));
    if (x != sizeof(rsa_printable_der) || memcmp(buf[0], rsa_printable_der, x)) {
       fprintf(stderr, "PRINTABLE encode failed: %lu, %lu\n", x, (unsigned long)sizeof(rsa_printable_der));
       return 1;
    }
-   DO(der_length_printable_string(rsa_printable, XSTRLEN((char*)rsa_printable), &y));
+   DO(der_length_printable_string(rsa_printable, rsa_printable_len, &y));
    if (y != x) {
       fprintf(stderr, "printable length failed to match: %lu, %lu\n", x, y);
       return 1;
    }
    y = sizeof(buf[1]);
    DO(der_decode_printable_string(buf[0], x, buf[1], &y));
-   if (y != XSTRLEN((char*)rsa_printable) || memcmp(buf[1], rsa_printable, XSTRLEN((char*)rsa_printable))) {
+   if (y != rsa_printable_len || memcmp(buf[1], rsa_printable, rsa_printable_len)) {
        fprintf(stderr, "DER printable failed test vector\n");
        return 1;
    }

--- a/tests/ecc_test.c
+++ b/tests/ecc_test.c
@@ -261,14 +261,14 @@ static int s_ecc_issue108(void)
    /* ECC-224 AKA SECP224R1 */
    if ((err = ecc_find_curve("SECP224R1", &dp)) != CRYPT_OK)              { goto done; }
    /* read A */
-   if ((err = mp_read_radix(a, (char *)dp->A,  16)) != CRYPT_OK)          { goto done; }
+   if ((err = mp_read_radix(a, dp->A,  16)) != CRYPT_OK)          { goto done; }
    /* read modulus */
-   if ((err = mp_read_radix(modulus, (char *)dp->prime, 16)) != CRYPT_OK) { goto done; }
+   if ((err = mp_read_radix(modulus, dp->prime, 16)) != CRYPT_OK) { goto done; }
    /* read order */
-   if ((err = mp_read_radix(order, (char *)dp->order, 16)) != CRYPT_OK)   { goto done; }
+   if ((err = mp_read_radix(order, dp->order, 16)) != CRYPT_OK)   { goto done; }
    /* read Q */
-   if ((err = mp_read_radix(Q->x, (char *)"EA3745501BBC6A70BBFDD8AEEDB18CF5073C6DC9AA7CBB5915170D60", 16)) != CRYPT_OK) { goto done; }
-   if ((err = mp_read_radix(Q->y, (char *)"6C9CB8E68AABFEC989CAC5E2326E0448B7E69C3E56039BA21A44FDAC", 16)) != CRYPT_OK) { goto done; }
+   if ((err = mp_read_radix(Q->x, "EA3745501BBC6A70BBFDD8AEEDB18CF5073C6DC9AA7CBB5915170D60", 16)) != CRYPT_OK) { goto done; }
+   if ((err = mp_read_radix(Q->y, "6C9CB8E68AABFEC989CAC5E2326E0448B7E69C3E56039BA21A44FDAC", 16)) != CRYPT_OK) { goto done; }
    mp_set(Q->z, 1);
    /* calculate nQ */
    if ((err = ltc_mp.ecc_ptmul(order, Q, Result, a, modulus, 1)) != CRYPT_OK)  { goto done; }
@@ -353,9 +353,9 @@ static int s_ecc_test_mp(void)
    err = CRYPT_OK;
 
    for (i = 0; ltc_ecc_curves[i].prime != NULL; i++) {
-      DO(mp_read_radix(a, (char *)ltc_ecc_curves[i].A,  16));
-      DO(mp_read_radix(modulus, (char *)ltc_ecc_curves[i].prime, 16));
-      DO(mp_read_radix(order, (char *)ltc_ecc_curves[i].order, 16));
+      DO(mp_read_radix(a, ltc_ecc_curves[i].A,  16));
+      DO(mp_read_radix(modulus, ltc_ecc_curves[i].prime, 16));
+      DO(mp_read_radix(order, ltc_ecc_curves[i].order, 16));
 
       /* is prime actually prime? */
       DO(mp_prime_is_prime(modulus, 8, &primality));
@@ -373,8 +373,8 @@ static int s_ecc_test_mp(void)
          printf("Order failed prime check: %s\n", buf);
       }
 
-      DO(mp_read_radix(G->x, (char *)ltc_ecc_curves[i].Gx, 16));
-      DO(mp_read_radix(G->y, (char *)ltc_ecc_curves[i].Gy, 16));
+      DO(mp_read_radix(G->x, ltc_ecc_curves[i].Gx, 16));
+      DO(mp_read_radix(G->y, ltc_ecc_curves[i].Gy, 16));
       mp_set(G->z, 1);
 
       /* then we should have G == (order + 1)G */


### PR DESCRIPTION
Most of all, this adds proper constification to `ltc_math_descriptor`,
the rest is suffering the consequences.

For TomsFastMath specifically, we add unconsting casts so LTM can be compiled
to TFM versions before it gets properly constified.  This is done through a
version checking helper macro that is added in libtom/tomsfastmath#36.
Note that the current TFM release isn't properly constified, but hopefully,
0.14.0 will be.
