### PR TITLE
Fix type in PEM+SSH decoder

### DIFF
--- a/src/misc/pem/pem_ssh.c
+++ b/src/misc/pem/pem_ssh.c
@@ -53,7 +53,7 @@ struct kdf_options {
    const char *name;
    const struct blockcipher_info *cipher;
    unsigned char salt[64];
-   ulong32 saltlen;
+   unsigned long saltlen;
    ulong32 num_rounds;
    struct password pw;
 };


### PR DESCRIPTION
9b6bf32f887899e88eda88dfb4727daaba4fd370 changed the type of the length argument of a `LTC_SSHDATA_STRING` from `ulong32` to `unsigned long` and usage of this wrong type survived multiple re-factors and code moves.

This fixes #669