### PR TITLE
Add missing LTC_ prefix to LTC_LRW_MODE macro

### DIFF
--- a/src/encauth/gcm/gcm_gf_mult.c
+++ b/src/encauth/gcm/gcm_gf_mult.c
@@ -48,7 +48,7 @@ const unsigned char gcm_shift_table[256*2] = {
 #endif
 
 
-#if defined(LTC_GCM_MODE) || defined(LRW_MODE)
+#if defined(LTC_GCM_MODE) || defined(LTC_LRW_MODE)
 
 #ifndef LTC_FAST
 /* right shift */

--- a/src/headers/tomcrypt_mac.h
+++ b/src/headers/tomcrypt_mac.h
@@ -460,7 +460,7 @@ int ccm_test(void);
 
 #endif /* LTC_CCM_MODE */
 
-#if defined(LRW_MODE) || defined(LTC_GCM_MODE)
+#if defined(LTC_LRW_MODE) || defined(LTC_GCM_MODE)
 void gcm_gf_mult(const unsigned char *a, const unsigned char *b, unsigned char *c);
 #endif
 


### PR DESCRIPTION
This also fixes the implicit declaration of function ‘gcm_gf_mult’ warning in lrw_start.c.
