### PR TITLE
Have src/headers/tomcrypt_private.h include stdarg.h

### DIFF
--- a/src/encauth/siv/siv.c
+++ b/src/encauth/siv/siv.c
@@ -1,7 +1,6 @@
 /* LibTomCrypt, modular cryptographic library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
 #include "tomcrypt_private.h"
-#include <stdarg.h>
 
 /**
   @file siv.c

--- a/src/hashes/helper/hash_memory_multi.c
+++ b/src/hashes/helper/hash_memory_multi.c
@@ -1,7 +1,6 @@
 /* LibTomCrypt, modular cryptographic library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
 #include "tomcrypt_private.h"
-#include <stdarg.h>
 
 #ifdef LTC_HASH_HELPERS
 /**

--- a/src/headers/tomcrypt_private.h
+++ b/src/headers/tomcrypt_private.h
@@ -2,6 +2,7 @@
 /* SPDX-License-Identifier: Unlicense */
 
 #include "tomcrypt.h"
+#include <stdarg.h>
 
 /*
  * Internal Macros

--- a/src/mac/blake2/blake2bmac_memory_multi.c
+++ b/src/mac/blake2/blake2bmac_memory_multi.c
@@ -2,7 +2,6 @@
 /* SPDX-License-Identifier: Unlicense */
 
 #include "tomcrypt_private.h"
-#include <stdarg.h>
 
 #ifdef LTC_BLAKE2BMAC
 

--- a/src/mac/blake2/blake2smac_memory_multi.c
+++ b/src/mac/blake2/blake2smac_memory_multi.c
@@ -2,7 +2,6 @@
 /* SPDX-License-Identifier: Unlicense */
 
 #include "tomcrypt_private.h"
-#include <stdarg.h>
 
 #ifdef LTC_BLAKE2SMAC
 

--- a/src/mac/f9/f9_memory_multi.c
+++ b/src/mac/f9/f9_memory_multi.c
@@ -1,7 +1,6 @@
 /* LibTomCrypt, modular cryptographic library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
 #include "tomcrypt_private.h"
-#include <stdarg.h>
 
 /**
   @file f9_memory_multi.c

--- a/src/mac/hmac/hmac_memory_multi.c
+++ b/src/mac/hmac/hmac_memory_multi.c
@@ -1,7 +1,6 @@
 /* LibTomCrypt, modular cryptographic library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
 #include "tomcrypt_private.h"
-#include <stdarg.h>
 
 /**
   @file hmac_memory_multi.c

--- a/src/mac/omac/omac_memory_multi.c
+++ b/src/mac/omac/omac_memory_multi.c
@@ -1,7 +1,6 @@
 /* LibTomCrypt, modular cryptographic library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
 #include "tomcrypt_private.h"
-#include <stdarg.h>
 
 /**
   @file omac_memory_multi.c

--- a/src/mac/pmac/pmac_memory_multi.c
+++ b/src/mac/pmac/pmac_memory_multi.c
@@ -1,7 +1,6 @@
 /* LibTomCrypt, modular cryptographic library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
 #include "tomcrypt_private.h"
-#include <stdarg.h>
 
 /**
    @file pmac_memory_multi.c

--- a/src/mac/poly1305/poly1305_memory_multi.c
+++ b/src/mac/poly1305/poly1305_memory_multi.c
@@ -7,7 +7,6 @@
  */
 
 #include "tomcrypt_private.h"
-#include <stdarg.h>
 
 #ifdef LTC_POLY1305
 

--- a/src/mac/xcbc/xcbc_memory_multi.c
+++ b/src/mac/xcbc/xcbc_memory_multi.c
@@ -1,7 +1,6 @@
 /* LibTomCrypt, modular cryptographic library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
 #include "tomcrypt_private.h"
-#include <stdarg.h>
 
 /**
   @file xcbc_memory_multi.c

--- a/src/math/multi.c
+++ b/src/math/multi.c
@@ -3,8 +3,6 @@
 #include "tomcrypt_private.h"
 
 #ifdef LTC_MPI
-#include <stdarg.h>
-
 int ltc_init_multi(void **a, ...)
 {
    void    **cur = a;

--- a/src/misc/crypt/crypt_fsa.c
+++ b/src/misc/crypt/crypt_fsa.c
@@ -1,7 +1,6 @@
 /* LibTomCrypt, modular cryptographic library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
 #include "tomcrypt_private.h"
-#include <stdarg.h>
 
 /**
   @file crypt_fsa.c

--- a/src/misc/ssh/ssh_decode_sequence_multi.c
+++ b/src/misc/ssh/ssh_decode_sequence_multi.c
@@ -1,7 +1,6 @@
 /* LibTomCrypt, modular cryptographic library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
 #include "tomcrypt_private.h"
-#include <stdarg.h>
 
 /**
    @file ssh_decode_sequence_multi.c

--- a/src/misc/ssh/ssh_encode_sequence_multi.c
+++ b/src/misc/ssh/ssh_encode_sequence_multi.c
@@ -1,7 +1,6 @@
 /* LibTomCrypt, modular cryptographic library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
 #include "tomcrypt_private.h"
-#include <stdarg.h>
 
 /**
    @file ssh_encode_sequence_multi.c

--- a/src/pk/asn1/der/sequence/der_decode_sequence_multi.c
+++ b/src/pk/asn1/der/sequence/der_decode_sequence_multi.c
@@ -1,7 +1,6 @@
 /* LibTomCrypt, modular cryptographic library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
 #include "tomcrypt_private.h"
-#include <stdarg.h>
 
 
 /**

--- a/src/pk/asn1/der/sequence/der_encode_sequence_multi.c
+++ b/src/pk/asn1/der/sequence/der_encode_sequence_multi.c
@@ -1,7 +1,6 @@
 /* LibTomCrypt, modular cryptographic library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
 #include "tomcrypt_private.h"
-#include <stdarg.h>
 
 
 /**

--- a/src/pk/rsa/rsa_key.c
+++ b/src/pk/rsa/rsa_key.c
@@ -9,8 +9,6 @@
 */
 
 #ifdef LTC_MRSA
-#include <stdarg.h>
-
 static void s_mpi_shrink_multi(void **a, ...)
 {
    void **cur;


### PR DESCRIPTION
This ensures that `va_list`, which is used in that file, gets properly
declared.

As a consequence, the following pattern in other files can be reduced:

    #include "tomcrypt_private.h"
    #include <stdarg.h>

Fixes #679
