### PR TITLE
Fix CMake configure on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,17 +119,6 @@ if(CMAKE_SYSTEM_NAME MATCHES "CYGWIN")
     list(APPEND LTC_C_FLAGS -no-undefined)
 endif()
 
-if(MSVC)
-    cmake_push_check_state()
-    set(CMAKE_REQUIRED_LIBRARIES bcrypt)
-    check_symbol_exists(BCryptGenRandom "Windows.h;bcrypt.h" BCRYPT_AVAILABLE)
-    cmake_pop_check_state()
-    if(BCRYPT_AVAILABLE)
-        target_link_libraries(${PROJECT_NAME} PRIVATE Bcrypt)
-        list(APPEND LTC_C_FLAGS -DLTC_WIN32_BCRYPT)
-    endif()
-endif()
-
 # If the user set the environment variables at generate-time, append them in order to allow
 # overriding our defaults.
 # ~~~
@@ -159,6 +148,17 @@ set_target_properties(
                SOVERSION ${PROJECT_VERSION_MAJOR}
                PUBLIC_HEADER "${PUBLIC_HEADERS}"
 )
+
+if(MSVC)
+    cmake_push_check_state()
+    set(CMAKE_REQUIRED_LIBRARIES bcrypt)
+    check_symbol_exists(BCryptGenRandom "Windows.h;bcrypt.h" BCRYPT_AVAILABLE)
+    cmake_pop_check_state()
+    if(BCRYPT_AVAILABLE)
+        target_link_libraries(${PROJECT_NAME} PRIVATE Bcrypt)
+        list(APPEND LTC_C_FLAGS -DLTC_WIN32_BCRYPT)
+    endif()
+endif()
 
 option(COMPILE_LTO "Build with LTO enabled")
 if(COMPILE_LTO)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,9 +21,19 @@ build_script:
       cd..
       git clone https://github.com/libtom/libtommath.git --branch=master
       cd libtommath
+      mkdir build
+      cd build
+      cmake -G "Ninja" ..
+      ninja
+      cd..
       nmake -f makefile.msvc
       cd..
       cd libtomcrypt
+      mkdir build
+      cd build
+      cmake -G "Ninja" ..
+      ninja
+      cd..
       nmake -f makefile.msvc all
 test_script:
 - cmd: test.exe


### PR DESCRIPTION
Calling `target_link_libraries` before a target has been added seems to cause errors during CMake configuration.

Since BCrypt was fixed in b508028b141a951aa9c41d0cddb815ed4ff950ed, this error seems to occur.

Moving the `target_link_libraries` call after the library has been added fixes this.