### PR TITLE
Fix build of aesni on msvc

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,13 @@ build_script:
       ninja
       cd..
       nmake -f makefile.msvc all
+      cp test.exe test-stock.exe
+      cp timing.exe timing-stock.exe
       nmake -f makefile.msvc clean
       nmake -f makefile.msvc all CFLAGS="/Ox /DUSE_LTM /DLTM_DESC /DLTC_AES_NI /I../libtommath"
 test_script:
-- cmd: test.exe
+- cmd: >-
+    test-stock.exe
+      test.exe
+      timing-stock.exe cipher_ecb
+      timing.exe cipher_ecb

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,5 +35,7 @@ build_script:
       ninja
       cd..
       nmake -f makefile.msvc all
+      nmake -f makefile.msvc clean
+      nmake -f makefile.msvc all CFLAGS="/Ox /DUSE_LTM /DLTM_DESC /DLTC_AES_NI /I../libtommath"
 test_script:
 - cmd: test.exe

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -294,13 +294,15 @@ test.exe: $(LIBMAIN_S) $(TOBJECTS)
 	cl $(LTC_CFLAGS) $(TOBJECTS) $(LIBMAIN_S) $(LTC_LDFLAGS) /Fe$@
 	@echo NOTICE: start the tests by launching test.exe
 
-all: $(LIBMAIN_S) hashsum.exe crypt.exe small.exe tv_gen.exe sizes.exe constants.exe timing.exe test.exe
+ALL_TEST=hashsum.exe crypt.exe small.exe tv_gen.exe sizes.exe constants.exe timing.exe test.exe
+
+all: $(LIBMAIN_S) $(ALL_TEST)
 
 test: test.exe
 
 clean:
 	@-cmd /c del /Q *_tv.txt 2>nul
-	@-cmd /c del /Q /S *.OBJ *.LIB *.EXE *.DLL 2>nul
+	@-cmd /c del /Q /S *.OBJ *.LIB $(ALL_TEST) *.DLL 2>nul
 
 #Install the library + headers
 install: $(LIBMAIN_S)

--- a/src/ciphers/aes/aes_desc.c
+++ b/src/ciphers/aes/aes_desc.c
@@ -63,10 +63,19 @@ static LTC_INLINE int s_aesni_is_supported(void)
       a = 1;
       c = 0;
 
+#if defined(_MSC_VER) && !defined(__clang__)
+      int arr[4];
+      __cpuidex(arr, a, c);
+      a = arr[0];
+      b = arr[1];
+      c = arr[2];
+      d = arr[3];
+#else
       __asm__ volatile ("cpuid"
            :"=a"(a), "=b"(b), "=c"(c), "=d"(d)
            :"a"(a), "c"(c)
           );
+#endif
 
       is_supported = ((c >> 19) & 1) && ((c >> 25) & 1);
       initialized = 1;


### PR DESCRIPTION
This fixes building LTC_AES_NI on msvc, keeps compat with clang-cl

### Checklist

* [x] ran tests (locally)
