### PR TITLE
Add CMake & arm64 tests to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,3 +133,47 @@ jobs:
         run: |
           make pre_gen
           make CFLAGS="-DLTM_DESC -DUSE_LTM" EXTRALIBS="-ltommath" AMALGAM=1 -j$(nproc) check
+
+  CMake:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-22.04, ubuntu-24.04, ubuntu-22.04-arm, ubuntu-24.04-arm ]
+        build_type: [ '', -DCMAKE_BUILD_TYPE=Debug, -DCMAKE_BUILD_TYPE=Release, -DCMAKE_BUILD_TYPE=RelWithDebInfo, -DCMAKE_BUILD_TYPE=MinSizeRel ]
+        cc: [ clang, gcc ]
+        config:
+          # Static library build
+          - { CMAKEOPTIONS: '-DBUILD_SHARED_LIBS=Off' }
+          # Shared library build
+          - { CMAKEOPTIONS: '-DBUILD_SHARED_LIBS=On'  }
+    steps:
+      - uses: actions/checkout@v4
+      - name: install dependencies
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_on: error
+          command: |
+            sudo apt-get update -qq
+            sudo apt-get remove -y libtommath1
+            curl -s https://packagecloud.io/install/repositories/libtom/packages/script.deb.sh | sudo bash
+            sudo apt-get install libtommath-git-dev
+            sudo apt-get install -y cmake gcc clang llvm
+      - name: build
+        run: |
+          mkdir build
+          cd build
+          CC=${{ matrix.cc }} cmake ${{ matrix.config.CMAKEOPTIONS }} ${{ matrix.build_type }} ..
+          make -j$(nproc)
+      - name: test
+        run: |
+          cd build
+          CC=${{ matrix.cc }} cmake ${{ matrix.config.CMAKEOPTIONS }} ${{ matrix.build_type }} -DBUILD_TESTING=On ..
+          make -j$(nproc)
+          ctest
+      - name: error logs
+        if: ${{ failure() }}
+        run: |
+          cat build/Testing/Temporary/LastTest.log || true
+          cat demo/build/Testing/Temporary/LastTest.log || true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,11 +63,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: install dependencies
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4.0.0
         with:
           timeout_minutes: 20
           max_attempts: 3
-          retry_on: error
           command: |
             sudo apt-get update -qq
             sudo apt-get install -y libgmp-dev valgrind libtool-bin clang-tools lcov ruby clang
@@ -117,11 +116,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: install dependencies
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4.0.0
         with:
-          timeout_minutes: 5
+          timeout_minutes: 20
           max_attempts: 3
-          retry_on: error
           command: |
             sudo apt-get update -qq
             sudo apt-get remove -y libtommath1
@@ -149,11 +147,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: install dependencies
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4.0.0
         with:
-          timeout_minutes: 5
+          timeout_minutes: 20
           max_attempts: 3
-          retry_on: error
           command: |
             sudo apt-get update -qq
             sudo apt-get remove -y libtommath1


### PR DESCRIPTION
This adds CMake tests on x86_64 and arm64 to the CI jobs.

Since #714 specifically adds arm64 support I thought this makes sense now.