### PR TITLE
Fix s_pclmul_is_supported() cache flag on MSVC

### DIFF
--- a/src/encauth/gcm/gcm_gf_mult.c
+++ b/src/encauth/gcm/gcm_gf_mult.c
@@ -38,8 +38,8 @@ static LTC_INLINE int s_pclmul_is_supported(void)
           );
 
       is_supported = ((c >> 1) & 1);
-      initialized = 1;
 #endif
+      initialized = 1;
    }
 
    return is_supported;


### PR DESCRIPTION
Move initialized=1 out of the #else branch so that on MSVC it doesn't call __cpuid every time.
