### PR TITLE
Fix s_ocb_done aliasing bug in decrypt path

### DIFF
--- a/src/encauth/ocb/ocb_test.c
+++ b/src/encauth/ocb/ocb_test.c
@@ -158,7 +158,7 @@ int ocb_test(void)
 
    int err, x, idx, res;
    unsigned long len;
-   unsigned char outct[MAXBLOCKSIZE], outtag[MAXBLOCKSIZE];
+   unsigned char outct[MAXBLOCKSIZE], outtag[MAXBLOCKSIZE], outpt[MAXBLOCKSIZE];
 
     /* AES can be under rijndael or aes... try to find it */
     if ((idx = find_cipher("aes")) == -1) {
@@ -179,6 +179,25 @@ int ocb_test(void)
            return CRYPT_FAIL_TESTVECTOR;
         }
 
+        /* Decrypt with separate input and output buffers.  Historically
+         * s_ocb_done() had an aliasing bug in its decrypt path that only
+         * surfaced when ct and pt were distinct buffers (the earlier
+         * in-place call below masked it).  Run this case first so it is
+         * exercised on every test vector.
+         */
+        XMEMSET(outpt, 0, sizeof(outpt));
+        if ((err = ocb_decrypt_verify_memory(idx, tests[x].key, 16, tests[x].nonce, outct, tests[x].ptlen,
+             outpt, tests[x].tag, len, &res)) != CRYPT_OK) {
+           return err;
+        }
+        if ((res != 1) || ltc_compare_testvector(outpt, tests[x].ptlen, tests[x].pt, tests[x].ptlen, "OCB separate-buffer", x)) {
+#ifdef LTC_TEST_DBG
+           printf("\n\nOCB: Failure-decrypt (separate buffers) - res = %d\n", res);
+#endif
+           return CRYPT_FAIL_TESTVECTOR;
+        }
+
+        /* Also exercise the in-place form for backward compatibility. */
         if ((err = ocb_decrypt_verify_memory(idx, tests[x].key, 16, tests[x].nonce, outct, tests[x].ptlen,
              outct, tests[x].tag, len, &res)) != CRYPT_OK) {
            return err;

--- a/src/encauth/ocb/s_ocb_done.c
+++ b/src/encauth/ocb/s_ocb_done.c
@@ -77,10 +77,18 @@ int s_ocb_done(ocb_state *ocb, const unsigned char *pt, unsigned long ptlen,
    }
 
    if (mode == 1) {
-      /* decrypt mode, so let's xor it first */
-      /* xor C[m] into checksum */
+      /* decrypt mode: xor C[m] into checksum.  The function's parameter
+       * names are misleading (see header comment) -- in decrypt mode the
+       * input ciphertext lives in `pt` (not `ct`), and `ct` is the output
+       * plaintext buffer that has not been written yet.  Reading from `ct`
+       * here only happens to work when the caller aliases the input and
+       * output buffers (in-place decryption); with separate buffers the
+       * checksum is computed against uninitialised memory and the tag
+       * verification fails.  Use `pt` (the input parameter) so the code
+       * works for both in-place and separate-buffer callers.
+       */
       for (x = 0; x < (int)ptlen; x++) {
-         ocb->checksum[x] ^= ct[x];
+         ocb->checksum[x] ^= pt[x];
       }
    }
 


### PR DESCRIPTION
I'm preparing a new release of my Tcl wrapper of libtomcrypt and hit an ocb decrypt issue while having Claude write a skill file for the package, which it tracked back to libtomcrypt and fixed here.  I don't know what this project's policy is on AI generated code, but I've reviewed it and the analysis appears correct (and boils down to a single character fix).  The message below and the commit were authored by Claude:

In decrypt mode (mode==1), s_ocb_done was XORing `ct[x]` into the checksum before writing the output.  The function's parameter names are misleading (the header comment notes pt/ct really mean in/out), so in decrypt mode `ct` is the not-yet-written *output* buffer and `pt` is the *input* ciphertext.  Reading from `ct` only worked when callers aliased the input and output buffers (in-place decryption), as the self-test does.  Callers passing distinct buffers got CRYPT_OK with stat=0 — correct plaintext but failed tag verification.

Fix by reading from `pt[x]` (the input).  Add a separate-buffer regression case to ocb_test that runs against every existing test vector and was confirmed to fail without the fix.

### Checklist

* [x] tests are added or updated
