### PR TITLE
fix unused-parameter warning

### DIFF
--- a/src/hashes/sha1_desc.c
+++ b/src/hashes/sha1_desc.c
@@ -132,6 +132,8 @@ int sha1_test(void)
 int sha1_test_desc(const struct ltc_hash_descriptor *desc, const char *name)
 {
 #ifndef LTC_TEST
+   (void)desc;
+   (void)name;
    return CRYPT_NOP;
 #else
    static const struct {

--- a/src/hashes/sha2/sha224_desc.c
+++ b/src/hashes/sha2/sha224_desc.c
@@ -121,7 +121,9 @@ int sha224_test(void)
 int sha224_test_desc(const struct ltc_hash_descriptor *desc, const char *name)
 {
  #ifndef LTC_TEST
-    return CRYPT_NOP;
+   (void)desc;
+   (void)name;
+   return CRYPT_NOP;
  #else
   static const struct {
       const char *msg;

--- a/src/hashes/sha2/sha256_desc.c
+++ b/src/hashes/sha2/sha256_desc.c
@@ -132,6 +132,8 @@ int sha256_test(void)
 int sha256_test_desc(const struct ltc_hash_descriptor *desc, const char *name)
 {
 #ifndef LTC_TEST
+   (void)desc;
+   (void)name;
    return CRYPT_NOP;
 #else
    static const struct {


### PR DESCRIPTION
A fix for warnings like this:
```
ltc/hashes/sha1_desc.c: In function ‘sha1_test_desc’:
ltc/hashes/sha1_desc.c:132:54: error: unused parameter ‘desc’ [-Werror=unused-parameter]
  132 | int sha1_test_desc(const struct ltc_hash_descriptor *desc, const char *name)
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
ltc/hashes/sha1_desc.c:132:72: error: unused parameter ‘name’ [-Werror=unused-parameter]
  132 | int sha1_test_desc(const struct ltc_hash_descriptor *desc, const char *name)
      |                                                            ~~~~~~~~~~~~^~~~
```
