### PR TITLE
patch HMAC to accept zero-length keys and remove the scrypt workaround

### DIFF
--- a/src/mac/hmac/hmac_file.c
+++ b/src/mac/hmac/hmac_file.c
@@ -39,7 +39,7 @@ int hmac_file(int hash, const char *fname,
    int err;
 
    LTC_ARGCHK(fname  != NULL);
-   LTC_ARGCHK(key    != NULL);
+   LTC_ARGCHK(key    != NULL || keylen == 0);
    LTC_ARGCHK(out    != NULL);
    LTC_ARGCHK(outlen != NULL);
 

--- a/src/mac/hmac/hmac_init.c
+++ b/src/mac/hmac/hmac_init.c
@@ -27,7 +27,7 @@ int hmac_init(hmac_state *hmac, int hash, const unsigned char *key, unsigned lon
     int err;
 
     LTC_ARGCHK(hmac != NULL);
-    LTC_ARGCHK(key  != NULL);
+    LTC_ARGCHK(key  != NULL || keylen == 0);
 
     /* valid hash? */
     if ((err = hash_is_valid(hash)) != CRYPT_OK) {
@@ -35,11 +35,6 @@ int hmac_init(hmac_state *hmac, int hash, const unsigned char *key, unsigned lon
     }
     hmac->hash = hash;
     hashsize   = hash_descriptor[hash].hashsize;
-
-    /* valid key length? */
-    if (keylen == 0) {
-        return CRYPT_INVALID_KEYSIZE;
-    }
 
     /* allocate ram for buf */
     buf = XMALLOC(LTC_HMAC_BLOCKSIZE);
@@ -60,7 +55,7 @@ int hmac_init(hmac_state *hmac, int hash, const unsigned char *key, unsigned lon
            goto LBL_ERR;
         }
         keylen = hashsize;
-    } else {
+    } else if (keylen != 0) {
         XMEMCPY(hmac->key, key, (size_t)keylen);
     }
 

--- a/src/mac/hmac/hmac_memory.c
+++ b/src/mac/hmac/hmac_memory.c
@@ -28,8 +28,8 @@ int hmac_memory(int hash,
     hmac_state *hmac;
     int         err;
 
-    LTC_ARGCHK(key    != NULL);
-    LTC_ARGCHK(in     != NULL);
+    LTC_ARGCHK(key    != NULL || keylen == 0);
+    LTC_ARGCHK(in     != NULL || inlen == 0);
     LTC_ARGCHK(out    != NULL);
     LTC_ARGCHK(outlen != NULL);
 

--- a/src/mac/hmac/hmac_memory_multi.c
+++ b/src/mac/hmac/hmac_memory_multi.c
@@ -34,8 +34,8 @@ int hmac_memory_multi(int hash,
     const unsigned char *curptr;
     unsigned long        curlen;
 
-    LTC_ARGCHK(key    != NULL);
-    LTC_ARGCHK(in     != NULL);
+    LTC_ARGCHK(key    != NULL || keylen == 0);
+    LTC_ARGCHK(in     != NULL || inlen == 0);
     LTC_ARGCHK(out    != NULL);
     LTC_ARGCHK(outlen != NULL);
 

--- a/src/mac/hmac/hmac_process.c
+++ b/src/mac/hmac/hmac_process.c
@@ -20,7 +20,8 @@ int hmac_process(hmac_state *hmac, const unsigned char *in, unsigned long inlen)
 {
     int err;
     LTC_ARGCHK(hmac != NULL);
-    LTC_ARGCHK(in != NULL);
+    LTC_ARGCHK(in != NULL || inlen == 0);
+    if (inlen == 0) return CRYPT_OK;
     if ((err = hash_is_valid(hmac->hash)) != CRYPT_OK) {
         return err;
     }

--- a/src/mac/hmac/hmac_test.c
+++ b/src/mac/hmac/hmac_test.c
@@ -48,6 +48,13 @@ int hmac_test(void)
     return CRYPT_NOP;
  #else
     unsigned char digest[MAXBLOCKSIZE];
+    static const unsigned char empty_key_sha256_expected[32] = {
+        0xfd, 0x7a, 0xdb, 0x15, 0x2c, 0x05, 0xef, 0x80,
+        0xdc, 0xcf, 0x50, 0xa1, 0xfa, 0x4c, 0x05, 0xd5,
+        0xa3, 0xec, 0x6d, 0xa9, 0x55, 0x75, 0xfc, 0x31,
+        0x2a, 0xe7, 0xc5, 0xd0, 0x91, 0x83, 0x63, 0x51
+    };
+    static const unsigned char empty_key_msg[] = { 'a', 'b', 'c' };
     int i;
 
     static const unsigned char hmac_test_case_keys[][136] = {
@@ -609,6 +616,17 @@ int hmac_test(void)
     }
     if (tested == 0) {
         return CRYPT_NOP;
+    }
+
+    i = find_hash("sha256");
+    if (i != -1) {
+        outlen = sizeof(digest);
+        if ((err = hmac_memory(i, NULL, 0, empty_key_msg, sizeof(empty_key_msg), digest, &outlen)) != CRYPT_OK) {
+            return err;
+        }
+        if (ltc_compare_testvector(digest, outlen, empty_key_sha256_expected, sizeof(empty_key_sha256_expected), "empty-key sha256", (unsigned long)i)) {
+            return CRYPT_FAIL_TESTVECTOR;
+        }
     }
     return CRYPT_OK;
  #endif

--- a/src/misc/scrypt/scrypt.c
+++ b/src/misc/scrypt/scrypt.c
@@ -123,9 +123,7 @@ int scrypt_pbkdf(const unsigned char *password, unsigned long password_len,
                  unsigned char *out, unsigned long outlen)
 {
    unsigned char *B = NULL, *V = NULL, *XY = NULL;
-   const unsigned char *pwd;
-   unsigned long pwd_len, Blen, Vlen, XYlen, i;
-   unsigned char zero_byte = 0;
+   unsigned long Blen, Vlen, XYlen, i;
    int err, hash_idx;
 
    LTC_ARGCHK(out != NULL);
@@ -143,15 +141,6 @@ int scrypt_pbkdf(const unsigned char *password, unsigned long password_len,
    hash_idx = find_hash("sha256");
    if (hash_idx == -1)                        return CRYPT_INVALID_HASH;
 
-   /* WORKAROUND: HMAC rejects zero-length keys; a single zero byte
-    * produces the same zero-padded key block as an empty key. */
-   pwd = password;
-   pwd_len = password_len;
-   if (pwd_len == 0) {
-      pwd = &zero_byte;
-      pwd_len = 1;
-   }
-
    Blen  = 128 * r * p;
    Vlen  = 128 * r * N;
    XYlen = 256 * r;
@@ -167,7 +156,7 @@ int scrypt_pbkdf(const unsigned char *password, unsigned long password_len,
    /* 1: B = PBKDF2-HMAC-SHA256(password, salt, 1, p * 128 * r) */
    {
       unsigned long blen_out = Blen;
-      err = pkcs_5_alg2(pwd, pwd_len, salt, salt_len, 1, hash_idx, B, &blen_out);
+      err = pkcs_5_alg2(password, password_len, salt, salt_len, 1, hash_idx, B, &blen_out);
       if (err != CRYPT_OK) goto cleanup;
    }
    /* 2: for i = 0 to p-1: B[i] = ROMix(r, B[i], N) */
@@ -177,7 +166,7 @@ int scrypt_pbkdf(const unsigned char *password, unsigned long password_len,
    /* 3: DK = PBKDF2-HMAC-SHA256(password, B, 1, dkLen) */
    {
       unsigned long outlen_out = outlen;
-      err = pkcs_5_alg2(pwd, pwd_len, B, Blen, 1, hash_idx, out, &outlen_out);
+      err = pkcs_5_alg2(password, password_len, B, Blen, 1, hash_idx, out, &outlen_out);
    }
 
 cleanup:


### PR DESCRIPTION
RFC 2104 says the HMAC key "can be of any length" which includes length 0
