### PR TITLE
GCM + FreeBSD + HWCAP_PMULL

### DIFF
--- a/src/encauth/gcm/gcm_gf_mult.c
+++ b/src/encauth/gcm/gcm_gf_mult.c
@@ -153,9 +153,11 @@ static void s_gcm_gf_mult_pclmul(const unsigned char *a, const unsigned char *b,
 #include <sys/sysctl.h>
 #elif defined(_WIN32)
 #include <windows.h>
-#else
+#elif defined(__linux__)
 #include <sys/auxv.h>
 #include <asm/hwcap.h>
+#elif defined(__FreeBSD__)
+#include <sys/auxv.h>
 #endif
 
 static LTC_INLINE int s_pmull_is_supported(void)
@@ -171,9 +173,14 @@ static LTC_INLINE int s_pmull_is_supported(void)
       }
 #elif defined (_WIN32)
       is_supported = IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE);
-#else
+#elif defined(__linux__)
       unsigned long hwcaps = getauxval(AT_HWCAP);
       is_supported = (hwcaps & HWCAP_PMULL);
+#elif defined(__FreeBSD__)
+      unsigned long hwcaps = 0;
+      if (elf_aux_info(AT_HWCAP, &hwcaps, sizeof(hwcaps)) == 0) {
+         is_supported = (hwcaps & HWCAP_PMULL) != 0;
+      }
 #endif
       initialized = 1;
    }


### PR DESCRIPTION
A fix for this type of build failure (seen on FreeBSD/arm64)
```
cc -Iltm -Iltc/headers -DLTC_SOURCE -DLTC_NO_TEST -DLTC_NO_PROTOTYPES -DLTM_DESC -DHAS_FPSETMASK -DHAS_FLOATINGPOINT_H -fno-strict-aliasing -pipe -fstack-protector-strong -I/usr/local/include -DPIC -fPIC -O2 -pipe  -DARGTYPE=4 -c ltc/encauth/gcm/gcm_gf_mult.c -o ltc/encauth/gcm/gcm_gf_mult.o
ltc/encauth/gcm/gcm_gf_mult.c:135:10: fatal error: 'asm/hwcap.h' file not found
  135 | #include <asm/hwcap.h>
      |          ^~~~~~~~~~~~~
1 error generated.
*** Error code 1
```

AFAIK `asm/hwcap.h` is a Linux kernel userspace API header, therefore guarded by `if defined(__linux__)`