### PR TITLE
padding_depad - reject zero-length input (except for LTC_PAD_ZERO)

### DIFF
--- a/src/misc/padding/padding_depad.c
+++ b/src/misc/padding/padding_depad.c
@@ -27,6 +27,13 @@ int padding_depad(const unsigned char *data, unsigned long *length, unsigned lon
 
    type = mode & LTC_PAD_MASK;
 
+   /* LTC_PAD_ZERO is the only mode where padding_pad() can produce a 0-byte output.
+      Every other mode always emits at least one padding byte, so a 0-byte buffer is malformed.
+   */
+   if (padded_length == 0 && type != LTC_PAD_ZERO) {
+      return CRYPT_INVALID_PACKET;
+   }
+
    if (type < LTC_PAD_ONE_AND_ZERO) {
       pad = data[padded_length - 1];
 

--- a/tests/padding_test.c
+++ b/tests/padding_test.c
@@ -215,6 +215,30 @@ int padding_test(void)
       SHOULD_FAIL(padding_depad(data, &len, (LTC_PAD_PKCS7 | 16)));
    }
 
+   /* zero-length input must be rejected for every mode except LTC_PAD_ZERO */
+   {
+      const unsigned long modes[] = {
+         LTC_PAD_PKCS7 | 16,
+#ifdef LTC_RNG_GET_BYTES
+         LTC_PAD_ISO_10126 | 16,
+#endif
+         LTC_PAD_ANSI_X923 | 16,
+         LTC_PAD_SSH | 16,
+         LTC_PAD_ONE_AND_ZERO | 16,
+         LTC_PAD_ZERO_ALWAYS | 16,
+      };
+      unsigned char dummy = 0;
+      unsigned long zlen, j;
+      for (j = 0; j < LTC_ARRAY_SIZE(modes); ++j) {
+         zlen = 0;
+         SHOULD_FAIL(padding_depad(&dummy, &zlen, modes[j]));
+      }
+      /* LTC_PAD_ZERO with len=0 must round-trip to len=0 (CRYPT_OK). */
+      zlen = 0;
+      DO(padding_depad(&dummy, &zlen, LTC_PAD_ZERO | 16));
+      DO(EQ(zlen, 0));
+   }
+
    return CRYPT_OK;
 }
 #endif


### PR DESCRIPTION
the fix is needed to pass the Wycheproof tests