### PR TITLE
Fix x86 ClangCL and GCC/Clang `-std=c##` compiles

### DIFF
--- a/src/ciphers/aes/aes_desc.c
+++ b/src/ciphers/aes/aes_desc.c
@@ -15,7 +15,7 @@
 #define LTC_S_X86_CPUID
 static LTC_INLINE void s_x86_cpuid(int* regs, int leaf)
 {
-#if defined _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__) // MSVC but not ClangCL
    __cpuid(regs, leaf);
 #else
    int a, b, c, d;

--- a/src/encauth/gcm/gcm_gf_mult.c
+++ b/src/encauth/gcm/gcm_gf_mult.c
@@ -33,7 +33,7 @@
 #define LTC_S_X86_CPUID
 static LTC_INLINE void s_x86_cpuid(int* regs, int leaf)
 {
-#if defined _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__) // MSVC but not ClangCL
    __cpuid(regs, leaf);
 #else
    int a, b, c, d;

--- a/src/hashes/sha1_desc.c
+++ b/src/hashes/sha1_desc.c
@@ -28,7 +28,7 @@ const struct ltc_hash_descriptor sha1_desc =
 #define LTC_S_X86_CPUID
 static LTC_INLINE void s_x86_cpuid(int* regs, int leaf)
 {
-#if defined _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__) // MSVC but not ClangCL
    __cpuid(regs, leaf);
 #else
     int a, b, c, d;

--- a/src/hashes/sha2/sha224_desc.c
+++ b/src/hashes/sha2/sha224_desc.c
@@ -33,7 +33,7 @@ const struct ltc_hash_descriptor sha224_desc =
 #define LTC_S_X86_CPUID
 static LTC_INLINE void s_x86_cpuid(int* regs, int leaf)
 {
-#if defined _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__) // MSVC but not ClangCL
    __cpuid(regs, leaf);
 #else
     int a, b, c, d;

--- a/src/hashes/sha2/sha256_desc.c
+++ b/src/hashes/sha2/sha256_desc.c
@@ -8,7 +8,7 @@
 #define LTC_S_X86_CPUID
 static LTC_INLINE void s_x86_cpuid(int* regs, int leaf)
 {
-#if defined _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__) // MSVC but not ClangCL
    __cpuid(regs, leaf);
 #else
     int a, b, c, d;


### PR DESCRIPTION
### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

* [x] if this fixes something: added a `Fixes:` tag to the commit message

Fixes compile for some x86 compiler configurations, including ClangCL on Windows, and GCC/Clang in Standard C mode (-std=c##).

Fixes https://github.com/libtom/libtomcrypt/issues/767

Notes:
- Reintroduced some nasty-looking parts from this past commit (aes_desc.c:L66-78):
  - https://github.com/libtom/libtomcrypt/commit/ec3804c452acfa794306b092d2209ab7e1d90ba5#diff-4b49c40dd5787d702d14e1859464a5941919a8dd8288dce824014f07939e321eL66-L78
- ClangCL is handled by falling through `defined(_MSC_VER) && !defined(__clang__)` into the GNU-style inline asm block
- `__asm__` instead of `asm` so that gcc/clang accept the inline asm block in Standard C mode
