### PR TITLE
Add conservative RISC-V platform detection

### DIFF
--- a/src/headers/tomcrypt_cfg.h
+++ b/src/headers/tomcrypt_cfg.h
@@ -92,6 +92,22 @@ LTC_EXPORT int   LTC_CALL XSTRCMP(const char *s1, const char *s2);
    #define LTC_FAST
 #endif
 
+/* detect RISC-V.  Do not enable LTC_FAST because unaligned word access is not
+ * guaranteed to be efficient or valid on all RISC-V systems. */
+#if defined(__riscv) || defined(__riscv__)
+   #define LTC_ARCH_RISCV
+   #if defined(__riscv_xlen) && (__riscv_xlen == 64)
+      #define ENDIAN_64BITWORD
+   #else
+      #define ENDIAN_32BITWORD
+   #endif
+   #if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+      #define ENDIAN_BIG
+   #elif defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+      #define ENDIAN_LITTLE
+   #endif
+#endif
+
 /* detect PPC32 */
 #if defined(LTC_PPC32)
    #define ENDIAN_BIG


### PR DESCRIPTION
## Why

libtomcrypt did not expose an explicit RISC-V configuration branch in `tomcrypt_cfg.h`, so riscv builds depended on indirect fallback logic for word size and endianness selection. This patch makes the baseline RISC-V configuration explicit while preserving the existing portable code paths.

## What changed

- Detect RISC-V targets in `tomcrypt_cfg.h` and define `LTC_ARCH_RISCV`.
- Select the configured word size from `__riscv_xlen`.
- Select endianness from compiler byte-order macros when available.
- Keep `LTC_FAST` disabled for RISC-V because unaligned word access is not guaranteed to be efficient or valid on all RISC-V systems.

## Verification

- Configured a native Ninja build with `WITH_LTM=OFF`, `WITH_TFM=OFF`, `WITH_GMP=OFF`, and `BUILD_TESTING=OFF`.
- Built the `libtomcrypt` target successfully with CMake/Ninja.
- Ran a simulated RISC-V preprocessing check and confirmed `LTC_ARCH_RISCV`, `ENDIAN_LITTLE`, and `ENDIAN_64BITWORD` are defined.
- Confirmed the simulated RISC-V macro path does not define `LTC_FAST`, `LTC_AES_NI`, `LTC_SHA1_X86`, `LTC_SHA224_X86`, `LTC_SHA256_X86`, `LTC_GCM_PCLMUL`, or `LTC_GCM_PMULL`.

## Notes

This is a conservative portability patch, not a RISC-V crypto-extension or RVV acceleration backend. It makes the RISC-V platform path explicit while preserving the existing portable C implementations.