### PR TITLE
EAX properly handle taglen boundaries

### DIFF
--- a/doc/crypt.tex
+++ b/doc/crypt.tex
@@ -1867,6 +1867,10 @@ have the same meaning as with those respective functions.
 The only difference is eax\_decrypt\_verify\_memory() does not emit a tag.  Instead you pass it a tag as input and it compares it against
 the tag it computed while decrypting the message.  If the tags match then it stores a $1$ in \textit{res}, otherwise it stores a $0$.
 
+The length of the tag is a security parameter of EAX mode: tags may be truncated and a zerolength tag is legal -- it simply
+provides no authenticity, which is the caller's choice.  A \textit{taglen} larger than the block size of the used cipher is rejected
+by eax\_decrypt\_verify\_memory() with \textbf{CRYPT\_INVALID\_ARG} (encrypt side can never emit such a tag).
+
 \mysection{OCB Mode}
 \subsection{Preface}
 

--- a/src/encauth/eax/eax_decrypt_verify_memory.c
+++ b/src/encauth/eax/eax_decrypt_verify_memory.c
@@ -49,8 +49,13 @@ int eax_decrypt_verify_memory(int cipher,
    /* default to zero */
    *stat = 0;
 
-   /* limit taglen */
-   taglen = MIN(taglen, MAXBLOCKSIZE);
+   if ((err = cipher_is_valid(cipher)) != CRYPT_OK) {
+      return err;
+   }
+   /* NOTE: zero-length tag is legal (it just provides no authenticity) */
+   if (taglen > (unsigned long)cipher_descriptor[cipher].block_length) {
+      return CRYPT_INVALID_ARG;
+   }
 
    /* allocate ram */
    buf = XMALLOC(taglen);


### PR DESCRIPTION
This issue was initially reported privately by @stigtsp as a potential vulnerability in CryptX (perl bindings for libtomcrypt).

The reported problem was that EAX accepts zero-length authentication tags.

I therefore checked the EAX specification:
* https://csrc.nist.gov/CSRC/media/Projects/Block-Cipher-Techniques/documents/BCM/proposed-modes/eax/eax-spec.pdf

It states:

> Any tag length T [0..n] should be possible, to allow each user to select how much security she wants from the integrity guarantees and how many bits she has to pay for this.

A zero-length tag is therefore valid. It provides no authentication, but that is the caller's choice.

However, I found that we were not correctly checking the upper bound of the tag length.

This patch:
* correctly checks the upper bound of the EAX tag length
* updates the documentation to clarify that a zero-length EAX tag is valid
