### PR TITLE
Argon2 enforce parallelism max 2^24-1

### DIFF
--- a/src/misc/argon2/argon2.c
+++ b/src/misc/argon2/argon2.c
@@ -14,6 +14,7 @@
 #define ARGON2_PREHASH_DIGEST_LEN  64
 #define ARGON2_PREHASH_SEED_LEN    72
 #define ARGON2_SYNC_POINTS         4
+#define ARGON2_MAX_LANES           0xFFFFFF /* RFC 9106: parallelism p is at most 2^24-1 */
 #define ARGON2_VERSION             0x13
 #define ARGON2_MIN_OUTLEN          4
 #define ARGON2_BLAKE2B_OUTBYTES    64
@@ -497,9 +498,11 @@ int argon2_hash(const unsigned char *pwd,  unsigned long pwdlen,
    LTC_ARGCHK(secret != NULL || secretlen == 0);
    LTC_ARGCHK(ad != NULL || adlen == 0);
    LTC_ARGCHK(t_cost >= 1);
-   LTC_ARGCHK(parallelism >= 1);
-   LTC_ARGCHK(m_cost >= 8 * parallelism);
    LTC_ARGCHK(type == ARGON2_D || type == ARGON2_I || type == ARGON2_ID);
+
+   if (parallelism < 1 || parallelism > ARGON2_MAX_LANES || m_cost < 8 * parallelism) {
+      return CRYPT_INVALID_ARG;
+   }
 
    /* Align memory: ensure memory_blocks is a multiple of 4*parallelism */
    memory_blocks = (ulong32)m_cost;

--- a/tests/argon2_test.c
+++ b/tests/argon2_test.c
@@ -72,6 +72,17 @@ int argon2_test(void)
       COMPARE_TESTVECTOR(tag, sizeof(tag), argon_testcase[n].expected, argon_testcase[n].elen, argon_testcase[n].name, n);
    }
 
+   /* RFC 9106: parallelism is limited to 2^24-1 (16777216 == 2^24) */
+   if (argon2_hash(password, sizeof(password),
+                   salt, sizeof(salt),
+                   secret, sizeof(secret),
+                   ad, sizeof(ad),
+                   3, 134217728, 16777216,
+                   ARGON2_ID,
+                   tag, sizeof(tag)) != CRYPT_INVALID_ARG) {
+      return CRYPT_FAIL_TESTVECTOR;
+   }
+
    return CRYPT_OK;
 }
 


### PR DESCRIPTION
This issue was initially reported privately by @stigtsp as a vulnerability "Argon2 parallelism integer overflow reaches a division by zero (SIGFPE denial of service)" in CryptX (perl bindings for libtomcrypt).