### PR TITLE
Fix LTC_FALLTHROUGH related error reported by MSVC compiler

### DIFF
--- a/src/headers/tomcrypt_cfg.h
+++ b/src/headers/tomcrypt_cfg.h
@@ -415,6 +415,9 @@ typedef unsigned long ltc_mp_digit;
 #if __has_attribute(fallthrough)
 #  define LTC_FALLTHROUGH LTC_ATTRIBUTE((fallthrough))
 #endif
+#ifndef LTC_FALLTHROUGH
+#  define LTC_FALLTHROUGH
+#endif
 #if __has_attribute(target)
 #  define LTC_TARGET(x) LTC_ATTRIBUTE((target(x)))
 #endif


### PR DESCRIPTION
Fixing appveyor failure