### PR TITLE
SHA-512 accelerated by x86 (alternative)

### DIFF
--- a/demos/latex-tables.c
+++ b/demos/latex-tables.c
@@ -242,6 +242,22 @@ static int print_hash_descriptors(void)
 #ifdef LTC_SHA1_X86
                                      HASH_DESC(sha1_x86_desc),
 #endif
+                                     HASH_DESC(sha512_portable_desc),
+#ifdef LTC_SHA512_X86
+                                     HASH_DESC(sha512_x86_desc),
+#endif
+                                     HASH_DESC(sha384_portable_desc),
+#ifdef LTC_SHA384_X86
+                                     HASH_DESC(sha384_x86_desc),
+#endif
+                                     HASH_DESC(sha512_224_portable_desc),
+#ifdef LTC_SHA512_224_X86
+                                     HASH_DESC(sha512_224_x86_desc),
+#endif
+                                     HASH_DESC(sha512_256_portable_desc),
+#ifdef LTC_SHA512_256_X86
+                                     HASH_DESC(sha512_256_x86_desc),
+#endif
    };
    struct desc descs[TAB_SIZE + 1] = {0};
    int ids[TAB_SIZE + 1] = {0};

--- a/doc/crypt.tex
+++ b/doc/crypt.tex
@@ -3128,6 +3128,14 @@ Additional to those standard descriptors, there exist the following target-speci
 \hline SHA224            & \code{sha224\_x86\_desc}         & 28 & 10 \\
 \hline SHA1              & \code{sha1\_portable\_desc}      & 20 &  2 \\
 \hline SHA1              & \code{sha1\_x86\_desc}           & 20 &  2 \\
+\hline SHA512            & \code{sha512\_portable\_desc}    & 64 &  5 \\
+\hline SHA512            & \code{sha512\_x86\_desc}         & 64 &  5 \\
+\hline SHA384            & \code{sha384\_portable\_desc}    & 48 &  4 \\
+\hline SHA384            & \code{sha384\_x86\_desc}         & 48 &  4 \\
+\hline SHA512-224        & \code{sha512\_224\_portable\_desc} & 28 & 15 \\
+\hline SHA512-224        & \code{sha512\_224\_x86\_desc}    & 28 & 15 \\
+\hline SHA512-256        & \code{sha512\_256\_portable\_desc} & 32 & 16 \\
+\hline SHA512-256        & \code{sha512\_256\_x86\_desc}    & 32 & 16 \\
 \hline
 \end{tabular}
 \end{center}

--- a/libtomcrypt_VS2008.vcproj
+++ b/libtomcrypt_VS2008.vcproj
@@ -939,6 +939,14 @@
 					>
 				</File>
 				<File
+					RelativePath="src\hashes\sha2\sha384_desc.c"
+					>
+				</File>
+				<File
+					RelativePath="src\hashes\sha2\sha384_x86.c"
+					>
+				</File>
+				<File
 					RelativePath="src\hashes\sha2\sha512.c"
 					>
 				</File>
@@ -947,7 +955,31 @@
 					>
 				</File>
 				<File
+					RelativePath="src\hashes\sha2\sha512_224_desc.c"
+					>
+				</File>
+				<File
+					RelativePath="src\hashes\sha2\sha512_224_x86.c"
+					>
+				</File>
+				<File
 					RelativePath="src\hashes\sha2\sha512_256.c"
+					>
+				</File>
+				<File
+					RelativePath="src\hashes\sha2\sha512_256_desc.c"
+					>
+				</File>
+				<File
+					RelativePath="src\hashes\sha2\sha512_256_x86.c"
+					>
+				</File>
+				<File
+					RelativePath="src\hashes\sha2\sha512_desc.c"
+					>
+				</File>
+				<File
+					RelativePath="src\hashes\sha2\sha512_x86.c"
 					>
 				</File>
 			</Filter>

--- a/makefile.mingw
+++ b/makefile.mingw
@@ -68,9 +68,12 @@ src/hashes/helper/hash_memory_multi.o src/hashes/md2.o src/hashes/md4.o src/hash
 src/hashes/rmd128.o src/hashes/rmd160.o src/hashes/rmd256.o src/hashes/rmd320.o src/hashes/sha1.o \
 src/hashes/sha1_desc.o src/hashes/sha1_x86.o src/hashes/sha2/sha224.o src/hashes/sha2/sha224_desc.o \
 src/hashes/sha2/sha224_x86.o src/hashes/sha2/sha256.o src/hashes/sha2/sha256_desc.o \
-src/hashes/sha2/sha256_x86.o src/hashes/sha2/sha384.o src/hashes/sha2/sha512.o \
-src/hashes/sha2/sha512_224.o src/hashes/sha2/sha512_256.o src/hashes/sha3.o src/hashes/sha3_test.o \
-src/hashes/sm3.o src/hashes/tiger.o src/hashes/whirl/whirl.o src/mac/blake2/blake2bmac.o \
+src/hashes/sha2/sha256_x86.o src/hashes/sha2/sha384.o src/hashes/sha2/sha384_desc.o \
+src/hashes/sha2/sha384_x86.o src/hashes/sha2/sha512.o src/hashes/sha2/sha512_224.o \
+src/hashes/sha2/sha512_224_desc.o src/hashes/sha2/sha512_224_x86.o src/hashes/sha2/sha512_256.o \
+src/hashes/sha2/sha512_256_desc.o src/hashes/sha2/sha512_256_x86.o src/hashes/sha2/sha512_desc.o \
+src/hashes/sha2/sha512_x86.o src/hashes/sha3.o src/hashes/sha3_test.o src/hashes/sm3.o \
+src/hashes/tiger.o src/hashes/whirl/whirl.o src/mac/blake2/blake2bmac.o \
 src/mac/blake2/blake2bmac_file.o src/mac/blake2/blake2bmac_memory.o \
 src/mac/blake2/blake2bmac_memory_multi.o src/mac/blake2/blake2bmac_test.o src/mac/blake2/blake2smac.o \
 src/mac/blake2/blake2smac_file.o src/mac/blake2/blake2smac_memory.o \

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -61,9 +61,12 @@ src/hashes/helper/hash_memory_multi.obj src/hashes/md2.obj src/hashes/md4.obj sr
 src/hashes/rmd128.obj src/hashes/rmd160.obj src/hashes/rmd256.obj src/hashes/rmd320.obj src/hashes/sha1.obj \
 src/hashes/sha1_desc.obj src/hashes/sha1_x86.obj src/hashes/sha2/sha224.obj src/hashes/sha2/sha224_desc.obj \
 src/hashes/sha2/sha224_x86.obj src/hashes/sha2/sha256.obj src/hashes/sha2/sha256_desc.obj \
-src/hashes/sha2/sha256_x86.obj src/hashes/sha2/sha384.obj src/hashes/sha2/sha512.obj \
-src/hashes/sha2/sha512_224.obj src/hashes/sha2/sha512_256.obj src/hashes/sha3.obj src/hashes/sha3_test.obj \
-src/hashes/sm3.obj src/hashes/tiger.obj src/hashes/whirl/whirl.obj src/mac/blake2/blake2bmac.obj \
+src/hashes/sha2/sha256_x86.obj src/hashes/sha2/sha384.obj src/hashes/sha2/sha384_desc.obj \
+src/hashes/sha2/sha384_x86.obj src/hashes/sha2/sha512.obj src/hashes/sha2/sha512_224.obj \
+src/hashes/sha2/sha512_224_desc.obj src/hashes/sha2/sha512_224_x86.obj src/hashes/sha2/sha512_256.obj \
+src/hashes/sha2/sha512_256_desc.obj src/hashes/sha2/sha512_256_x86.obj src/hashes/sha2/sha512_desc.obj \
+src/hashes/sha2/sha512_x86.obj src/hashes/sha3.obj src/hashes/sha3_test.obj src/hashes/sm3.obj \
+src/hashes/tiger.obj src/hashes/whirl/whirl.obj src/mac/blake2/blake2bmac.obj \
 src/mac/blake2/blake2bmac_file.obj src/mac/blake2/blake2bmac_memory.obj \
 src/mac/blake2/blake2bmac_memory_multi.obj src/mac/blake2/blake2bmac_test.obj src/mac/blake2/blake2smac.obj \
 src/mac/blake2/blake2smac_file.obj src/mac/blake2/blake2smac_memory.obj \

--- a/makefile.unix
+++ b/makefile.unix
@@ -82,9 +82,12 @@ src/hashes/helper/hash_memory_multi.o src/hashes/md2.o src/hashes/md4.o src/hash
 src/hashes/rmd128.o src/hashes/rmd160.o src/hashes/rmd256.o src/hashes/rmd320.o src/hashes/sha1.o \
 src/hashes/sha1_desc.o src/hashes/sha1_x86.o src/hashes/sha2/sha224.o src/hashes/sha2/sha224_desc.o \
 src/hashes/sha2/sha224_x86.o src/hashes/sha2/sha256.o src/hashes/sha2/sha256_desc.o \
-src/hashes/sha2/sha256_x86.o src/hashes/sha2/sha384.o src/hashes/sha2/sha512.o \
-src/hashes/sha2/sha512_224.o src/hashes/sha2/sha512_256.o src/hashes/sha3.o src/hashes/sha3_test.o \
-src/hashes/sm3.o src/hashes/tiger.o src/hashes/whirl/whirl.o src/mac/blake2/blake2bmac.o \
+src/hashes/sha2/sha256_x86.o src/hashes/sha2/sha384.o src/hashes/sha2/sha384_desc.o \
+src/hashes/sha2/sha384_x86.o src/hashes/sha2/sha512.o src/hashes/sha2/sha512_224.o \
+src/hashes/sha2/sha512_224_desc.o src/hashes/sha2/sha512_224_x86.o src/hashes/sha2/sha512_256.o \
+src/hashes/sha2/sha512_256_desc.o src/hashes/sha2/sha512_256_x86.o src/hashes/sha2/sha512_desc.o \
+src/hashes/sha2/sha512_x86.o src/hashes/sha3.o src/hashes/sha3_test.o src/hashes/sm3.o \
+src/hashes/tiger.o src/hashes/whirl/whirl.o src/mac/blake2/blake2bmac.o \
 src/mac/blake2/blake2bmac_file.o src/mac/blake2/blake2bmac_memory.o \
 src/mac/blake2/blake2bmac_memory_multi.o src/mac/blake2/blake2bmac_test.o src/mac/blake2/blake2smac.o \
 src/mac/blake2/blake2smac_file.o src/mac/blake2/blake2smac_memory.o \

--- a/makefile_include.mk
+++ b/makefile_include.mk
@@ -253,9 +253,12 @@ src/hashes/helper/hash_memory_multi.o src/hashes/md2.o src/hashes/md4.o src/hash
 src/hashes/rmd128.o src/hashes/rmd160.o src/hashes/rmd256.o src/hashes/rmd320.o src/hashes/sha1.o \
 src/hashes/sha1_desc.o src/hashes/sha1_x86.o src/hashes/sha2/sha224.o src/hashes/sha2/sha224_desc.o \
 src/hashes/sha2/sha224_x86.o src/hashes/sha2/sha256.o src/hashes/sha2/sha256_desc.o \
-src/hashes/sha2/sha256_x86.o src/hashes/sha2/sha384.o src/hashes/sha2/sha512.o \
-src/hashes/sha2/sha512_224.o src/hashes/sha2/sha512_256.o src/hashes/sha3.o src/hashes/sha3_test.o \
-src/hashes/sm3.o src/hashes/tiger.o src/hashes/whirl/whirl.o src/mac/blake2/blake2bmac.o \
+src/hashes/sha2/sha256_x86.o src/hashes/sha2/sha384.o src/hashes/sha2/sha384_desc.o \
+src/hashes/sha2/sha384_x86.o src/hashes/sha2/sha512.o src/hashes/sha2/sha512_224.o \
+src/hashes/sha2/sha512_224_desc.o src/hashes/sha2/sha512_224_x86.o src/hashes/sha2/sha512_256.o \
+src/hashes/sha2/sha512_256_desc.o src/hashes/sha2/sha512_256_x86.o src/hashes/sha2/sha512_desc.o \
+src/hashes/sha2/sha512_x86.o src/hashes/sha3.o src/hashes/sha3_test.o src/hashes/sm3.o \
+src/hashes/tiger.o src/hashes/whirl/whirl.o src/mac/blake2/blake2bmac.o \
 src/mac/blake2/blake2bmac_file.o src/mac/blake2/blake2bmac_memory.o \
 src/mac/blake2/blake2bmac_memory_multi.o src/mac/blake2/blake2bmac_test.o src/mac/blake2/blake2smac.o \
 src/mac/blake2/blake2smac_file.o src/mac/blake2/blake2smac_memory.o \

--- a/sources.cmake
+++ b/sources.cmake
@@ -102,9 +102,17 @@ src/hashes/sha2/sha256.c
 src/hashes/sha2/sha256_desc.c
 src/hashes/sha2/sha256_x86.c
 src/hashes/sha2/sha384.c
+src/hashes/sha2/sha384_desc.c
+src/hashes/sha2/sha384_x86.c
 src/hashes/sha2/sha512.c
 src/hashes/sha2/sha512_224.c
+src/hashes/sha2/sha512_224_desc.c
+src/hashes/sha2/sha512_224_x86.c
 src/hashes/sha2/sha512_256.c
+src/hashes/sha2/sha512_256_desc.c
+src/hashes/sha2/sha512_256_x86.c
+src/hashes/sha2/sha512_desc.c
+src/hashes/sha2/sha512_x86.c
 src/hashes/sha3.c
 src/hashes/sha3_test.c
 src/hashes/sm3.c

--- a/src/hashes/sha2/sha384.c
+++ b/src/hashes/sha2/sha384.c
@@ -9,7 +9,7 @@
 
 #if defined(LTC_SHA384) && defined(LTC_SHA512)
 
-const struct ltc_hash_descriptor sha384_desc =
+const struct ltc_hash_descriptor sha384_portable_desc =
 {
     "sha384",
     4,
@@ -21,33 +21,11 @@ const struct ltc_hash_descriptor sha384_desc =
    9,
 
     &sha384_init,
-    &sha512_process,
-    &sha384_done,
-    &sha384_test,
+    &sha384_c_process,
+    &sha384_c_done,
+    &sha384_c_test,
     NULL
 };
-
-/**
-   Initialize the hash state
-   @param md   The hash state you wish to initialize
-   @return CRYPT_OK if successful
-*/
-int sha384_init(hash_state * md)
-{
-    LTC_ARGCHK(md != NULL);
-
-    md->sha512.curlen = 0;
-    md->sha512.length = 0;
-    md->sha512.state[0] = CONST64(0xcbbb9d5dc1059ed8);
-    md->sha512.state[1] = CONST64(0x629a292a367cd507);
-    md->sha512.state[2] = CONST64(0x9159015a3070dd17);
-    md->sha512.state[3] = CONST64(0x152fecd8f70e5939);
-    md->sha512.state[4] = CONST64(0x67332667ffc00b31);
-    md->sha512.state[5] = CONST64(0x8eb44a8768581511);
-    md->sha512.state[6] = CONST64(0xdb0c2e0d64f98fa7);
-    md->sha512.state[7] = CONST64(0x47b5481dbefa4fa4);
-    return CRYPT_OK;
-}
 
 /**
    Terminate the hash to get the digest
@@ -55,70 +33,29 @@ int sha384_init(hash_state * md)
    @param out [out] The destination of the hash (48 bytes)
    @return CRYPT_OK if successful
 */
-int sha384_done(hash_state * md, unsigned char *out)
+int sha384_c_done(hash_state * md, unsigned char *out)
 {
    unsigned char buf[64];
+   int err;
 
    LTC_ARGCHK(md  != NULL);
    LTC_ARGCHK(out != NULL);
 
-    if (md->sha512.curlen >= sizeof(md->sha512.buf)) {
-       return CRYPT_INVALID_ARG;
-    }
-
-   sha512_done(md, buf);
+   err = sha512_c_done(md, buf);
    XMEMCPY(out, buf, 48);
 #ifdef LTC_CLEAN_STACK
    zeromem(buf, sizeof(buf));
 #endif
-   return CRYPT_OK;
+   return err;
 }
 
 /**
   Self-test the hash
   @return CRYPT_OK if successful, CRYPT_NOP if self-tests have been disabled
 */
-int  sha384_test(void)
+int sha384_c_test(void)
 {
- #ifndef LTC_TEST
-    return CRYPT_NOP;
- #else
-  static const struct {
-      const char *msg;
-      unsigned char hash[48];
-  } tests[] = {
-    { "abc",
-      { 0xcb, 0x00, 0x75, 0x3f, 0x45, 0xa3, 0x5e, 0x8b,
-        0xb5, 0xa0, 0x3d, 0x69, 0x9a, 0xc6, 0x50, 0x07,
-        0x27, 0x2c, 0x32, 0xab, 0x0e, 0xde, 0xd1, 0x63,
-        0x1a, 0x8b, 0x60, 0x5a, 0x43, 0xff, 0x5b, 0xed,
-        0x80, 0x86, 0x07, 0x2b, 0xa1, 0xe7, 0xcc, 0x23,
-        0x58, 0xba, 0xec, 0xa1, 0x34, 0xc8, 0x25, 0xa7 }
-    },
-    { "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu",
-      { 0x09, 0x33, 0x0c, 0x33, 0xf7, 0x11, 0x47, 0xe8,
-        0x3d, 0x19, 0x2f, 0xc7, 0x82, 0xcd, 0x1b, 0x47,
-        0x53, 0x11, 0x1b, 0x17, 0x3b, 0x3b, 0x05, 0xd2,
-        0x2f, 0xa0, 0x80, 0x86, 0xe3, 0xb0, 0xf7, 0x12,
-        0xfc, 0xc7, 0xc7, 0x1a, 0x55, 0x7e, 0x2d, 0xb9,
-        0x66, 0xc3, 0xe9, 0xfa, 0x91, 0x74, 0x60, 0x39 }
-    },
-  };
-
-  int i;
-  unsigned char tmp[48];
-  hash_state md;
-
-  for (i = 0; i < (int)(sizeof(tests) / sizeof(tests[0])); i++) {
-      sha384_init(&md);
-      sha384_process(&md, (unsigned char*)tests[i].msg, (unsigned long)XSTRLEN(tests[i].msg));
-      sha384_done(&md, tmp);
-      if (ltc_compare_testvector(tmp, sizeof(tmp), tests[i].hash, sizeof(tests[i].hash), "SHA384", i)) {
-         return CRYPT_FAIL_TESTVECTOR;
-      }
-  }
-  return CRYPT_OK;
- #endif
+   return sha384_test_desc(&sha384_portable_desc, "SHA384 portable");
 }
 
 #endif /* defined(LTC_SHA384) && defined(LTC_SHA512) */

--- a/src/hashes/sha2/sha384_desc.c
+++ b/src/hashes/sha2/sha384_desc.c
@@ -1,0 +1,128 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis */
+/* SPDX-License-Identifier: Unlicense */
+#include "tomcrypt_private.h"
+
+/**
+   @file sha384_desc.c
+   SHA384 multiplexer between the portable and the x86 implementation
+*/
+
+#if defined(LTC_SHA384) && defined(LTC_SHA512)
+
+const struct ltc_hash_descriptor sha384_desc =
+{
+    "sha384",
+    4,
+    48,
+    128,
+
+    /* OID */
+   { 2, 16, 840, 1, 101, 3, 4, 2, 2,  },
+   9,
+
+    &sha384_init,
+    &sha512_process,
+    &sha384_done,
+    &sha384_test,
+    NULL
+};
+
+/**
+   Initialize the hash state
+   @param md   The hash state you wish to initialize
+   @return CRYPT_OK if successful
+*/
+int sha384_init(hash_state * md)
+{
+    LTC_ARGCHK(md != NULL);
+
+    md->sha512.curlen = 0;
+    md->sha512.length = 0;
+    md->sha512.state[0] = CONST64(0xcbbb9d5dc1059ed8);
+    md->sha512.state[1] = CONST64(0x629a292a367cd507);
+    md->sha512.state[2] = CONST64(0x9159015a3070dd17);
+    md->sha512.state[3] = CONST64(0x152fecd8f70e5939);
+    md->sha512.state[4] = CONST64(0x67332667ffc00b31);
+    md->sha512.state[5] = CONST64(0x8eb44a8768581511);
+    md->sha512.state[6] = CONST64(0xdb0c2e0d64f98fa7);
+    md->sha512.state[7] = CONST64(0x47b5481dbefa4fa4);
+    return CRYPT_OK;
+}
+
+/**
+   Terminate the hash to get the digest
+   @param md  The hash state
+   @param out [out] The destination of the hash (48 bytes)
+   @return CRYPT_OK if successful
+*/
+int sha384_done(hash_state * md, unsigned char *out)
+{
+#if defined LTC_SHA384_X86
+    if(sha512ni_is_supported()) {
+        return sha384_x86_done(md, out);
+    }
+#endif
+    return sha384_c_done(md, out);
+}
+
+/**
+  Self-test the hash
+  @return CRYPT_OK if successful, CRYPT_NOP if self-tests have been disabled
+*/
+int sha384_test(void)
+{
+   return sha384_test_desc(&sha384_desc, "SHA384");
+}
+
+int sha384_test_desc(const struct ltc_hash_descriptor *desc, const char *name)
+{
+#ifndef LTC_TEST
+   LTC_UNUSED_PARAM(desc);
+   LTC_UNUSED_PARAM(name);
+   return CRYPT_NOP;
+#else
+  static const struct {
+      const char *msg;
+      unsigned char hash[48];
+  } tests[] = {
+    { "abc",
+      { 0xcb, 0x00, 0x75, 0x3f, 0x45, 0xa3, 0x5e, 0x8b,
+        0xb5, 0xa0, 0x3d, 0x69, 0x9a, 0xc6, 0x50, 0x07,
+        0x27, 0x2c, 0x32, 0xab, 0x0e, 0xde, 0xd1, 0x63,
+        0x1a, 0x8b, 0x60, 0x5a, 0x43, 0xff, 0x5b, 0xed,
+        0x80, 0x86, 0x07, 0x2b, 0xa1, 0xe7, 0xcc, 0x23,
+        0x58, 0xba, 0xec, 0xa1, 0x34, 0xc8, 0x25, 0xa7 }
+    },
+    { "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu",
+      { 0x09, 0x33, 0x0c, 0x33, 0xf7, 0x11, 0x47, 0xe8,
+        0x3d, 0x19, 0x2f, 0xc7, 0x82, 0xcd, 0x1b, 0x47,
+        0x53, 0x11, 0x1b, 0x17, 0x3b, 0x3b, 0x05, 0xd2,
+        0x2f, 0xa0, 0x80, 0x86, 0xe3, 0xb0, 0xf7, 0x12,
+        0xfc, 0xc7, 0xc7, 0x1a, 0x55, 0x7e, 0x2d, 0xb9,
+        0x66, 0xc3, 0xe9, 0xfa, 0x91, 0x74, 0x60, 0x39 }
+    },
+  };
+
+  int i;
+  unsigned char tmp[48];
+  hash_state md;
+
+  LTC_ARGCHK(desc != NULL);
+  LTC_ARGCHK(desc->init != NULL);
+  LTC_ARGCHK(desc->process != NULL);
+  LTC_ARGCHK(desc->done != NULL);
+  LTC_ARGCHK(name != NULL);
+
+  for (i = 0; i < (int)(sizeof(tests) / sizeof(tests[0])); i++) {
+      desc->init(&md);
+      desc->process(&md, (unsigned char*)tests[i].msg, (unsigned long)XSTRLEN(tests[i].msg));
+      desc->done(&md, tmp);
+      if (ltc_compare_testvector(tmp, sizeof(tmp), tests[i].hash, sizeof(tests[i].hash), name, i)) {
+         return CRYPT_FAIL_TESTVECTOR;
+      }
+  }
+  return CRYPT_OK;
+#endif
+}
+
+#endif /* defined(LTC_SHA384) && defined(LTC_SHA512) */

--- a/src/hashes/sha2/sha384_x86.c
+++ b/src/hashes/sha2/sha384_x86.c
@@ -1,0 +1,61 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis */
+/* SPDX-License-Identifier: Unlicense */
+#include "tomcrypt_private.h"
+
+/**
+   @file sha384_x86.c
+   SHA384 using the Intel SHA512 extension (SHA512 truncated to 384 bits)
+*/
+
+#if defined(LTC_SHA384) && defined(LTC_SHA512) && defined(LTC_SHA384_X86) && defined(LTC_SHA512_X86)
+
+const struct ltc_hash_descriptor sha384_x86_desc =
+{
+    "sha384",
+    4,
+    48,
+    128,
+
+    /* OID */
+   { 2, 16, 840, 1, 101, 3, 4, 2, 2,  },
+   9,
+
+    &sha384_init,
+    &sha384_x86_process,
+    &sha384_x86_done,
+    &sha384_x86_test,
+    NULL
+};
+
+/**
+   Terminate the hash to get the digest
+   @param md  The hash state
+   @param out [out] The destination of the hash (48 bytes)
+   @return CRYPT_OK if successful
+*/
+int sha384_x86_done(hash_state * md, unsigned char *out)
+{
+    unsigned char buf[64];
+    int err;
+
+    LTC_ARGCHK(md  != NULL);
+    LTC_ARGCHK(out != NULL);
+
+    err = sha512_x86_done(md, buf);
+    XMEMCPY(out, buf, 48);
+#ifdef LTC_CLEAN_STACK
+    zeromem(buf, sizeof(buf));
+#endif
+    return err;
+}
+
+/**
+  Self-test the hash
+  @return CRYPT_OK if successful, CRYPT_NOP if self-tests have been disabled
+*/
+int sha384_x86_test(void)
+{
+   return sha384_test_desc(&sha384_x86_desc, "SHA384 x86");
+}
+
+#endif /* defined(LTC_SHA384) && defined(LTC_SHA512) */

--- a/src/hashes/sha2/sha512.c
+++ b/src/hashes/sha2/sha512.c
@@ -9,7 +9,7 @@
 
 #ifdef LTC_SHA512
 
-const struct ltc_hash_descriptor sha512_desc =
+const struct ltc_hash_descriptor sha512_portable_desc =
 {
     "sha512",
     5,
@@ -21,9 +21,9 @@ const struct ltc_hash_descriptor sha512_desc =
    9,
 
     &sha512_init,
-    &sha512_process,
-    &sha512_done,
-    &sha512_test,
+    &sha512_c_process,
+    &sha512_c_done,
+    &sha512_c_test,
     NULL
 };
 
@@ -201,34 +201,13 @@ static int s_sha512_compress(hash_state * md, const unsigned char *buf)
 #endif
 
 /**
-   Initialize the hash state
-   @param md   The hash state you wish to initialize
-   @return CRYPT_OK if successful
-*/
-int sha512_init(hash_state * md)
-{
-    LTC_ARGCHK(md != NULL);
-    md->sha512.curlen = 0;
-    md->sha512.length = 0;
-    md->sha512.state[0] = CONST64(0x6a09e667f3bcc908);
-    md->sha512.state[1] = CONST64(0xbb67ae8584caa73b);
-    md->sha512.state[2] = CONST64(0x3c6ef372fe94f82b);
-    md->sha512.state[3] = CONST64(0xa54ff53a5f1d36f1);
-    md->sha512.state[4] = CONST64(0x510e527fade682d1);
-    md->sha512.state[5] = CONST64(0x9b05688c2b3e6c1f);
-    md->sha512.state[6] = CONST64(0x1f83d9abfb41bd6b);
-    md->sha512.state[7] = CONST64(0x5be0cd19137e2179);
-    return CRYPT_OK;
-}
-
-/**
    Process a block of memory though the hash
    @param md     The hash state
    @param in     The data to hash
    @param inlen  The length of the data (octets)
    @return CRYPT_OK if successful
 */
-HASH_PROCESS(sha512_process, s_sha512_compress, sha512, 128)
+HASH_PROCESS(sha512_c_process, s_sha512_compress, sha512, 128)
 
 /**
    Terminate the hash to get the digest
@@ -236,7 +215,7 @@ HASH_PROCESS(sha512_process, s_sha512_compress, sha512, 128)
    @param out [out] The destination of the hash (64 bytes)
    @return CRYPT_OK if successful
 */
-int sha512_done(hash_state * md, unsigned char *out)
+int sha512_c_done(hash_state * md, unsigned char *out)
 {
     int i;
 
@@ -291,51 +270,9 @@ int sha512_done(hash_state * md, unsigned char *out)
   Self-test the hash
   @return CRYPT_OK if successful, CRYPT_NOP if self-tests have been disabled
 */
-int  sha512_test(void)
+int sha512_c_test(void)
 {
- #ifndef LTC_TEST
-    return CRYPT_NOP;
- #else
-  static const struct {
-      const char *msg;
-      unsigned char hash[64];
-  } tests[] = {
-    { "abc",
-     { 0xdd, 0xaf, 0x35, 0xa1, 0x93, 0x61, 0x7a, 0xba,
-       0xcc, 0x41, 0x73, 0x49, 0xae, 0x20, 0x41, 0x31,
-       0x12, 0xe6, 0xfa, 0x4e, 0x89, 0xa9, 0x7e, 0xa2,
-       0x0a, 0x9e, 0xee, 0xe6, 0x4b, 0x55, 0xd3, 0x9a,
-       0x21, 0x92, 0x99, 0x2a, 0x27, 0x4f, 0xc1, 0xa8,
-       0x36, 0xba, 0x3c, 0x23, 0xa3, 0xfe, 0xeb, 0xbd,
-       0x45, 0x4d, 0x44, 0x23, 0x64, 0x3c, 0xe8, 0x0e,
-       0x2a, 0x9a, 0xc9, 0x4f, 0xa5, 0x4c, 0xa4, 0x9f }
-    },
-    { "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu",
-     { 0x8e, 0x95, 0x9b, 0x75, 0xda, 0xe3, 0x13, 0xda,
-       0x8c, 0xf4, 0xf7, 0x28, 0x14, 0xfc, 0x14, 0x3f,
-       0x8f, 0x77, 0x79, 0xc6, 0xeb, 0x9f, 0x7f, 0xa1,
-       0x72, 0x99, 0xae, 0xad, 0xb6, 0x88, 0x90, 0x18,
-       0x50, 0x1d, 0x28, 0x9e, 0x49, 0x00, 0xf7, 0xe4,
-       0x33, 0x1b, 0x99, 0xde, 0xc4, 0xb5, 0x43, 0x3a,
-       0xc7, 0xd3, 0x29, 0xee, 0xb6, 0xdd, 0x26, 0x54,
-       0x5e, 0x96, 0xe5, 0x5b, 0x87, 0x4b, 0xe9, 0x09 }
-    },
-  };
-
-  int i;
-  unsigned char tmp[64];
-  hash_state md;
-
-  for (i = 0; i < (int)(sizeof(tests) / sizeof(tests[0])); i++) {
-      sha512_init(&md);
-      sha512_process(&md, (unsigned char *)tests[i].msg, (unsigned long)XSTRLEN(tests[i].msg));
-      sha512_done(&md, tmp);
-      if (ltc_compare_testvector(tmp, sizeof(tmp), tests[i].hash, sizeof(tests[i].hash), "SHA512", i)) {
-         return CRYPT_FAIL_TESTVECTOR;
-      }
-  }
-  return CRYPT_OK;
-  #endif
+   return sha512_test_desc(&sha512_portable_desc, "SHA512 portable");
 }
 
 #undef Ch

--- a/src/hashes/sha2/sha512_224.c
+++ b/src/hashes/sha2/sha512_224.c
@@ -9,7 +9,7 @@
 
 #if defined(LTC_SHA512_224) && defined(LTC_SHA512)
 
-const struct ltc_hash_descriptor sha512_224_desc =
+const struct ltc_hash_descriptor sha512_224_portable_desc =
 {
     "sha512-224",
     15,
@@ -21,100 +21,41 @@ const struct ltc_hash_descriptor sha512_224_desc =
    9,
 
     &sha512_224_init,
-    &sha512_process,
-    &sha512_224_done,
-    &sha512_224_test,
+    &sha512_224_c_process,
+    &sha512_224_c_done,
+    &sha512_224_c_test,
     NULL
 };
 
 /**
-   Initialize the hash state
-   @param md   The hash state you wish to initialize
-   @return CRYPT_OK if successful
-*/
-int sha512_224_init(hash_state * md)
-{
-    LTC_ARGCHK(md != NULL);
-
-    md->sha512.curlen = 0;
-    md->sha512.length = 0;
-    md->sha512.state[0] = CONST64(0x8C3D37C819544DA2);
-    md->sha512.state[1] = CONST64(0x73E1996689DCD4D6);
-    md->sha512.state[2] = CONST64(0x1DFAB7AE32FF9C82);
-    md->sha512.state[3] = CONST64(0x679DD514582F9FCF);
-    md->sha512.state[4] = CONST64(0x0F6D2B697BD44DA8);
-    md->sha512.state[5] = CONST64(0x77E36F7304C48942);
-    md->sha512.state[6] = CONST64(0x3F9D85A86A1D36C8);
-    md->sha512.state[7] = CONST64(0x1112E6AD91D692A1);
-    return CRYPT_OK;
-}
-
-/**
    Terminate the hash to get the digest
    @param md  The hash state
-   @param out [out] The destination of the hash (48 bytes)
+   @param out [out] The destination of the hash (28 bytes)
    @return CRYPT_OK if successful
 */
-int sha512_224_done(hash_state * md, unsigned char *out)
+int sha512_224_c_done(hash_state * md, unsigned char *out)
 {
    unsigned char buf[64];
+   int err;
 
    LTC_ARGCHK(md  != NULL);
    LTC_ARGCHK(out != NULL);
 
-    if (md->sha512.curlen >= sizeof(md->sha512.buf)) {
-       return CRYPT_INVALID_ARG;
-    }
-
-   sha512_done(md, buf);
+   err = sha512_c_done(md, buf);
    XMEMCPY(out, buf, 28);
 #ifdef LTC_CLEAN_STACK
    zeromem(buf, sizeof(buf));
 #endif
-   return CRYPT_OK;
+   return err;
 }
 
 /**
   Self-test the hash
   @return CRYPT_OK if successful, CRYPT_NOP if self-tests have been disabled
 */
-int  sha512_224_test(void)
+int sha512_224_c_test(void)
 {
- #ifndef LTC_TEST
-    return CRYPT_NOP;
- #else
-  static const struct {
-      const char *msg;
-      unsigned char hash[28];
-  } tests[] = {
-    { "abc",
-      { 0x46, 0x34, 0x27, 0x0F, 0x70, 0x7B, 0x6A, 0x54,
-        0xDA, 0xAE, 0x75, 0x30, 0x46, 0x08, 0x42, 0xE2,
-        0x0E, 0x37, 0xED, 0x26, 0x5C, 0xEE, 0xE9, 0xA4,
-        0x3E, 0x89, 0x24, 0xAA }
-    },
-    { "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu",
-      { 0x23, 0xFE, 0xC5, 0xBB, 0x94, 0xD6, 0x0B, 0x23,
-        0x30, 0x81, 0x92, 0x64, 0x0B, 0x0C, 0x45, 0x33,
-        0x35, 0xD6, 0x64, 0x73, 0x4F, 0xE4, 0x0E, 0x72,
-        0x68, 0x67, 0x4A, 0xF9 }
-    },
-  };
-
-  int i;
-  unsigned char tmp[28];
-  hash_state md;
-
-  for (i = 0; i < (int)(sizeof(tests) / sizeof(tests[0])); i++) {
-      sha512_224_init(&md);
-      sha512_224_process(&md, (unsigned char*)tests[i].msg, (unsigned long)XSTRLEN(tests[i].msg));
-      sha512_224_done(&md, tmp);
-      if (ltc_compare_testvector(tmp, sizeof(tmp), tests[i].hash, sizeof(tests[i].hash), "SHA512-224", i)) {
-         return CRYPT_FAIL_TESTVECTOR;
-      }
-  }
-  return CRYPT_OK;
- #endif
+   return sha512_224_test_desc(&sha512_224_portable_desc, "SHA512-224 portable");
 }
 
-#endif /* defined(LTC_SHA384) && defined(LTC_SHA512) */
+#endif /* defined(LTC_SHA512_224) && defined(LTC_SHA512) */

--- a/src/hashes/sha2/sha512_224_desc.c
+++ b/src/hashes/sha2/sha512_224_desc.c
@@ -1,0 +1,124 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis */
+/* SPDX-License-Identifier: Unlicense */
+#include "tomcrypt_private.h"
+
+/**
+   @file sha512_224_desc.c
+   SHA512/224 multiplexer between the portable and the x86 implementation
+*/
+
+#if defined(LTC_SHA512_224) && defined(LTC_SHA512)
+
+const struct ltc_hash_descriptor sha512_224_desc =
+{
+    "sha512-224",
+    15,
+    28,
+    128,
+
+    /* OID */
+   { 2, 16, 840, 1, 101, 3, 4, 2, 5,  },
+   9,
+
+    &sha512_224_init,
+    &sha512_process,
+    &sha512_224_done,
+    &sha512_224_test,
+    NULL
+};
+
+/**
+   Initialize the hash state
+   @param md   The hash state you wish to initialize
+   @return CRYPT_OK if successful
+*/
+int sha512_224_init(hash_state * md)
+{
+    LTC_ARGCHK(md != NULL);
+
+    md->sha512.curlen = 0;
+    md->sha512.length = 0;
+    md->sha512.state[0] = CONST64(0x8C3D37C819544DA2);
+    md->sha512.state[1] = CONST64(0x73E1996689DCD4D6);
+    md->sha512.state[2] = CONST64(0x1DFAB7AE32FF9C82);
+    md->sha512.state[3] = CONST64(0x679DD514582F9FCF);
+    md->sha512.state[4] = CONST64(0x0F6D2B697BD44DA8);
+    md->sha512.state[5] = CONST64(0x77E36F7304C48942);
+    md->sha512.state[6] = CONST64(0x3F9D85A86A1D36C8);
+    md->sha512.state[7] = CONST64(0x1112E6AD91D692A1);
+    return CRYPT_OK;
+}
+
+/**
+   Terminate the hash to get the digest
+   @param md  The hash state
+   @param out [out] The destination of the hash (28 bytes)
+   @return CRYPT_OK if successful
+*/
+int sha512_224_done(hash_state * md, unsigned char *out)
+{
+#if defined LTC_SHA512_224_X86
+    if(sha512ni_is_supported()) {
+        return sha512_224_x86_done(md, out);
+    }
+#endif
+    return sha512_224_c_done(md, out);
+}
+
+/**
+  Self-test the hash
+  @return CRYPT_OK if successful, CRYPT_NOP if self-tests have been disabled
+*/
+int sha512_224_test(void)
+{
+   return sha512_224_test_desc(&sha512_224_desc, "SHA512-224");
+}
+
+int sha512_224_test_desc(const struct ltc_hash_descriptor *desc, const char *name)
+{
+#ifndef LTC_TEST
+   LTC_UNUSED_PARAM(desc);
+   LTC_UNUSED_PARAM(name);
+   return CRYPT_NOP;
+#else
+  static const struct {
+      const char *msg;
+      unsigned char hash[28];
+  } tests[] = {
+    { "abc",
+      { 0x46, 0x34, 0x27, 0x0F, 0x70, 0x7B, 0x6A, 0x54,
+        0xDA, 0xAE, 0x75, 0x30, 0x46, 0x08, 0x42, 0xE2,
+        0x0E, 0x37, 0xED, 0x26, 0x5C, 0xEE, 0xE9, 0xA4,
+        0x3E, 0x89, 0x24, 0xAA }
+    },
+    { "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu",
+      { 0x23, 0xFE, 0xC5, 0xBB, 0x94, 0xD6, 0x0B, 0x23,
+        0x30, 0x81, 0x92, 0x64, 0x0B, 0x0C, 0x45, 0x33,
+        0x35, 0xD6, 0x64, 0x73, 0x4F, 0xE4, 0x0E, 0x72,
+        0x68, 0x67, 0x4A, 0xF9 }
+    },
+  };
+
+  int i;
+  unsigned char tmp[28];
+  hash_state md;
+
+  LTC_ARGCHK(desc != NULL);
+  LTC_ARGCHK(desc->init != NULL);
+  LTC_ARGCHK(desc->process != NULL);
+  LTC_ARGCHK(desc->done != NULL);
+  LTC_ARGCHK(name != NULL);
+
+  for (i = 0; i < (int)(sizeof(tests) / sizeof(tests[0])); i++) {
+      desc->init(&md);
+      desc->process(&md, (unsigned char*)tests[i].msg, (unsigned long)XSTRLEN(tests[i].msg));
+      desc->done(&md, tmp);
+      if (ltc_compare_testvector(tmp, sizeof(tmp), tests[i].hash, sizeof(tests[i].hash), name, i)) {
+         return CRYPT_FAIL_TESTVECTOR;
+      }
+  }
+  return CRYPT_OK;
+#endif
+}
+
+#endif /* defined(LTC_SHA512_224) && defined(LTC_SHA512) */

--- a/src/hashes/sha2/sha512_224_x86.c
+++ b/src/hashes/sha2/sha512_224_x86.c
@@ -1,0 +1,61 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis */
+/* SPDX-License-Identifier: Unlicense */
+#include "tomcrypt_private.h"
+
+/**
+   @file sha512_224_x86.c
+   SHA512/224 using the Intel SHA512 extension (SHA512 truncated to 224 bits)
+*/
+
+#if defined(LTC_SHA512_224) && defined(LTC_SHA512) && defined(LTC_SHA512_224_X86) && defined(LTC_SHA512_X86)
+
+const struct ltc_hash_descriptor sha512_224_x86_desc =
+{
+    "sha512-224",
+    15,
+    28,
+    128,
+
+    /* OID */
+   { 2, 16, 840, 1, 101, 3, 4, 2, 5,  },
+   9,
+
+    &sha512_224_init,
+    &sha512_224_x86_process,
+    &sha512_224_x86_done,
+    &sha512_224_x86_test,
+    NULL
+};
+
+/**
+   Terminate the hash to get the digest
+   @param md  The hash state
+   @param out [out] The destination of the hash (28 bytes)
+   @return CRYPT_OK if successful
+*/
+int sha512_224_x86_done(hash_state * md, unsigned char *out)
+{
+    unsigned char buf[64];
+    int err;
+
+    LTC_ARGCHK(md  != NULL);
+    LTC_ARGCHK(out != NULL);
+
+    err = sha512_x86_done(md, buf);
+    XMEMCPY(out, buf, 28);
+#ifdef LTC_CLEAN_STACK
+    zeromem(buf, sizeof(buf));
+#endif
+    return err;
+}
+
+/**
+  Self-test the hash
+  @return CRYPT_OK if successful, CRYPT_NOP if self-tests have been disabled
+*/
+int sha512_224_x86_test(void)
+{
+   return sha512_224_test_desc(&sha512_224_x86_desc, "SHA512-224 x86");
+}
+
+#endif /* defined(LTC_SHA512_224) && defined(LTC_SHA512) */

--- a/src/hashes/sha2/sha512_256.c
+++ b/src/hashes/sha2/sha512_256.c
@@ -9,7 +9,7 @@
 
 #if defined(LTC_SHA512_256) && defined(LTC_SHA512)
 
-const struct ltc_hash_descriptor sha512_256_desc =
+const struct ltc_hash_descriptor sha512_256_portable_desc =
 {
     "sha512-256",
     16,
@@ -21,100 +21,41 @@ const struct ltc_hash_descriptor sha512_256_desc =
    9,
 
     &sha512_256_init,
-    &sha512_process,
-    &sha512_256_done,
-    &sha512_256_test,
+    &sha512_256_c_process,
+    &sha512_256_c_done,
+    &sha512_256_c_test,
     NULL
 };
 
 /**
-   Initialize the hash state
-   @param md   The hash state you wish to initialize
-   @return CRYPT_OK if successful
-*/
-int sha512_256_init(hash_state * md)
-{
-    LTC_ARGCHK(md != NULL);
-
-    md->sha512.curlen = 0;
-    md->sha512.length = 0;
-    md->sha512.state[0] = CONST64(0x22312194FC2BF72C);
-    md->sha512.state[1] = CONST64(0x9F555FA3C84C64C2);
-    md->sha512.state[2] = CONST64(0x2393B86B6F53B151);
-    md->sha512.state[3] = CONST64(0x963877195940EABD);
-    md->sha512.state[4] = CONST64(0x96283EE2A88EFFE3);
-    md->sha512.state[5] = CONST64(0xBE5E1E2553863992);
-    md->sha512.state[6] = CONST64(0x2B0199FC2C85B8AA);
-    md->sha512.state[7] = CONST64(0x0EB72DDC81C52CA2);
-    return CRYPT_OK;
-}
-
-/**
    Terminate the hash to get the digest
    @param md  The hash state
-   @param out [out] The destination of the hash (48 bytes)
+   @param out [out] The destination of the hash (32 bytes)
    @return CRYPT_OK if successful
 */
-int sha512_256_done(hash_state * md, unsigned char *out)
+int sha512_256_c_done(hash_state * md, unsigned char *out)
 {
    unsigned char buf[64];
+   int err;
 
    LTC_ARGCHK(md  != NULL);
    LTC_ARGCHK(out != NULL);
 
-    if (md->sha512.curlen >= sizeof(md->sha512.buf)) {
-       return CRYPT_INVALID_ARG;
-    }
-
-   sha512_done(md, buf);
+   err = sha512_c_done(md, buf);
    XMEMCPY(out, buf, 32);
 #ifdef LTC_CLEAN_STACK
    zeromem(buf, sizeof(buf));
 #endif
-   return CRYPT_OK;
+   return err;
 }
 
 /**
   Self-test the hash
   @return CRYPT_OK if successful, CRYPT_NOP if self-tests have been disabled
 */
-int  sha512_256_test(void)
+int sha512_256_c_test(void)
 {
- #ifndef LTC_TEST
-    return CRYPT_NOP;
- #else
-  static const struct {
-      const char *msg;
-      unsigned char hash[32];
-  } tests[] = {
-    { "abc",
-      { 0x53, 0x04, 0x8E, 0x26, 0x81, 0x94, 0x1E, 0xF9,
-        0x9B, 0x2E, 0x29, 0xB7, 0x6B, 0x4C, 0x7D, 0xAB,
-        0xE4, 0xC2, 0xD0, 0xC6, 0x34, 0xFC, 0x6D, 0x46,
-        0xE0, 0xE2, 0xF1, 0x31, 0x07, 0xE7, 0xAF, 0x23 }
-    },
-    { "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu",
-      { 0x39, 0x28, 0xE1, 0x84, 0xFB, 0x86, 0x90, 0xF8,
-        0x40, 0xDA, 0x39, 0x88, 0x12, 0x1D, 0x31, 0xBE,
-        0x65, 0xCB, 0x9D, 0x3E, 0xF8, 0x3E, 0xE6, 0x14,
-        0x6F, 0xEA, 0xC8, 0x61, 0xE1, 0x9B, 0x56, 0x3A }
-    },
-  };
-
-  int i;
-  unsigned char tmp[32];
-  hash_state md;
-
-  for (i = 0; i < (int)(sizeof(tests) / sizeof(tests[0])); i++) {
-      sha512_256_init(&md);
-      sha512_256_process(&md, (unsigned char*)tests[i].msg, (unsigned long)XSTRLEN(tests[i].msg));
-      sha512_256_done(&md, tmp);
-      if (ltc_compare_testvector(tmp, sizeof(tmp), tests[i].hash, sizeof(tests[i].hash), "SHA512-265", i)) {
-         return CRYPT_FAIL_TESTVECTOR;
-      }
-  }
-  return CRYPT_OK;
- #endif
+   return sha512_256_test_desc(&sha512_256_portable_desc, "SHA512-256 portable");
 }
 
-#endif /* defined(LTC_SHA384) && defined(LTC_SHA512) */
+#endif /* defined(LTC_SHA512_256) && defined(LTC_SHA512) */

--- a/src/hashes/sha2/sha512_256_desc.c
+++ b/src/hashes/sha2/sha512_256_desc.c
@@ -1,0 +1,124 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis */
+/* SPDX-License-Identifier: Unlicense */
+#include "tomcrypt_private.h"
+
+/**
+   @file sha512_256_desc.c
+   SHA512/256 multiplexer between the portable and the x86 implementation
+*/
+
+#if defined(LTC_SHA512_256) && defined(LTC_SHA512)
+
+const struct ltc_hash_descriptor sha512_256_desc =
+{
+    "sha512-256",
+    16,
+    32,
+    128,
+
+    /* OID */
+   { 2, 16, 840, 1, 101, 3, 4, 2, 6,  },
+   9,
+
+    &sha512_256_init,
+    &sha512_process,
+    &sha512_256_done,
+    &sha512_256_test,
+    NULL
+};
+
+/**
+   Initialize the hash state
+   @param md   The hash state you wish to initialize
+   @return CRYPT_OK if successful
+*/
+int sha512_256_init(hash_state * md)
+{
+    LTC_ARGCHK(md != NULL);
+
+    md->sha512.curlen = 0;
+    md->sha512.length = 0;
+    md->sha512.state[0] = CONST64(0x22312194FC2BF72C);
+    md->sha512.state[1] = CONST64(0x9F555FA3C84C64C2);
+    md->sha512.state[2] = CONST64(0x2393B86B6F53B151);
+    md->sha512.state[3] = CONST64(0x963877195940EABD);
+    md->sha512.state[4] = CONST64(0x96283EE2A88EFFE3);
+    md->sha512.state[5] = CONST64(0xBE5E1E2553863992);
+    md->sha512.state[6] = CONST64(0x2B0199FC2C85B8AA);
+    md->sha512.state[7] = CONST64(0x0EB72DDC81C52CA2);
+    return CRYPT_OK;
+}
+
+/**
+   Terminate the hash to get the digest
+   @param md  The hash state
+   @param out [out] The destination of the hash (32 bytes)
+   @return CRYPT_OK if successful
+*/
+int sha512_256_done(hash_state * md, unsigned char *out)
+{
+#if defined LTC_SHA512_256_X86
+    if(sha512ni_is_supported()) {
+        return sha512_256_x86_done(md, out);
+    }
+#endif
+    return sha512_256_c_done(md, out);
+}
+
+/**
+  Self-test the hash
+  @return CRYPT_OK if successful, CRYPT_NOP if self-tests have been disabled
+*/
+int sha512_256_test(void)
+{
+   return sha512_256_test_desc(&sha512_256_desc, "SHA512-256");
+}
+
+int sha512_256_test_desc(const struct ltc_hash_descriptor *desc, const char *name)
+{
+#ifndef LTC_TEST
+   LTC_UNUSED_PARAM(desc);
+   LTC_UNUSED_PARAM(name);
+   return CRYPT_NOP;
+#else
+  static const struct {
+      const char *msg;
+      unsigned char hash[32];
+  } tests[] = {
+    { "abc",
+      { 0x53, 0x04, 0x8E, 0x26, 0x81, 0x94, 0x1E, 0xF9,
+        0x9B, 0x2E, 0x29, 0xB7, 0x6B, 0x4C, 0x7D, 0xAB,
+        0xE4, 0xC2, 0xD0, 0xC6, 0x34, 0xFC, 0x6D, 0x46,
+        0xE0, 0xE2, 0xF1, 0x31, 0x07, 0xE7, 0xAF, 0x23 }
+    },
+    { "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu",
+      { 0x39, 0x28, 0xE1, 0x84, 0xFB, 0x86, 0x90, 0xF8,
+        0x40, 0xDA, 0x39, 0x88, 0x12, 0x1D, 0x31, 0xBE,
+        0x65, 0xCB, 0x9D, 0x3E, 0xF8, 0x3E, 0xE6, 0x14,
+        0x6F, 0xEA, 0xC8, 0x61, 0xE1, 0x9B, 0x56, 0x3A }
+    },
+  };
+
+  int i;
+  unsigned char tmp[32];
+  hash_state md;
+
+  LTC_ARGCHK(desc != NULL);
+  LTC_ARGCHK(desc->init != NULL);
+  LTC_ARGCHK(desc->process != NULL);
+  LTC_ARGCHK(desc->done != NULL);
+  LTC_ARGCHK(name != NULL);
+
+  for (i = 0; i < (int)(sizeof(tests) / sizeof(tests[0])); i++) {
+      desc->init(&md);
+      desc->process(&md, (unsigned char*)tests[i].msg, (unsigned long)XSTRLEN(tests[i].msg));
+      desc->done(&md, tmp);
+      if (ltc_compare_testvector(tmp, sizeof(tmp), tests[i].hash, sizeof(tests[i].hash), name, i)) {
+         return CRYPT_FAIL_TESTVECTOR;
+      }
+  }
+  return CRYPT_OK;
+#endif
+}
+
+#endif /* defined(LTC_SHA512_256) && defined(LTC_SHA512) */

--- a/src/hashes/sha2/sha512_256_x86.c
+++ b/src/hashes/sha2/sha512_256_x86.c
@@ -1,0 +1,61 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis */
+/* SPDX-License-Identifier: Unlicense */
+#include "tomcrypt_private.h"
+
+/**
+   @file sha512_256_x86.c
+   SHA512/256 using the Intel SHA512 extension (SHA512 truncated to 256 bits)
+*/
+
+#if defined(LTC_SHA512_256) && defined(LTC_SHA512) && defined(LTC_SHA512_256_X86) && defined(LTC_SHA512_X86)
+
+const struct ltc_hash_descriptor sha512_256_x86_desc =
+{
+    "sha512-256",
+    16,
+    32,
+    128,
+
+    /* OID */
+   { 2, 16, 840, 1, 101, 3, 4, 2, 6,  },
+   9,
+
+    &sha512_256_init,
+    &sha512_256_x86_process,
+    &sha512_256_x86_done,
+    &sha512_256_x86_test,
+    NULL
+};
+
+/**
+   Terminate the hash to get the digest
+   @param md  The hash state
+   @param out [out] The destination of the hash (32 bytes)
+   @return CRYPT_OK if successful
+*/
+int sha512_256_x86_done(hash_state * md, unsigned char *out)
+{
+    unsigned char buf[64];
+    int err;
+
+    LTC_ARGCHK(md  != NULL);
+    LTC_ARGCHK(out != NULL);
+
+    err = sha512_x86_done(md, buf);
+    XMEMCPY(out, buf, 32);
+#ifdef LTC_CLEAN_STACK
+    zeromem(buf, sizeof(buf));
+#endif
+    return err;
+}
+
+/**
+  Self-test the hash
+  @return CRYPT_OK if successful, CRYPT_NOP if self-tests have been disabled
+*/
+int sha512_256_x86_test(void)
+{
+   return sha512_256_test_desc(&sha512_256_x86_desc, "SHA512-256 x86");
+}
+
+#endif /* defined(LTC_SHA512_256) && defined(LTC_SHA512) */

--- a/src/hashes/sha2/sha512_desc.c
+++ b/src/hashes/sha2/sha512_desc.c
@@ -1,0 +1,263 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis */
+/* SPDX-License-Identifier: Unlicense */
+#include "tomcrypt_private.h"
+
+/**
+   @file sha512_desc.c
+   SHA512 multiplexer between the portable and the x86 implementation
+*/
+
+#if defined LTC_ARCH_X86
+
+#if defined(_MSC_VER)
+#include <intrin.h>
+#endif
+
+#if defined _MSC_VER && (!defined _MSC_FULL_VER || _MSC_FULL_VER < 160040219)
+/* __cpuidex() / _xgetbv() require at least VS2008 SP1 / VS2010 SP1 */
+#define LTC_SHA512_CPUID_UNAVAILABLE
+#endif
+
+#ifndef LTC_SHA512_CPUID_UNAVAILABLE
+#if !defined (LTC_S_X86_CPUID)
+#define LTC_S_X86_CPUID
+static LTC_INLINE void s_x86_cpuid(int* regs, int leaf)
+{
+#if defined _MSC_VER
+   __cpuid(regs, leaf);
+#else
+    int a, b, c, d;
+
+    a = leaf;
+    b = c = d = 0;
+    __asm__ volatile ("cpuid"
+        :"=a"(a), "=b"(b), "=c"(c), "=d"(d)
+        :"a"(a), "c"(c)
+    );
+    regs[0] = a;
+    regs[1] = b;
+    regs[2] = c;
+    regs[3] = d;
+#endif
+}
+#endif /* LTC_S_X86_CPUID */
+
+static LTC_INLINE void s_x86_cpuid_ex(int* regs, int leaf, int subleaf)
+{
+#if defined _MSC_VER
+   __cpuidex(regs, leaf, subleaf);
+#else
+    int a, b, c, d;
+
+    a = leaf;
+    c = subleaf;
+    b = d = 0;
+    __asm__ volatile ("cpuid"
+        :"=a"(a), "=b"(b), "=c"(c), "=d"(d)
+        :"a"(a), "c"(c)
+    );
+    regs[0] = a;
+    regs[1] = b;
+    regs[2] = c;
+    regs[3] = d;
+#endif
+}
+
+static LTC_INLINE unsigned int s_x86_xgetbv0(void)
+{
+#if defined _MSC_VER
+   return (unsigned int)_xgetbv(0);
+#else
+    unsigned int eax_, edx_;
+
+    __asm__ ("xgetbv"
+        :"=a"(eax_), "=d"(edx_)
+        :"c"(0)
+    );
+    return eax_;
+#endif
+}
+#endif /* LTC_SHA512_CPUID_UNAVAILABLE */
+
+static LTC_INLINE int s_sha512_x86_is_supported(void)
+{
+#ifdef LTC_SHA512_CPUID_UNAVAILABLE
+    return 0;
+#else
+    static int initialized = 0;
+    static int is_supported = 0;
+
+    if (initialized == 0) {
+        int regs[4];
+        int osxsave, avx2, sha512, ymm;
+        /* Leaf 0, Reg 0 contains the number of leafs available */
+        s_x86_cpuid(regs, 0);
+        if(regs[0] >= 7) {
+           s_x86_cpuid(regs, 1);
+           osxsave = ((((unsigned int)(regs[2])) >> 27) & 1u) != 0; /* OSXSAVE, leaf 1, ecx, bit 27 */
+           s_x86_cpuid(regs, 7);
+           avx2 = ((((unsigned int)(regs[1])) >> 5) & 1u) != 0; /* AVX2, leaf 7, ebx, bit 5 */
+           sha512 = 0;
+           if (regs[0] >= 1) {
+              s_x86_cpuid_ex(regs, 7, 1);
+              sha512 = ((((unsigned int)(regs[0])) >> 0) & 1u) != 0; /* SHA512, leaf 7 subleaf 1, eax, bit 0 */
+           }
+           /* the OS must enable XMM+YMM state management, XCR0 bits 1 and 2 */
+           ymm = osxsave && ((s_x86_xgetbv0() & 0x6u) == 0x6u);
+           is_supported = avx2 && sha512 && ymm;
+        }
+        initialized = 1;
+    }
+    return is_supported;
+#endif /* LTC_SHA512_CPUID_UNAVAILABLE */
+}
+#endif /* LTC_ARCH_X86 */
+
+int sha512ni_is_supported(void)
+{
+#ifdef LTC_ARCH_X86
+   return s_sha512_x86_is_supported();
+#else
+   return 0;
+#endif
+}
+
+#ifdef LTC_SHA512
+
+const struct ltc_hash_descriptor sha512_desc =
+{
+    "sha512",
+    5,
+    64,
+    128,
+
+    /* OID */
+   { 2, 16, 840, 1, 101, 3, 4, 2, 3,  },
+   9,
+
+    &sha512_init,
+    &sha512_process,
+    &sha512_done,
+    &sha512_test,
+    NULL
+};
+
+/**
+   Initialize the hash state
+   @param md   The hash state you wish to initialize
+   @return CRYPT_OK if successful
+*/
+int sha512_init(hash_state * md)
+{
+    LTC_ARGCHK(md != NULL);
+    md->sha512.curlen = 0;
+    md->sha512.length = 0;
+    md->sha512.state[0] = CONST64(0x6a09e667f3bcc908);
+    md->sha512.state[1] = CONST64(0xbb67ae8584caa73b);
+    md->sha512.state[2] = CONST64(0x3c6ef372fe94f82b);
+    md->sha512.state[3] = CONST64(0xa54ff53a5f1d36f1);
+    md->sha512.state[4] = CONST64(0x510e527fade682d1);
+    md->sha512.state[5] = CONST64(0x9b05688c2b3e6c1f);
+    md->sha512.state[6] = CONST64(0x1f83d9abfb41bd6b);
+    md->sha512.state[7] = CONST64(0x5be0cd19137e2179);
+    return CRYPT_OK;
+}
+
+/**
+   Process a block of memory though the hash
+   @param md     The hash state
+   @param in     The data to hash
+   @param inlen  The length of the data (octets)
+   @return CRYPT_OK if successful
+*/
+int sha512_process(hash_state * md, const unsigned char *in, unsigned long inlen)
+{
+#if defined LTC_SHA512_X86
+    if(s_sha512_x86_is_supported()) {
+        return sha512_x86_process(md, in, inlen);
+    }
+#endif
+    return sha512_c_process(md, in, inlen);
+}
+
+/**
+   Terminate the hash to get the digest
+   @param md  The hash state
+   @param out [out] The destination of the hash (64 bytes)
+   @return CRYPT_OK if successful
+*/
+int sha512_done(hash_state * md, unsigned char *out)
+{
+#if defined LTC_SHA512_X86
+    if(s_sha512_x86_is_supported()) {
+        return sha512_x86_done(md, out);
+    }
+#endif
+    return sha512_c_done(md, out);
+}
+
+/**
+  Self-test the hash
+  @return CRYPT_OK if successful, CRYPT_NOP if self-tests have been disabled
+*/
+int sha512_test(void)
+{
+   return sha512_test_desc(&sha512_desc, "SHA512");
+}
+
+int sha512_test_desc(const struct ltc_hash_descriptor *desc, const char *name)
+{
+#ifndef LTC_TEST
+   LTC_UNUSED_PARAM(desc);
+   LTC_UNUSED_PARAM(name);
+   return CRYPT_NOP;
+#else
+  static const struct {
+      const char *msg;
+      unsigned char hash[64];
+  } tests[] = {
+    { "abc",
+     { 0xdd, 0xaf, 0x35, 0xa1, 0x93, 0x61, 0x7a, 0xba,
+       0xcc, 0x41, 0x73, 0x49, 0xae, 0x20, 0x41, 0x31,
+       0x12, 0xe6, 0xfa, 0x4e, 0x89, 0xa9, 0x7e, 0xa2,
+       0x0a, 0x9e, 0xee, 0xe6, 0x4b, 0x55, 0xd3, 0x9a,
+       0x21, 0x92, 0x99, 0x2a, 0x27, 0x4f, 0xc1, 0xa8,
+       0x36, 0xba, 0x3c, 0x23, 0xa3, 0xfe, 0xeb, 0xbd,
+       0x45, 0x4d, 0x44, 0x23, 0x64, 0x3c, 0xe8, 0x0e,
+       0x2a, 0x9a, 0xc9, 0x4f, 0xa5, 0x4c, 0xa4, 0x9f }
+    },
+    { "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu",
+     { 0x8e, 0x95, 0x9b, 0x75, 0xda, 0xe3, 0x13, 0xda,
+       0x8c, 0xf4, 0xf7, 0x28, 0x14, 0xfc, 0x14, 0x3f,
+       0x8f, 0x77, 0x79, 0xc6, 0xeb, 0x9f, 0x7f, 0xa1,
+       0x72, 0x99, 0xae, 0xad, 0xb6, 0x88, 0x90, 0x18,
+       0x50, 0x1d, 0x28, 0x9e, 0x49, 0x00, 0xf7, 0xe4,
+       0x33, 0x1b, 0x99, 0xde, 0xc4, 0xb5, 0x43, 0x3a,
+       0xc7, 0xd3, 0x29, 0xee, 0xb6, 0xdd, 0x26, 0x54,
+       0x5e, 0x96, 0xe5, 0x5b, 0x87, 0x4b, 0xe9, 0x09 }
+    },
+  };
+
+  int i;
+  unsigned char tmp[64];
+  hash_state md;
+
+  LTC_ARGCHK(desc != NULL);
+  LTC_ARGCHK(desc->init != NULL);
+  LTC_ARGCHK(desc->process != NULL);
+  LTC_ARGCHK(desc->done != NULL);
+  LTC_ARGCHK(name != NULL);
+
+  for (i = 0; i < (int)(sizeof(tests) / sizeof(tests[0])); i++) {
+      desc->init(&md);
+      desc->process(&md, (unsigned char *)tests[i].msg, (unsigned long)XSTRLEN(tests[i].msg));
+      desc->done(&md, tmp);
+      if (ltc_compare_testvector(tmp, sizeof(tmp), tests[i].hash, sizeof(tests[i].hash), name, i)) {
+         return CRYPT_FAIL_TESTVECTOR;
+      }
+  }
+  return CRYPT_OK;
+#endif
+}
+
+#endif

--- a/src/hashes/sha2/sha512_x86.c
+++ b/src/hashes/sha2/sha512_x86.c
@@ -345,7 +345,7 @@ static int LTC_SHA512_TARGET s_sha512_x86_compress(hash_state * md, const unsign
     state_b = ltc_mm256_blend_epi64(tmp_c, tmp_d, ltc_blend_epi64_k(0x1, 0x1, 0x0, 0x0));
     _mm256_storeu_si256(((__m256i*)(&md->sha512.state[0])), state_a);
     _mm256_storeu_si256(((__m256i*)(&md->sha512.state[4])), state_b);
-  return CRYPT_OK;
+    return CRYPT_OK;
 
 #undef ltc_permute_epi64_k
 #undef ltc_blend_epi32_k

--- a/src/hashes/sha2/sha512_x86.c
+++ b/src/hashes/sha2/sha512_x86.c
@@ -1,0 +1,445 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis */
+/* SPDX-License-Identifier: Unlicense */
+#include "tomcrypt_private.h"
+
+/**
+  @file sha512_x86.c
+  SHA512 by Marek Knapek
+*/
+
+#if defined(LTC_SHA512) && defined(LTC_SHA512_X86)
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-align"
+#pragma GCC diagnostic ignored "-Wdeclaration-after-statement"
+#pragma GCC diagnostic ignored "-Wuninitialized"
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+#if defined(_MSC_VER)
+#include <intrin.h>
+#endif
+#include <emmintrin.h> /* SSE2   _mm_set_epi64x */
+#include <immintrin.h> /* AVX    _mm256_castsi128_si256 _mm256_castsi256_si128 _mm256_load_si256 _mm256_loadu_si256 _mm256_storeu_si256
+                          AVX2   _mm256_add_epi64 _mm256_blend_epi32 _mm256_permute4x64_epi64 _mm256_shuffle_epi8
+                          SHA512 _mm256_sha512msg1_epi64 _mm256_sha512msg2_epi64 _mm256_sha512rnds2_epi64 */
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+const struct ltc_hash_descriptor sha512_x86_desc =
+{
+    "sha512",
+    5,
+    64,
+    128,
+
+    /* OID */
+   { 2, 16, 840, 1, 101, 3, 4, 2, 3,  },
+   9,
+
+    &sha512_init,
+    &sha512_x86_process,
+    &sha512_x86_done,
+    &sha512_x86_test,
+    NULL
+};
+
+/* the K array */
+#define K sha512_x86_K
+LTC_ALIGN_MSVC(32)
+static const ulong64 K[80] LTC_ALIGN(32) = {
+CONST64(0x428a2f98d728ae22), CONST64(0x7137449123ef65cd),
+CONST64(0xb5c0fbcfec4d3b2f), CONST64(0xe9b5dba58189dbbc),
+CONST64(0x3956c25bf348b538), CONST64(0x59f111f1b605d019),
+CONST64(0x923f82a4af194f9b), CONST64(0xab1c5ed5da6d8118),
+CONST64(0xd807aa98a3030242), CONST64(0x12835b0145706fbe),
+CONST64(0x243185be4ee4b28c), CONST64(0x550c7dc3d5ffb4e2),
+CONST64(0x72be5d74f27b896f), CONST64(0x80deb1fe3b1696b1),
+CONST64(0x9bdc06a725c71235), CONST64(0xc19bf174cf692694),
+CONST64(0xe49b69c19ef14ad2), CONST64(0xefbe4786384f25e3),
+CONST64(0x0fc19dc68b8cd5b5), CONST64(0x240ca1cc77ac9c65),
+CONST64(0x2de92c6f592b0275), CONST64(0x4a7484aa6ea6e483),
+CONST64(0x5cb0a9dcbd41fbd4), CONST64(0x76f988da831153b5),
+CONST64(0x983e5152ee66dfab), CONST64(0xa831c66d2db43210),
+CONST64(0xb00327c898fb213f), CONST64(0xbf597fc7beef0ee4),
+CONST64(0xc6e00bf33da88fc2), CONST64(0xd5a79147930aa725),
+CONST64(0x06ca6351e003826f), CONST64(0x142929670a0e6e70),
+CONST64(0x27b70a8546d22ffc), CONST64(0x2e1b21385c26c926),
+CONST64(0x4d2c6dfc5ac42aed), CONST64(0x53380d139d95b3df),
+CONST64(0x650a73548baf63de), CONST64(0x766a0abb3c77b2a8),
+CONST64(0x81c2c92e47edaee6), CONST64(0x92722c851482353b),
+CONST64(0xa2bfe8a14cf10364), CONST64(0xa81a664bbc423001),
+CONST64(0xc24b8b70d0f89791), CONST64(0xc76c51a30654be30),
+CONST64(0xd192e819d6ef5218), CONST64(0xd69906245565a910),
+CONST64(0xf40e35855771202a), CONST64(0x106aa07032bbd1b8),
+CONST64(0x19a4c116b8d2d0c8), CONST64(0x1e376c085141ab53),
+CONST64(0x2748774cdf8eeb99), CONST64(0x34b0bcb5e19b48a8),
+CONST64(0x391c0cb3c5c95a63), CONST64(0x4ed8aa4ae3418acb),
+CONST64(0x5b9cca4f7763e373), CONST64(0x682e6ff3d6b2b8a3),
+CONST64(0x748f82ee5defb2fc), CONST64(0x78a5636f43172f60),
+CONST64(0x84c87814a1f0ab72), CONST64(0x8cc702081a6439ec),
+CONST64(0x90befffa23631e28), CONST64(0xa4506cebde82bde9),
+CONST64(0xbef9a3f7b2c67915), CONST64(0xc67178f2e372532b),
+CONST64(0xca273eceea26619c), CONST64(0xd186b8c721c0c207),
+CONST64(0xeada7dd6cde0eb1e), CONST64(0xf57d4f7fee6ed178),
+CONST64(0x06f067aa72176fba), CONST64(0x0a637dc5a2c898a6),
+CONST64(0x113f9804bef90dae), CONST64(0x1b710b35131c471b),
+CONST64(0x28db77f523047d84), CONST64(0x32caab7b40c72493),
+CONST64(0x3c9ebe0a15c9bebc), CONST64(0x431d67c49c100d4c),
+CONST64(0x4cc5d4becb3e42b6), CONST64(0x597f299cfc657e2a),
+CONST64(0x5fcb6fab3ad6faec), CONST64(0x6c44198c4a475817)
+};
+
+/* compress 1024-bits */
+#ifdef LTC_CLEAN_STACK
+static int LTC_SHA512_TARGET ss_sha512_x86_compress(hash_state * md, const unsigned char *buf)
+#else
+static int LTC_SHA512_TARGET s_sha512_x86_compress(hash_state * md, const unsigned char *buf)
+#endif
+{
+#define ltc_permute_epi64_k(a, b, c, d) ((((a) & 0x3) << (3 * 2)) | (((b) & 0x3) << (2 * 2)) | (((c) & 0x3) << (1 * 2)) | (((d) & 0x3) << (0 * 2)))
+#define ltc_blend_epi32_k(a, b, c, d, e, f, g, h) ((((a) & 0x1) << 7) | (((b) & 0x1) << 6) | (((c) & 0x1) << 5) | (((d) & 0x1) << 4) | (((e) & 0x1) << 3) | (((f) & 0x1) << 2) | (((g) & 0x1) << 1) | (((h) & 0x1) << 0))
+#define ltc_blend_epi64_k(a, b, c, d) ((((a) & 0x1) << 3) | (((b) & 0x1) << 2) | (((c) & 0x1) << 1) | (((d) & 0x1) << 0))
+#define ltc_mm256_blend_epi64(a, b, c) _mm256_blend_epi32((a), (b), ltc_blend_epi32_k((((c) >> 3) & 0x1), (((c) >> 3) & 0x1), (((c) >> 2) & 0x1), (((c) >> 2) & 0x1), (((c) >> 1) & 0x1), (((c) >> 1) & 0x1), (((c) >> 0) & 0x1), (((c) >> 0) & 0x1)))
+#define any 0
+
+    __m256i reverse;
+    __m256i state_a;
+    __m256i state_b;
+    __m256i tmp_a;
+    __m256i tmp_b;
+    __m256i tmp_c;
+    __m256i tmp_d;
+    __m256i old_a;
+    __m256i old_b;
+    __m256i msg_a;
+    __m256i msg_b;
+    __m256i msg_c;
+    __m256i msg_d;
+
+    reverse = _mm256_permute4x64_epi64(_mm256_castsi128_si256(_mm_set_epi64x(0x08090a0b0c0d0e0full, 0x0001020304050607ull)), ltc_permute_epi64_k(0x1, 0x0, 0x1, 0x0));
+    state_a = _mm256_loadu_si256(((__m256i const*)(&md->sha512.state[0])));
+    state_b = _mm256_loadu_si256(((__m256i const*)(&md->sha512.state[4])));
+    tmp_a = _mm256_permute4x64_epi64(state_b, ltc_permute_epi64_k(any, any, 0x2, 0x3));
+    tmp_b = _mm256_permute4x64_epi64(state_a, ltc_permute_epi64_k(0x2, 0x3, any, any));
+    tmp_c = _mm256_permute4x64_epi64(state_b, ltc_permute_epi64_k(any, any, 0x0, 0x1));
+    tmp_d = _mm256_permute4x64_epi64(state_a, ltc_permute_epi64_k(0x0, 0x1, any, any));
+    state_a = ltc_mm256_blend_epi64(tmp_a, tmp_b, ltc_blend_epi64_k(0x1, 0x1, 0x0, 0x0));
+    state_b = ltc_mm256_blend_epi64(tmp_c, tmp_d, ltc_blend_epi64_k(0x1, 0x1, 0x0, 0x0));
+
+    old_a = state_a;
+    old_b = state_b;
+    tmp_a = _mm256_load_si256(((__m256i const*)(&K[0 * (256 / (sizeof(ulong64) * CHAR_BIT))])));
+    msg_a = _mm256_loadu_si256(((__m256i const*)(&buf[0 * (256 / CHAR_BIT)])));
+    msg_a = _mm256_shuffle_epi8(msg_a, reverse);
+    tmp_a = _mm256_add_epi64(tmp_a, msg_a);
+    state_a = _mm256_sha512rnds2_epi64(state_a, state_b, _mm256_castsi256_si128(tmp_a));
+    tmp_a = _mm256_permute4x64_epi64(tmp_a, ltc_permute_epi64_k(any, any, 0x3, 0x2));
+    state_b = _mm256_sha512rnds2_epi64(state_b, state_a, _mm256_castsi256_si128(tmp_a));
+    tmp_a = _mm256_load_si256(((__m256i const*)(&K[1 * (256 / (sizeof(ulong64) * CHAR_BIT))])));
+    msg_b = _mm256_loadu_si256(((__m256i const*)(&buf[1 * (256 / CHAR_BIT)])));
+    msg_b = _mm256_shuffle_epi8(msg_b, reverse);
+    tmp_a = _mm256_add_epi64(tmp_a, msg_b);
+    state_a = _mm256_sha512rnds2_epi64(state_a, state_b, _mm256_castsi256_si128(tmp_a));
+    tmp_a = _mm256_permute4x64_epi64(tmp_a, ltc_permute_epi64_k(any, any, 0x3, 0x2));
+    state_b = _mm256_sha512rnds2_epi64(state_b, state_a, _mm256_castsi256_si128(tmp_a));
+    tmp_a = _mm256_load_si256(((__m256i const*)(&K[2 * (256 / (sizeof(ulong64) * CHAR_BIT))])));
+    msg_c = _mm256_loadu_si256(((__m256i const*)(&buf[2 * (256 / CHAR_BIT)])));
+    msg_c = _mm256_shuffle_epi8(msg_c, reverse);
+    tmp_a = _mm256_add_epi64(tmp_a, msg_c);
+    state_a = _mm256_sha512rnds2_epi64(state_a, state_b, _mm256_castsi256_si128(tmp_a));
+    tmp_a = _mm256_permute4x64_epi64(tmp_a, ltc_permute_epi64_k(any, any, 0x3, 0x2));
+    state_b = _mm256_sha512rnds2_epi64(state_b, state_a, _mm256_castsi256_si128(tmp_a));
+    tmp_a = _mm256_load_si256(((__m256i const*)(&K[3 * (256 / (sizeof(ulong64) * CHAR_BIT))])));
+    msg_d = _mm256_loadu_si256(((__m256i const*)(&buf[3 * (256 / CHAR_BIT)])));
+    msg_d = _mm256_shuffle_epi8(msg_d, reverse);
+    tmp_a = _mm256_add_epi64(tmp_a, msg_d);
+    state_a = _mm256_sha512rnds2_epi64(state_a, state_b, _mm256_castsi256_si128(tmp_a));
+    tmp_a = _mm256_permute4x64_epi64(tmp_a, ltc_permute_epi64_k(any, any, 0x3, 0x2));
+    state_b = _mm256_sha512rnds2_epi64(state_b, state_a, _mm256_castsi256_si128(tmp_a));
+    msg_a = _mm256_sha512msg1_epi64(msg_a, _mm256_castsi256_si128(msg_b));
+    tmp_a = _mm256_permute4x64_epi64(msg_c, ltc_permute_epi64_k(any, 0x3, 0x2, 0x1));
+    tmp_b = _mm256_permute4x64_epi64(msg_d, ltc_permute_epi64_k(0x0, any, any, any));
+    tmp_a = ltc_mm256_blend_epi64(tmp_a, tmp_b, ltc_blend_epi64_k(0x1, 0x0, 0x0, 0x0));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_a);
+    msg_a = _mm256_sha512msg2_epi64(tmp_a, msg_d);
+    tmp_a = _mm256_load_si256(((__m256i const*)(&K[4 * (256 / (sizeof(ulong64) * CHAR_BIT))])));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_a);
+    state_a = _mm256_sha512rnds2_epi64(state_a, state_b, _mm256_castsi256_si128(tmp_a));
+    tmp_a = _mm256_permute4x64_epi64(tmp_a, ltc_permute_epi64_k(any, any, 0x3, 0x2));
+    state_b = _mm256_sha512rnds2_epi64(state_b, state_a, _mm256_castsi256_si128(tmp_a));
+    msg_b = _mm256_sha512msg1_epi64(msg_b, _mm256_castsi256_si128(msg_c));
+    tmp_a = _mm256_permute4x64_epi64(msg_d, ltc_permute_epi64_k(any, 0x3, 0x2, 0x1));
+    tmp_b = _mm256_permute4x64_epi64(msg_a, ltc_permute_epi64_k(0x0, any, any, any));
+    tmp_a = ltc_mm256_blend_epi64(tmp_a, tmp_b, ltc_blend_epi64_k(0x1, 0x0, 0x0, 0x0));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_b);
+    msg_b = _mm256_sha512msg2_epi64(tmp_a, msg_a);
+    tmp_a = _mm256_load_si256(((__m256i const*)(&K[5 * (256 / (sizeof(ulong64) * CHAR_BIT))])));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_b);
+    state_a = _mm256_sha512rnds2_epi64(state_a, state_b, _mm256_castsi256_si128(tmp_a));
+    tmp_a = _mm256_permute4x64_epi64(tmp_a, ltc_permute_epi64_k(any, any, 0x3, 0x2));
+    state_b = _mm256_sha512rnds2_epi64(state_b, state_a, _mm256_castsi256_si128(tmp_a));
+    msg_c = _mm256_sha512msg1_epi64(msg_c, _mm256_castsi256_si128(msg_d));
+    tmp_a = _mm256_permute4x64_epi64(msg_a, ltc_permute_epi64_k(any, 0x3, 0x2, 0x1));
+    tmp_b = _mm256_permute4x64_epi64(msg_b, ltc_permute_epi64_k(0x0, any, any, any));
+    tmp_a = ltc_mm256_blend_epi64(tmp_a, tmp_b, ltc_blend_epi64_k(0x1, 0x0, 0x0, 0x0));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_c);
+    msg_c = _mm256_sha512msg2_epi64(tmp_a, msg_b);
+    tmp_a = _mm256_load_si256(((__m256i const*)(&K[6 * (256 / (sizeof(ulong64) * CHAR_BIT))])));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_c);
+    state_a = _mm256_sha512rnds2_epi64(state_a, state_b, _mm256_castsi256_si128(tmp_a));
+    tmp_a = _mm256_permute4x64_epi64(tmp_a, ltc_permute_epi64_k(any, any, 0x3, 0x2));
+    state_b = _mm256_sha512rnds2_epi64(state_b, state_a, _mm256_castsi256_si128(tmp_a));
+    msg_d = _mm256_sha512msg1_epi64(msg_d, _mm256_castsi256_si128(msg_a));
+    tmp_a = _mm256_permute4x64_epi64(msg_b, ltc_permute_epi64_k(any, 0x3, 0x2, 0x1));
+    tmp_b = _mm256_permute4x64_epi64(msg_c, ltc_permute_epi64_k(0x0, any, any, any));
+    tmp_a = ltc_mm256_blend_epi64(tmp_a, tmp_b, ltc_blend_epi64_k(0x1, 0x0, 0x0, 0x0));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_d);
+    msg_d = _mm256_sha512msg2_epi64(tmp_a, msg_c);
+    tmp_a = _mm256_load_si256(((__m256i const*)(&K[7 * (256 / (sizeof(ulong64) * CHAR_BIT))])));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_d);
+    state_a = _mm256_sha512rnds2_epi64(state_a, state_b, _mm256_castsi256_si128(tmp_a));
+    tmp_a = _mm256_permute4x64_epi64(tmp_a, ltc_permute_epi64_k(any, any, 0x3, 0x2));
+    state_b = _mm256_sha512rnds2_epi64(state_b, state_a, _mm256_castsi256_si128(tmp_a));
+    msg_a = _mm256_sha512msg1_epi64(msg_a, _mm256_castsi256_si128(msg_b));
+    tmp_a = _mm256_permute4x64_epi64(msg_c, ltc_permute_epi64_k(any, 0x3, 0x2, 0x1));
+    tmp_b = _mm256_permute4x64_epi64(msg_d, ltc_permute_epi64_k(0x0, any, any, any));
+    tmp_a = ltc_mm256_blend_epi64(tmp_a, tmp_b, ltc_blend_epi64_k(0x1, 0x0, 0x0, 0x0));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_a);
+    msg_a = _mm256_sha512msg2_epi64(tmp_a, msg_d);
+    tmp_a = _mm256_load_si256(((__m256i const*)(&K[8 * (256 / (sizeof(ulong64) * CHAR_BIT))])));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_a);
+    state_a = _mm256_sha512rnds2_epi64(state_a, state_b, _mm256_castsi256_si128(tmp_a));
+    tmp_a = _mm256_permute4x64_epi64(tmp_a, ltc_permute_epi64_k(any, any, 0x3, 0x2));
+    state_b = _mm256_sha512rnds2_epi64(state_b, state_a, _mm256_castsi256_si128(tmp_a));
+    msg_b = _mm256_sha512msg1_epi64(msg_b, _mm256_castsi256_si128(msg_c));
+    tmp_a = _mm256_permute4x64_epi64(msg_d, ltc_permute_epi64_k(any, 0x3, 0x2, 0x1));
+    tmp_b = _mm256_permute4x64_epi64(msg_a, ltc_permute_epi64_k(0x0, any, any, any));
+    tmp_a = ltc_mm256_blend_epi64(tmp_a, tmp_b, ltc_blend_epi64_k(0x1, 0x0, 0x0, 0x0));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_b);
+    msg_b = _mm256_sha512msg2_epi64(tmp_a, msg_a);
+    tmp_a = _mm256_load_si256(((__m256i const*)(&K[9 * (256 / (sizeof(ulong64) * CHAR_BIT))])));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_b);
+    state_a = _mm256_sha512rnds2_epi64(state_a, state_b, _mm256_castsi256_si128(tmp_a));
+    tmp_a = _mm256_permute4x64_epi64(tmp_a, ltc_permute_epi64_k(any, any, 0x3, 0x2));
+    state_b = _mm256_sha512rnds2_epi64(state_b, state_a, _mm256_castsi256_si128(tmp_a));
+    msg_c = _mm256_sha512msg1_epi64(msg_c, _mm256_castsi256_si128(msg_d));
+    tmp_a = _mm256_permute4x64_epi64(msg_a, ltc_permute_epi64_k(any, 0x3, 0x2, 0x1));
+    tmp_b = _mm256_permute4x64_epi64(msg_b, ltc_permute_epi64_k(0x0, any, any, any));
+    tmp_a = ltc_mm256_blend_epi64(tmp_a, tmp_b, ltc_blend_epi64_k(0x1, 0x0, 0x0, 0x0));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_c);
+    msg_c = _mm256_sha512msg2_epi64(tmp_a, msg_b);
+    tmp_a = _mm256_load_si256(((__m256i const*)(&K[10 * (256 / (sizeof(ulong64) * CHAR_BIT))])));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_c);
+    state_a = _mm256_sha512rnds2_epi64(state_a, state_b, _mm256_castsi256_si128(tmp_a));
+    tmp_a = _mm256_permute4x64_epi64(tmp_a, ltc_permute_epi64_k(any, any, 0x3, 0x2));
+    state_b = _mm256_sha512rnds2_epi64(state_b, state_a, _mm256_castsi256_si128(tmp_a));
+    msg_d = _mm256_sha512msg1_epi64(msg_d, _mm256_castsi256_si128(msg_a));
+    tmp_a = _mm256_permute4x64_epi64(msg_b, ltc_permute_epi64_k(any, 0x3, 0x2, 0x1));
+    tmp_b = _mm256_permute4x64_epi64(msg_c, ltc_permute_epi64_k(0x0, any, any, any));
+    tmp_a = ltc_mm256_blend_epi64(tmp_a, tmp_b, ltc_blend_epi64_k(0x1, 0x0, 0x0, 0x0));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_d);
+    msg_d = _mm256_sha512msg2_epi64(tmp_a, msg_c);
+    tmp_a = _mm256_load_si256(((__m256i const*)(&K[11 * (256 / (sizeof(ulong64) * CHAR_BIT))])));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_d);
+    state_a = _mm256_sha512rnds2_epi64(state_a, state_b, _mm256_castsi256_si128(tmp_a));
+    tmp_a = _mm256_permute4x64_epi64(tmp_a, ltc_permute_epi64_k(any, any, 0x3, 0x2));
+    state_b = _mm256_sha512rnds2_epi64(state_b, state_a, _mm256_castsi256_si128(tmp_a));
+    msg_a = _mm256_sha512msg1_epi64(msg_a, _mm256_castsi256_si128(msg_b));
+    tmp_a = _mm256_permute4x64_epi64(msg_c, ltc_permute_epi64_k(any, 0x3, 0x2, 0x1));
+    tmp_b = _mm256_permute4x64_epi64(msg_d, ltc_permute_epi64_k(0x0, any, any, any));
+    tmp_a = ltc_mm256_blend_epi64(tmp_a, tmp_b, ltc_blend_epi64_k(0x1, 0x0, 0x0, 0x0));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_a);
+    msg_a = _mm256_sha512msg2_epi64(tmp_a, msg_d);
+    tmp_a = _mm256_load_si256(((__m256i const*)(&K[12 * (256 / (sizeof(ulong64) * CHAR_BIT))])));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_a);
+    state_a = _mm256_sha512rnds2_epi64(state_a, state_b, _mm256_castsi256_si128(tmp_a));
+    tmp_a = _mm256_permute4x64_epi64(tmp_a, ltc_permute_epi64_k(any, any, 0x3, 0x2));
+    state_b = _mm256_sha512rnds2_epi64(state_b, state_a, _mm256_castsi256_si128(tmp_a));
+    msg_b = _mm256_sha512msg1_epi64(msg_b, _mm256_castsi256_si128(msg_c));
+    tmp_a = _mm256_permute4x64_epi64(msg_d, ltc_permute_epi64_k(any, 0x3, 0x2, 0x1));
+    tmp_b = _mm256_permute4x64_epi64(msg_a, ltc_permute_epi64_k(0x0, any, any, any));
+    tmp_a = ltc_mm256_blend_epi64(tmp_a, tmp_b, ltc_blend_epi64_k(0x1, 0x0, 0x0, 0x0));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_b);
+    msg_b = _mm256_sha512msg2_epi64(tmp_a, msg_a);
+    tmp_a = _mm256_load_si256(((__m256i const*)(&K[13 * (256 / (sizeof(ulong64) * CHAR_BIT))])));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_b);
+    state_a = _mm256_sha512rnds2_epi64(state_a, state_b, _mm256_castsi256_si128(tmp_a));
+    tmp_a = _mm256_permute4x64_epi64(tmp_a, ltc_permute_epi64_k(any, any, 0x3, 0x2));
+    state_b = _mm256_sha512rnds2_epi64(state_b, state_a, _mm256_castsi256_si128(tmp_a));
+    msg_c = _mm256_sha512msg1_epi64(msg_c, _mm256_castsi256_si128(msg_d));
+    tmp_a = _mm256_permute4x64_epi64(msg_a, ltc_permute_epi64_k(any, 0x3, 0x2, 0x1));
+    tmp_b = _mm256_permute4x64_epi64(msg_b, ltc_permute_epi64_k(0x0, any, any, any));
+    tmp_a = ltc_mm256_blend_epi64(tmp_a, tmp_b, ltc_blend_epi64_k(0x1, 0x0, 0x0, 0x0));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_c);
+    msg_c = _mm256_sha512msg2_epi64(tmp_a, msg_b);
+    tmp_a = _mm256_load_si256(((__m256i const*)(&K[14 * (256 / (sizeof(ulong64) * CHAR_BIT))])));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_c);
+    state_a = _mm256_sha512rnds2_epi64(state_a, state_b, _mm256_castsi256_si128(tmp_a));
+    tmp_a = _mm256_permute4x64_epi64(tmp_a, ltc_permute_epi64_k(any, any, 0x3, 0x2));
+    state_b = _mm256_sha512rnds2_epi64(state_b, state_a, _mm256_castsi256_si128(tmp_a));
+    msg_d = _mm256_sha512msg1_epi64(msg_d, _mm256_castsi256_si128(msg_a));
+    tmp_a = _mm256_permute4x64_epi64(msg_b, ltc_permute_epi64_k(any, 0x3, 0x2, 0x1));
+    tmp_b = _mm256_permute4x64_epi64(msg_c, ltc_permute_epi64_k(0x0, any, any, any));
+    tmp_a = ltc_mm256_blend_epi64(tmp_a, tmp_b, ltc_blend_epi64_k(0x1, 0x0, 0x0, 0x0));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_d);
+    msg_d = _mm256_sha512msg2_epi64(tmp_a, msg_c);
+    tmp_a = _mm256_load_si256(((__m256i const*)(&K[15 * (256 / (sizeof(ulong64) * CHAR_BIT))])));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_d);
+    state_a = _mm256_sha512rnds2_epi64(state_a, state_b, _mm256_castsi256_si128(tmp_a));
+    tmp_a = _mm256_permute4x64_epi64(tmp_a, ltc_permute_epi64_k(any, any, 0x3, 0x2));
+    state_b = _mm256_sha512rnds2_epi64(state_b, state_a, _mm256_castsi256_si128(tmp_a));
+    msg_a = _mm256_sha512msg1_epi64(msg_a, _mm256_castsi256_si128(msg_b));
+    tmp_a = _mm256_permute4x64_epi64(msg_c, ltc_permute_epi64_k(any, 0x3, 0x2, 0x1));
+    tmp_b = _mm256_permute4x64_epi64(msg_d, ltc_permute_epi64_k(0x0, any, any, any));
+    tmp_a = ltc_mm256_blend_epi64(tmp_a, tmp_b, ltc_blend_epi64_k(0x1, 0x0, 0x0, 0x0));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_a);
+    msg_a = _mm256_sha512msg2_epi64(tmp_a, msg_d);
+    tmp_a = _mm256_load_si256(((__m256i const*)(&K[16 * (256 / (sizeof(ulong64) * CHAR_BIT))])));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_a);
+    state_a = _mm256_sha512rnds2_epi64(state_a, state_b, _mm256_castsi256_si128(tmp_a));
+    tmp_a = _mm256_permute4x64_epi64(tmp_a, ltc_permute_epi64_k(any, any, 0x3, 0x2));
+    state_b = _mm256_sha512rnds2_epi64(state_b, state_a, _mm256_castsi256_si128(tmp_a));
+    msg_b = _mm256_sha512msg1_epi64(msg_b, _mm256_castsi256_si128(msg_c));
+    tmp_a = _mm256_permute4x64_epi64(msg_d, ltc_permute_epi64_k(any, 0x3, 0x2, 0x1));
+    tmp_b = _mm256_permute4x64_epi64(msg_a, ltc_permute_epi64_k(0x0, any, any, any));
+    tmp_a = ltc_mm256_blend_epi64(tmp_a, tmp_b, ltc_blend_epi64_k(0x1, 0x0, 0x0, 0x0));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_b);
+    msg_b = _mm256_sha512msg2_epi64(tmp_a, msg_a);
+    tmp_a = _mm256_load_si256(((__m256i const*)(&K[17 * (256 / (sizeof(ulong64) * CHAR_BIT))])));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_b);
+    state_a = _mm256_sha512rnds2_epi64(state_a, state_b, _mm256_castsi256_si128(tmp_a));
+    tmp_a = _mm256_permute4x64_epi64(tmp_a, ltc_permute_epi64_k(any, any, 0x3, 0x2));
+    state_b = _mm256_sha512rnds2_epi64(state_b, state_a, _mm256_castsi256_si128(tmp_a));
+    msg_c = _mm256_sha512msg1_epi64(msg_c, _mm256_castsi256_si128(msg_d));
+    tmp_a = _mm256_permute4x64_epi64(msg_a, ltc_permute_epi64_k(any, 0x3, 0x2, 0x1));
+    tmp_b = _mm256_permute4x64_epi64(msg_b, ltc_permute_epi64_k(0x0, any, any, any));
+    tmp_a = ltc_mm256_blend_epi64(tmp_a, tmp_b, ltc_blend_epi64_k(0x1, 0x0, 0x0, 0x0));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_c);
+    msg_c = _mm256_sha512msg2_epi64(tmp_a, msg_b);
+    tmp_a = _mm256_load_si256(((__m256i const*)(&K[18 * (256 / (sizeof(ulong64) * CHAR_BIT))])));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_c);
+    state_a = _mm256_sha512rnds2_epi64(state_a, state_b, _mm256_castsi256_si128(tmp_a));
+    tmp_a = _mm256_permute4x64_epi64(tmp_a, ltc_permute_epi64_k(any, any, 0x3, 0x2));
+    state_b = _mm256_sha512rnds2_epi64(state_b, state_a, _mm256_castsi256_si128(tmp_a));
+    msg_d = _mm256_sha512msg1_epi64(msg_d, _mm256_castsi256_si128(msg_a));
+    tmp_a = _mm256_permute4x64_epi64(msg_b, ltc_permute_epi64_k(any, 0x3, 0x2, 0x1));
+    tmp_b = _mm256_permute4x64_epi64(msg_c, ltc_permute_epi64_k(0x0, any, any, any));
+    tmp_a = ltc_mm256_blend_epi64(tmp_a, tmp_b, ltc_blend_epi64_k(0x1, 0x0, 0x0, 0x0));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_d);
+    msg_d = _mm256_sha512msg2_epi64(tmp_a, msg_c);
+    tmp_a = _mm256_load_si256(((__m256i const*)(&K[19 * (256 / (sizeof(ulong64) * CHAR_BIT))])));
+    tmp_a = _mm256_add_epi64(tmp_a, msg_d);
+    state_a = _mm256_sha512rnds2_epi64(state_a, state_b, _mm256_castsi256_si128(tmp_a));
+    tmp_a = _mm256_permute4x64_epi64(tmp_a, ltc_permute_epi64_k(any, any, 0x3, 0x2));
+    state_b = _mm256_sha512rnds2_epi64(state_b, state_a, _mm256_castsi256_si128(tmp_a));
+    state_a = _mm256_add_epi64(state_a, old_a);
+    state_b = _mm256_add_epi64(state_b, old_b);
+
+    tmp_a = _mm256_permute4x64_epi64(state_b, ltc_permute_epi64_k(any, any, 0x2, 0x3));
+    tmp_b = _mm256_permute4x64_epi64(state_a, ltc_permute_epi64_k(0x2, 0x3, any, any));
+    tmp_c = _mm256_permute4x64_epi64(state_b, ltc_permute_epi64_k(any, any, 0x0, 0x1));
+    tmp_d = _mm256_permute4x64_epi64(state_a, ltc_permute_epi64_k(0x0, 0x1, any, any));
+    state_a = ltc_mm256_blend_epi64(tmp_a, tmp_b, ltc_blend_epi64_k(0x1, 0x1, 0x0, 0x0));
+    state_b = ltc_mm256_blend_epi64(tmp_c, tmp_d, ltc_blend_epi64_k(0x1, 0x1, 0x0, 0x0));
+    _mm256_storeu_si256(((__m256i*)(&md->sha512.state[0])), state_a);
+    _mm256_storeu_si256(((__m256i*)(&md->sha512.state[4])), state_b);
+  return CRYPT_OK;
+
+#undef ltc_permute_epi64_k
+#undef ltc_blend_epi32_k
+#undef ltc_blend_epi64_k
+#undef ltc_mm256_blend_epi64
+#undef any
+}
+#undef K
+
+/* compress 1024-bits */
+#ifdef LTC_CLEAN_STACK
+static int s_sha512_x86_compress(hash_state * md, const unsigned char *buf)
+{
+    int err;
+    err = ss_sha512_x86_compress(md, buf);
+    burn_stack(sizeof(ulong64) * 90 + sizeof(int));
+    return err;
+}
+#endif
+
+/**
+   Process a block of memory though the hash
+   @param md     The hash state
+   @param in     The data to hash
+   @param inlen  The length of the data (octets)
+   @return CRYPT_OK if successful
+*/
+HASH_PROCESS(sha512_x86_process, s_sha512_x86_compress, sha512, 128)
+
+/**
+   Terminate the hash to get the digest
+   @param md  The hash state
+   @param out [out] The destination of the hash (64 bytes)
+   @return CRYPT_OK if successful
+*/
+int sha512_x86_done(hash_state * md, unsigned char *out)
+{
+    int i;
+
+    LTC_ARGCHK(md  != NULL);
+    LTC_ARGCHK(out != NULL);
+
+    if (md->sha512.curlen >= sizeof(md->sha512.buf)) {
+       return CRYPT_INVALID_ARG;
+    }
+
+
+    /* increase the length of the message */
+    md->sha512.length += md->sha512.curlen * CONST64(8);
+
+    /* append the '1' bit */
+    md->sha512.buf[md->sha512.curlen++] = (unsigned char)0x80;
+
+    /* if the length is currently above 112 bytes we append zeros
+     * then compress.  Then we can fall back to padding zeros and length
+     * encoding like normal.
+     */
+    if (md->sha512.curlen > 112) {
+        while (md->sha512.curlen < 128) {
+            md->sha512.buf[md->sha512.curlen++] = (unsigned char)0;
+        }
+        s_sha512_x86_compress(md, md->sha512.buf);
+        md->sha512.curlen = 0;
+    }
+
+    /* pad upto 120 bytes of zeroes
+     * note: that from 112 to 120 is the 64 MSB of the length.  We assume that you won't hash
+     * > 2^64 bits of data... :-)
+     */
+    while (md->sha512.curlen < 120) {
+        md->sha512.buf[md->sha512.curlen++] = (unsigned char)0;
+    }
+
+    /* store length */
+    STORE64H(md->sha512.length, md->sha512.buf+120);
+    s_sha512_x86_compress(md, md->sha512.buf);
+
+    /* copy output */
+    for (i = 0; i < 8; i++) {
+        STORE64H(md->sha512.state[i], out+(8*i));
+    }
+#ifdef LTC_CLEAN_STACK
+    zeromem(md, sizeof(hash_state));
+#endif
+    return CRYPT_OK;
+}
+
+/**
+  Self-test the hash
+  @return CRYPT_OK if successful, CRYPT_NOP if self-tests have been disabled
+*/
+int sha512_x86_test(void)
+{
+   return sha512_test_desc(&sha512_x86_desc, "SHA512 x86");
+}
+
+#endif /* defined(LTC_SHA512) && defined(LTC_SHA512_X86) */

--- a/src/headers/tomcrypt_cfg.h
+++ b/src/headers/tomcrypt_cfg.h
@@ -342,9 +342,10 @@ typedef unsigned long ltc_mp_digit;
          #define LTC_SHA256_X86
       #endif
    #endif
-   /* the SHA512 extension intrinsics require GCC 14 resp. clang 17 (MSVC doesn't support them yet) */
+   /* the SHA512 extension intrinsics require GCC 14 resp. clang 17 */
    #if (defined __GNUC__ && !defined __clang__ && (__GNUC__ >= 14)) || \
-       (defined __clang__ && (__clang_major__ >= 17))
+       (defined __clang__ && (__clang_major__ >= 17)) || \
+       (defined _MSC_FULL_VER && (_MSC_FULL_VER) >=  194033813l) /* MSVC 2022 17.10 */
       #if !defined(LTC_NO_SHA384_X86)
          #define LTC_SHA384_X86
       #endif

--- a/src/headers/tomcrypt_cfg.h
+++ b/src/headers/tomcrypt_cfg.h
@@ -342,6 +342,22 @@ typedef unsigned long ltc_mp_digit;
          #define LTC_SHA256_X86
       #endif
    #endif
+   /* the SHA512 extension intrinsics require GCC 14 resp. clang 17 (MSVC doesn't support them yet) */
+   #if (defined __GNUC__ && !defined __clang__ && (__GNUC__ >= 14)) || \
+       (defined __clang__ && (__clang_major__ >= 17))
+      #if !defined(LTC_NO_SHA384_X86)
+         #define LTC_SHA384_X86
+      #endif
+      #if !defined(LTC_NO_SHA512_X86)
+         #define LTC_SHA512_X86
+      #endif
+      #if !defined(LTC_NO_SHA512_224_X86)
+         #define LTC_SHA512_224_X86
+      #endif
+      #if !defined(LTC_NO_SHA512_256_X86)
+         #define LTC_SHA512_256_X86
+      #endif
+   #endif
 #endif
 
 #if defined(__aarch64__) || defined(_M_ARM64)

--- a/src/headers/tomcrypt_hash.h
+++ b/src/headers/tomcrypt_hash.h
@@ -361,7 +361,21 @@ int sha512_process(hash_state * md, const unsigned char *in, unsigned long inlen
 int sha512_done(hash_state * md, unsigned char *out);
 int sha512_test(void);
 extern const struct ltc_hash_descriptor sha512_desc;
-#endif
+
+#define sha512_c_init sha512_init
+int sha512_c_process(hash_state * md, const unsigned char *in, unsigned long inlen);
+int sha512_c_done(hash_state * md, unsigned char *out);
+int sha512_c_test(void);
+extern const struct ltc_hash_descriptor sha512_portable_desc;
+
+#ifdef LTC_SHA512_X86
+#define sha512_x86_init sha512_init
+int sha512_x86_process(hash_state * md, const unsigned char *in, unsigned long inlen);
+int sha512_x86_done(hash_state * md, unsigned char *out);
+int sha512_x86_test(void);
+extern const struct ltc_hash_descriptor sha512_x86_desc;
+#endif /* LTC_SHA512_X86 */
+#endif /* LTC_SHA512 */
 
 #ifdef LTC_SHA384
 #ifndef LTC_SHA512
@@ -372,7 +386,21 @@ int sha384_init(hash_state * md);
 int sha384_done(hash_state * md, unsigned char *out);
 int sha384_test(void);
 extern const struct ltc_hash_descriptor sha384_desc;
-#endif
+
+#define sha384_c_init sha384_init
+#define sha384_c_process sha512_c_process
+int sha384_c_done(hash_state * md, unsigned char *out);
+int sha384_c_test(void);
+extern const struct ltc_hash_descriptor sha384_portable_desc;
+
+#ifdef LTC_SHA384_X86
+#define sha384_x86_init sha384_init
+#define sha384_x86_process sha512_x86_process
+int sha384_x86_done(hash_state * md, unsigned char *out);
+int sha384_x86_test(void);
+extern const struct ltc_hash_descriptor sha384_x86_desc;
+#endif /* LTC_SHA384_X86 */
+#endif /* LTC_SHA384 */
 
 #ifdef LTC_SHA512_256
 #ifndef LTC_SHA512
@@ -383,6 +411,20 @@ int sha512_256_init(hash_state * md);
 int sha512_256_done(hash_state * md, unsigned char *out);
 int sha512_256_test(void);
 extern const struct ltc_hash_descriptor sha512_256_desc;
+
+#define sha512_256_c_init sha512_256_init
+#define sha512_256_c_process sha512_c_process
+int sha512_256_c_done(hash_state * md, unsigned char *out);
+int sha512_256_c_test(void);
+extern const struct ltc_hash_descriptor sha512_256_portable_desc;
+
+#ifdef LTC_SHA512_256_X86
+#define sha512_256_x86_init sha512_256_init
+#define sha512_256_x86_process sha512_x86_process
+int sha512_256_x86_done(hash_state * md, unsigned char *out);
+int sha512_256_x86_test(void);
+extern const struct ltc_hash_descriptor sha512_256_x86_desc;
+#endif /* LTC_SHA512_256_X86 */
 #endif /* LTC_SHA512_256 */
 
 #ifdef LTC_SHA512_224
@@ -394,9 +436,24 @@ int sha512_224_init(hash_state * md);
 int sha512_224_done(hash_state * md, unsigned char *out);
 int sha512_224_test(void);
 extern const struct ltc_hash_descriptor sha512_224_desc;
+
+#define sha512_224_c_init sha512_224_init
+#define sha512_224_c_process sha512_c_process
+int sha512_224_c_done(hash_state * md, unsigned char *out);
+int sha512_224_c_test(void);
+extern const struct ltc_hash_descriptor sha512_224_portable_desc;
+
+#ifdef LTC_SHA512_224_X86
+#define sha512_224_x86_init sha512_224_init
+#define sha512_224_x86_process sha512_x86_process
+int sha512_224_x86_done(hash_state * md, unsigned char *out);
+int sha512_224_x86_test(void);
+extern const struct ltc_hash_descriptor sha512_224_x86_desc;
+#endif /* LTC_SHA512_224_X86 */
 #endif /* LTC_SHA512_224 */
 
 int shani_is_supported(void);
+int sha512ni_is_supported(void);
 
 #ifdef LTC_SHA256
 int sha256_init(hash_state * md);

--- a/src/headers/tomcrypt_private.h
+++ b/src/headers/tomcrypt_private.h
@@ -270,6 +270,7 @@ int func_name (hash_state * md, const unsigned char *in, unsigned long inlen)   
 
 
 #define LTC_SHA_TARGET LTC_ATTRIBUTE((__target__("sse2,ssse3,sse4.1,sha")))
+#define LTC_SHA512_TARGET LTC_ATTRIBUTE((__target__("avx2,sha512")))
 
 #ifdef LTC_SHA1
 int sha1_test_desc(const struct ltc_hash_descriptor *desc, const char *name);
@@ -279,6 +280,18 @@ int sha224_test_desc(const struct ltc_hash_descriptor *desc, const char *name);
 #endif
 #ifdef LTC_SHA256
 int sha256_test_desc(const struct ltc_hash_descriptor *desc, const char *name);
+#endif
+#ifdef LTC_SHA384
+int sha384_test_desc(const struct ltc_hash_descriptor *desc, const char *name);
+#endif
+#ifdef LTC_SHA512
+int sha512_test_desc(const struct ltc_hash_descriptor *desc, const char *name);
+#endif
+#ifdef LTC_SHA512_224
+int sha512_224_test_desc(const struct ltc_hash_descriptor *desc, const char *name);
+#endif
+#ifdef LTC_SHA512_256
+int sha512_256_test_desc(const struct ltc_hash_descriptor *desc, const char *name);
 #endif
 
 #ifdef LTC_KMAC

--- a/src/misc/crypt/crypt.c
+++ b/src/misc/crypt/crypt.c
@@ -536,6 +536,18 @@ const char *crypt_build_settings =
 #if defined(LTC_SHA256) && defined(LTC_SHA256_X86)
    " SHA256-NI "
 #endif
+#if defined(LTC_SHA384) && defined(LTC_SHA384_X86)
+   " SHA384-NI "
+#endif
+#if defined(LTC_SHA512) && defined(LTC_SHA512_X86)
+   " SHA512-NI "
+#endif
+#if defined(LTC_SHA512_224) && defined(LTC_SHA512_224_X86)
+   " SHA512-224-NI "
+#endif
+#if defined(LTC_SHA512_256) && defined(LTC_SHA512_256_X86)
+   " SHA512-256-NI "
+#endif
 #if defined(LTC_DEVRANDOM)
     " LTC_DEVRANDOM "
 #endif

--- a/src/misc/crypt/crypt_register_all_hashes.c
+++ b/src/misc/crypt/crypt_register_all_hashes.c
@@ -16,6 +16,7 @@
 int register_all_hashes(void)
 {
 #ifdef LTC_SHA512
+   /* `sha512_desc` does the multiplexing into `sha512_x86_desc` resp. `sha512_portable_desc` depending on the capabilities of the CPU. */
    REGISTER_HASH(&sha512_desc);
 #endif
 #ifdef LTC_SHA256
@@ -33,9 +34,11 @@ int register_all_hashes(void)
    REGISTER_HASH(&shake256_desc);
 #endif
 #ifdef LTC_SHA512_256
+   /* `sha512_256_desc` does the multiplexing into `sha512_256_x86_desc` resp. `sha512_256_portable_desc` depending on the capabilities of the CPU. */
    REGISTER_HASH(&sha512_256_desc);
 #endif
 #ifdef LTC_SHA512_224
+   /* `sha512_224_desc` does the multiplexing into `sha512_224_x86_desc` resp. `sha512_224_portable_desc` depending on the capabilities of the CPU. */
    REGISTER_HASH(&sha512_224_desc);
 #endif
 #ifdef LTC_SHA224
@@ -45,6 +48,7 @@ int register_all_hashes(void)
    REGISTER_HASH(&sha224_desc);
 #endif
 #ifdef LTC_SHA384
+   /* `sha384_desc` does the multiplexing into `sha384_x86_desc` resp. `sha384_portable_desc` depending on the capabilities of the CPU. */
    REGISTER_HASH(&sha384_desc);
 #endif
 #ifdef LTC_SHA1

--- a/tests/cipher_hash_test.c
+++ b/tests/cipher_hash_test.c
@@ -121,6 +121,24 @@ int cipher_hash_test(void)
       DO(s_hash_state_clone_test(&sha1_x86_desc, "sha1-x86-clone"));
 #endif
    }
+   if (sha512ni_is_supported()) {
+#if defined(LTC_SHA512) && defined(LTC_SHA512_X86)
+      DO(sha512_x86_test());
+      DO(s_hash_state_clone_test(&sha512_x86_desc, "sha512-x86-clone"));
+#endif
+#if defined(LTC_SHA384) && defined(LTC_SHA384_X86)
+      DO(sha384_x86_test());
+      DO(s_hash_state_clone_test(&sha384_x86_desc, "sha384-x86-clone"));
+#endif
+#if defined(LTC_SHA512_224) && defined(LTC_SHA512_224_X86)
+      DO(sha512_224_x86_test());
+      DO(s_hash_state_clone_test(&sha512_224_x86_desc, "sha512-224-x86-clone"));
+#endif
+#if defined(LTC_SHA512_256) && defined(LTC_SHA512_256_X86)
+      DO(sha512_256_x86_test());
+      DO(s_hash_state_clone_test(&sha512_256_x86_desc, "sha512-256-x86-clone"));
+#endif
+   }
 #if defined(LTC_SHA256)
    DO(sha256_c_test());
    DO(s_hash_state_clone_test(&sha256_portable_desc, "sha256-c-clone"));
@@ -132,6 +150,22 @@ int cipher_hash_test(void)
 #if defined(LTC_SHA1)
    DO(sha1_c_test());
    DO(s_hash_state_clone_test(&sha1_portable_desc, "sha1-c-clone"));
+#endif
+#if defined(LTC_SHA512)
+   DO(sha512_c_test());
+   DO(s_hash_state_clone_test(&sha512_portable_desc, "sha512-c-clone"));
+#endif
+#if defined(LTC_SHA384)
+   DO(sha384_c_test());
+   DO(s_hash_state_clone_test(&sha384_portable_desc, "sha384-c-clone"));
+#endif
+#if defined(LTC_SHA512_224)
+   DO(sha512_224_c_test());
+   DO(s_hash_state_clone_test(&sha512_224_portable_desc, "sha512-224-c-clone"));
+#endif
+#if defined(LTC_SHA512_256)
+   DO(sha512_256_c_test());
+   DO(s_hash_state_clone_test(&sha512_256_portable_desc, "sha512-256-c-clone"));
 #endif
 #ifdef LTC_SHA3
    /* SHAKE128 + SHAKE256 tests are a bit special */

--- a/tests/test.c
+++ b/tests/test.c
@@ -238,15 +238,19 @@ static void s_unregister_all(void)
   unregister_hash(&sha256_desc);
 #endif
 #ifdef LTC_SHA384
+  /* `register_all_hashes()` does not register `sha384_portable_desc` nor `sha384_x86_desc`, so we don't have to unregister them */
   unregister_hash(&sha384_desc);
 #endif
 #ifdef LTC_SHA512
+  /* `register_all_hashes()` does not register `sha512_portable_desc` nor `sha512_x86_desc`, so we don't have to unregister them */
   unregister_hash(&sha512_desc);
 #endif
 #ifdef LTC_SHA512_224
+  /* `register_all_hashes()` does not register `sha512_224_portable_desc` nor `sha512_224_x86_desc`, so we don't have to unregister them */
   unregister_hash(&sha512_224_desc);
 #endif
 #ifdef LTC_SHA512_256
+  /* `register_all_hashes()` does not register `sha512_256_portable_desc` nor `sha512_256_x86_desc`, so we don't have to unregister them */
   unregister_hash(&sha512_256_desc);
 #endif
 #ifdef LTC_SHA3
@@ -393,6 +397,7 @@ int main(int argc, char **argv)
 
    printf("AES-NI CPU support = %d\n", aesni_is_supported());
    printf("SHA-NI CPU support = %d\n", shani_is_supported());
+   printf("SHA512-NI CPU support = %d\n", sha512ni_is_supported());
    printf("PMUL CPU support = %d\n", gcm_hw_pmul_is_supported());
    putchar('\n');
 


### PR DESCRIPTION
This is an alternative to #731

@MarekKnapek I have taken your `sha512_x86.c` from #731 and:
* applied the aligned/unaligned access patch (`_mm256_load_si256/_mm256_store_si256` >> `_mm256_loadu_si256/_mm256_storeu_si256`)
* made a few other tweaks needed to fit the latest sha1/sha2 changes
* basically following approach used in sha256_x86 in current `develop` as much as possible

Could you please test whether this PR works as expected?