### PR TITLE
Small fixes

### DIFF
--- a/src/hashes/helper/hash_memory.c
+++ b/src/hashes/helper/hash_memory.c
@@ -19,8 +19,9 @@
 */
 int hash_memory(int hash, const unsigned char *in, unsigned long inlen, unsigned char *out, unsigned long *outlen)
 {
-    hash_state *md;
-    int err;
+    hash_state    *md;
+    unsigned long hashsize;
+    int           err;
 
     LTC_ARGCHK(in     != NULL);
     LTC_ARGCHK(out    != NULL);
@@ -30,8 +31,10 @@ int hash_memory(int hash, const unsigned char *in, unsigned long inlen, unsigned
         return err;
     }
 
-    if (*outlen < hash_descriptor[hash].hashsize) {
-       *outlen = hash_descriptor[hash].hashsize;
+    hashsize = hash_descriptor[hash].hashsize;
+
+    if (*outlen < hashsize) {
+       *outlen = hashsize;
        return CRYPT_BUFFER_OVERFLOW;
     }
 
@@ -47,7 +50,7 @@ int hash_memory(int hash, const unsigned char *in, unsigned long inlen, unsigned
        goto LBL_ERR;
     }
     err = hash_descriptor[hash].done(md, out);
-    *outlen = hash_descriptor[hash].hashsize;
+    *outlen = hashsize;
 LBL_ERR:
 #ifdef LTC_CLEAN_STACK
     zeromem(md, sizeof(hash_state));

--- a/src/headers/tomcrypt_cfg.h
+++ b/src/headers/tomcrypt_cfg.h
@@ -257,16 +257,6 @@ typedef unsigned long ltc_mp_digit;
    #define LTC_NO_ROTATE
 #endif
 
-/* Just portable C implementations */
-#ifdef LTC_NO_ACCEL
-   #define LTC_NO_AES_NI
-   #define LTC_NO_GCM_PCLMUL
-   #define LTC_NO_GCM_PMULL
-   #define LTC_NO_SHA1_X86
-   #define LTC_NO_SHA224_X86
-   #define LTC_NO_SHA256_X86
-#endif
-
 /* No LTC_FAST if explicitly disabled */
 #if defined(LTC_NO_FAST)
    #undef LTC_FAST
@@ -322,6 +312,16 @@ typedef unsigned long ltc_mp_digit;
 
 #if (defined(__x86_64__) || defined(__i386__) || defined(_M_X64) || defined(_M_IX86))
    #define LTC_ARCH_X86
+#endif
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+   #define LTC_ARCH_AARCH64
+#endif
+
+/* Just portable C implementations, LTC_NO_ACCEL disables all the CPU-specific ones at once */
+#ifndef LTC_NO_ACCEL
+
+#ifdef LTC_ARCH_X86
    #if !defined(LTC_NO_AES_NI)
       #define LTC_AES_NI
    #endif
@@ -359,15 +359,16 @@ typedef unsigned long ltc_mp_digit;
          #define LTC_SHA512_256_X86
       #endif
    #endif
-#endif
+#endif /* LTC_ARCH_X86 */
 
-#if defined(__aarch64__) || defined(_M_ARM64)
-   #define LTC_ARCH_AARCH64
+#ifdef LTC_ARCH_AARCH64
    #if !defined(LTC_NO_GCM_PMULL)
       #define LTC_GCM_PMULL
       #undef LTC_GCM_TABLES
    #endif
-#endif
+#endif /* LTC_ARCH_AARCH64 */
+
+#endif /* LTC_NO_ACCEL */
 
 #if defined(__GNUC__)
    #define LTC_ALIGN_MSVC(n)

--- a/src/headers/tomcrypt_pk.h
+++ b/src/headers/tomcrypt_pk.h
@@ -297,13 +297,8 @@ int dh_export_key(void *out, unsigned long *outlen, int type, const dh_key *key)
 
 
 /* ---- ECC Routines ---- */
-#ifdef LTC_MECC
 
-/* size of our temp buffers for exported keys */
-#define ECC_BUF_SIZE 256
-
-/* max private key size */
-#define ECC_MAXSIZE  66
+/* the curve type is required even without LTC_MECC, e.g. by the SSH PEM decoder */
 
 /** Structure defines a GF(p) curve */
 typedef struct {
@@ -331,6 +326,14 @@ typedef struct {
    /** The OID */
    const char *OID;
 } ltc_ecc_curve;
+
+#ifdef LTC_MECC
+
+/* size of our temp buffers for exported keys */
+#define ECC_BUF_SIZE 256
+
+/* max private key size */
+#define ECC_MAXSIZE  66
 
 /** A point on a ECC curve, stored in Jacbobian format such that (x,y,z) => (x/z^2, y/z^3, 1) when interpretted as affine */
 typedef struct {

--- a/src/headers/tomcrypt_private.h
+++ b/src/headers/tomcrypt_private.h
@@ -968,6 +968,8 @@ int ltc_pkcs_1_mgf1(int                  hash_idx,
                     const unsigned char *seed, unsigned long seedlen,
                           unsigned char *mask, unsigned long masklen);
 
+/* OAEP/PSS padding requires the RSA parameter helpers */
+#ifdef LTC_MRSA
 int ltc_pkcs_1_pss_encode_mgf1(const unsigned char *msghash,       unsigned long  msghashlen,
                              ltc_rsa_op_parameters *params,
                                      unsigned long  modulus_bitlen,
@@ -985,6 +987,7 @@ int ltc_pkcs_1_oaep_decode(const unsigned char *msg,    unsigned long msglen,
                                  unsigned long  modulus_bitlen,
                                  unsigned char *out,    unsigned long *outlen,
                                  int           *res);
+#endif /* LTC_MRSA */
 
 int ltc_pkcs_1_v1_5_encode(const unsigned char *msg,
                                  unsigned long  msglen,

--- a/src/mac/hmac/hmac_init.c
+++ b/src/mac/hmac/hmac_init.c
@@ -64,7 +64,7 @@ int hmac_init(hmac_state *hmac, int hash, const unsigned char *key, unsigned lon
     }
 
     /* Create the initialization vector for step (3) */
-    for(i=0; i < LTC_HMAC_BLOCKSIZE;   i++) {
+    for(i=0; i < LTC_HMAC_BLOCKSIZE; i++) {
        buf[i] = hmac->key[i] ^ 0x36;
     }
 

--- a/src/misc/deprecated.c
+++ b/src/misc/deprecated.c
@@ -256,6 +256,8 @@ int pkcs_1_mgf1(int                  hash_idx,
 {
    return ltc_pkcs_1_mgf1(hash_idx, seed, seedlen, mask, masklen);
 }
+
+#ifdef LTC_MRSA
 /**
   PKCS #1 v2.00 OAEP encode
   @param msg             The data to encode
@@ -379,6 +381,7 @@ int pkcs_1_pss_decode(const unsigned char *msghash, unsigned long msghashlen,
    }
    return ltc_pkcs_1_pss_decode_mgf1(msghash, msghashlen, sig, siglen, &params, modulus_bitlen, res);
 }
+#endif /* LTC_MRSA */
 
 
 /*! \brief PKCS #1 v1.5 encode.

--- a/src/misc/mem_neq.c
+++ b/src/misc/mem_neq.c
@@ -28,9 +28,9 @@
 */
 int mem_neq(const void *a, const void *b, size_t len)
 {
-   unsigned char ret = 0;
-   const unsigned char* pa;
-   const unsigned char* pb;
+   volatile unsigned char ret = 0;
+   const volatile unsigned char *pa;
+   const volatile unsigned char *pb;
 
    LTC_ARGCHK(a != NULL);
    LTC_ARGCHK(b != NULL);

--- a/src/pk/asn1/der/choice/der_decode_choice.c
+++ b/src/pk/asn1/der/choice/der_decode_choice.c
@@ -109,7 +109,7 @@ int der_decode_choice(const unsigned char *in,   unsigned long *inlen,
            case LTC_ASN1_NULL:
                if (*inlen == 2 && in[x] == 0x05 && in[x+1] == 0x00) {
                   *inlen = 2;
-                  list[x].used   = 1;
+                  list[x].used = 1;
                   return CRYPT_OK;
                }
                break;

--- a/src/pk/asn1/der/generalizedtime/der_decode_generalizedtime.c
+++ b/src/pk/asn1/der/generalizedtime/der_decode_generalizedtime.c
@@ -88,14 +88,14 @@ int der_decode_generalizedtime(const unsigned char *in, unsigned long *inlen,
    }
 
    /* possible encodings are
-YYYYMMDDhhmmssZ
-YYYYMMDDhhmmss+hh'mm'
-YYYYMMDDhhmmss-hh'mm'
-YYYYMMDDhhmmss.fsZ
-YYYYMMDDhhmmss.fs+hh'mm'
-YYYYMMDDhhmmss.fs-hh'mm'
+      YYYYMMDDhhmmssZ
+      YYYYMMDDhhmmss+hh'mm'
+      YYYYMMDDhhmmss-hh'mm'
+      YYYYMMDDhhmmss.fsZ
+      YYYYMMDDhhmmss.fs+hh'mm'
+      YYYYMMDDhhmmss.fs-hh'mm'
 
-    So let's do a trivial decode upto [including] ss
+      So let's do a trivial decode upto [including] ss
    */
 
     x = 0;

--- a/src/pk/asn1/der/integer/der_decode_integer.c
+++ b/src/pk/asn1/der/integer/der_decode_integer.c
@@ -72,7 +72,6 @@ int der_decode_integer(const unsigned char *in, unsigned long inlen, void *num)
    }
 
    return CRYPT_OK;
-
 }
 
 #endif

--- a/src/pk/asn1/der/short_integer/der_decode_short_integer.c
+++ b/src/pk/asn1/der/short_integer/der_decode_short_integer.c
@@ -59,7 +59,6 @@ int der_decode_short_integer(const unsigned char *in, unsigned long inlen, unsig
    *num = y;
 
    return CRYPT_OK;
-
 }
 
 #endif

--- a/src/pk/asn1/der/utctime/der_decode_utctime.c
+++ b/src/pk/asn1/der/utctime/der_decode_utctime.c
@@ -69,16 +69,15 @@ int der_decode_utctime(const unsigned char *in, unsigned long *inlen,
    declen = x; /* octets decoded into buf - the parsing below must not read past them */
    *inlen = 2 + x;
 
-
    /* possible encodings are
-YYMMDDhhmmZ
-YYMMDDhhmm+hh'mm'
-YYMMDDhhmm-hh'mm'
-YYMMDDhhmmssZ
-YYMMDDhhmmss+hh'mm'
-YYMMDDhhmmss-hh'mm'
+      YYMMDDhhmmZ
+      YYMMDDhhmm+hh'mm'
+      YYMMDDhhmm-hh'mm'
+      YYMMDDhhmmssZ
+      YYMMDDhhmmss+hh'mm'
+      YYMMDDhhmmss-hh'mm'
 
-    So let's do a trivial decode upto [including] mm
+      So let's do a trivial decode upto [including] mm
    */
 
     x = 0;

--- a/src/pk/asn1/pkcs8/pkcs8_get.c
+++ b/src/pk/asn1/pkcs8/pkcs8_get.c
@@ -53,7 +53,25 @@ int pkcs8_get_children(const ltc_asn1_list *decoded_list, enum ltc_oid_id *pka, 
    if ((*alg_id == NULL) || ((*alg_id)->child == NULL) || (*priv_key == NULL)) {
       return CRYPT_INVALID_PACKET;
    }
-   return pk_get_oid_from_asn1((*alg_id)->child, pka);
+   if ((err = pk_get_oid_from_asn1((*alg_id)->child, pka)) != CRYPT_OK) {
+      return err;
+   }
+
+   switch (*pka) {
+      /* RFC 8410 requires the parameters field of the AlgorithmIdentifier to be absent */
+      case LTC_OID_X25519:
+      case LTC_OID_ED25519:
+      case LTC_OID_X448:
+      case LTC_OID_ED448:
+         if ((*alg_id)->child->next != NULL) {
+            return CRYPT_INVALID_PACKET;
+         }
+         break;
+      default:
+         break;
+   }
+
+   return CRYPT_OK;
 }
 
 #endif /* LTC_PKCS_8 */

--- a/src/pk/ecc/ecc_sign_hash_internal.c
+++ b/src/pk/ecc/ecc_sign_hash_internal.c
@@ -70,7 +70,7 @@ int ecc_sign_hash_internal(const unsigned char *in,  unsigned long inlen,
       if (opts->enable_recovery_id) {
          /* find recovery ID (if needed) */
          v = 0;
-         if (ltc_mp_copy(pubkey.pubkey.x, s) != CRYPT_OK)                      { goto error; }
+         if ((err = ltc_mp_copy(pubkey.pubkey.x, s)) != CRYPT_OK)              { goto error; }
          while (ltc_mp_cmp_d(s, 0) == LTC_MP_GT && ltc_mp_cmp(s, p) != LTC_MP_LT) {
             /* Compute x1 div n... this will almost never be reached for curves with order 1 */
             v += 2;
@@ -99,6 +99,7 @@ int ecc_sign_hash_internal(const unsigned char *in,  unsigned long inlen,
    } while (--max_iterations > 0);
 
    if (max_iterations == 0) {
+      err = CRYPT_ERROR;
       goto errnokey;
    }
 

--- a/src/pk/ecc/ecc_ssh_ecdsa_encode_name.c
+++ b/src/pk/ecc/ecc_ssh_ecdsa_encode_name.c
@@ -8,7 +8,7 @@
    Russ Williams
 */
 
-#ifdef LTC_SSH
+#if defined(LTC_MECC) && defined(LTC_SSH)
 
 /**
   Curve/OID to SSH+ECDSA name string mapping

--- a/src/pk/pkcs1/pkcs_1_oaep_decode.c
+++ b/src/pk/pkcs1/pkcs_1_oaep_decode.c
@@ -7,7 +7,7 @@
   OAEP Padding for PKCS #1, Tom St Denis
 */
 
-#ifdef LTC_PKCS_1
+#ifdef LTC_MRSA
 /**
    PKCS #1 v2.00 OAEP decode
    @param msg              The encoded data to decode
@@ -170,4 +170,4 @@ LBL_ERR:
    return err;
 }
 
-#endif /* LTC_PKCS_1 */
+#endif /* LTC_MRSA */

--- a/src/pk/pkcs1/pkcs_1_oaep_encode.c
+++ b/src/pk/pkcs1/pkcs_1_oaep_encode.c
@@ -7,7 +7,7 @@
   OAEP Padding for PKCS #1, Tom St Denis
 */
 
-#ifdef LTC_PKCS_1
+#ifdef LTC_MRSA
 /**
   PKCS #1 v2.00 OAEP encode
   @param msg             The data to encode
@@ -148,5 +148,5 @@ LBL_ERR:
    return err;
 }
 
-#endif /* LTC_PKCS_1 */
+#endif /* LTC_MRSA */
 

--- a/src/pk/pkcs1/pkcs_1_pss_decode.c
+++ b/src/pk/pkcs1/pkcs_1_pss_decode.c
@@ -7,7 +7,7 @@
   PKCS #1 PSS Signature Padding, Tom St Denis
 */
 
-#ifdef LTC_PKCS_1
+#ifdef LTC_MRSA
 
 /**
    PKCS #1 v2.00 Signature Verification
@@ -165,4 +165,4 @@ LBL_ERR:
    return err;
 }
 
-#endif /* LTC_PKCS_1 */
+#endif /* LTC_MRSA */

--- a/src/pk/pkcs1/pkcs_1_pss_decode.c
+++ b/src/pk/pkcs1/pkcs_1_pss_decode.c
@@ -25,7 +25,7 @@ int ltc_pkcs_1_pss_decode_mgf1(const unsigned char *msghash, unsigned long  msgh
                                ltc_rsa_op_parameters *params,
                                      unsigned long  modulus_bitlen,    int *res)
 {
-   unsigned char *DB, *mask, *salt, *hash;
+   unsigned char *DB, *mask, *hash;
    unsigned long x, y, hLen, modulus_len, saltlen;
    int           err;
    hash_state    md;
@@ -54,20 +54,16 @@ int ltc_pkcs_1_pss_decode_mgf1(const unsigned char *msghash, unsigned long  msgh
       return CRYPT_PK_INVALID_SIZE;
    }
 
-   /* allocate ram for DB/mask/salt/hash of size modulus_len */
+   /* allocate ram for DB/mask/hash of size modulus_len */
    DB   = XMALLOC(modulus_len);
    mask = XMALLOC(modulus_len);
-   salt = XMALLOC(modulus_len);
    hash = XMALLOC(modulus_len);
-   if (DB == NULL || mask == NULL || salt == NULL || hash == NULL) {
+   if (DB == NULL || mask == NULL || hash == NULL) {
       if (DB != NULL) {
          XFREE(DB);
       }
       if (mask != NULL) {
          XFREE(mask);
-      }
-      if (salt != NULL) {
-         XFREE(salt);
       }
       if (hash != NULL) {
          XFREE(hash);
@@ -153,12 +149,10 @@ LBL_ERR:
 #ifdef LTC_CLEAN_STACK
    zeromem(DB,   modulus_len);
    zeromem(mask, modulus_len);
-   zeromem(salt, modulus_len);
    zeromem(hash, modulus_len);
 #endif
 
    XFREE(hash);
-   XFREE(salt);
    XFREE(mask);
    XFREE(DB);
 

--- a/src/pk/pkcs1/pkcs_1_pss_encode.c
+++ b/src/pk/pkcs1/pkcs_1_pss_encode.c
@@ -70,7 +70,6 @@ int ltc_pkcs_1_pss_encode_mgf1(const unsigned char *msghash,       unsigned long
       return CRYPT_MEM;
    }
 
-
    /* generate random salt */
    if (saltlen > 0) {
       if (prng_descriptor[params->wprng].read(salt, saltlen, params->prng) != saltlen) {

--- a/src/pk/pkcs1/pkcs_1_pss_encode.c
+++ b/src/pk/pkcs1/pkcs_1_pss_encode.c
@@ -7,7 +7,7 @@
   PKCS #1 PSS Signature Padding, Tom St Denis
 */
 
-#ifdef LTC_PKCS_1
+#ifdef LTC_MRSA
 
 /**
    PKCS #1 v2.00 Signature Encoding
@@ -156,4 +156,4 @@ LBL_ERR:
    return err;
 }
 
-#endif /* LTC_PKCS_1 */
+#endif /* LTC_MRSA */

--- a/tests/ed25519_test.c
+++ b/tests/ed25519_test.c
@@ -98,6 +98,21 @@ static int s_rfc_8410_10_test(void)
    return CRYPT_OK;
 }
 
+/* RFC 8410 requires the parameters field of the AlgorithmIdentifier to be absent */
+static int s_ed25519_pkcs8_params_test(void)
+{
+   /* RFC 8410 - 10.3.  Example Ed25519 Private Key, with a NULL parameters element added */
+   const char *b64 = "MDACAQAwBwYDK2VwBQAEIgQg1O5y2/kTWErVttjx92n4rTr+fCjL8dT74Jeoj0R1WEI=";
+   curve25519_key key;
+   unsigned char buf[1024];
+   unsigned long buflen = sizeof(buf);
+
+   DO(base64_decode(b64, XSTRLEN(b64), buf, &buflen));
+   SHOULD_FAIL_WITH(ed25519_import_pkcs8(buf, buflen, NULL, &key), CRYPT_INVALID_PACKET);
+
+   return CRYPT_OK;
+}
+
 typedef struct {
    const char* secret_key;
    const char* public_key;
@@ -458,6 +473,7 @@ int ed25519_mpi_test(void)
 {
    if (ltc_mp.name == NULL) return CRYPT_NOP;
    DO(s_rfc_8410_10_test());
+   DO(s_ed25519_pkcs8_params_test());
    return CRYPT_OK;
 }
 

--- a/tests/pkcs_1_eme_test.c
+++ b/tests/pkcs_1_eme_test.c
@@ -2,7 +2,7 @@
 /* SPDX-License-Identifier: Unlicense */
 #include <tomcrypt_test.h>
 
-#if defined(LTC_PKCS_1)
+#if defined(LTC_MRSA)
 
 #include "../notes/rsa-testvectors/pkcs1v15crypt-vectors.c"
 

--- a/tests/pkcs_1_emsa_test.c
+++ b/tests/pkcs_1_emsa_test.c
@@ -2,7 +2,7 @@
 /* SPDX-License-Identifier: Unlicense */
 #include <tomcrypt_test.h>
 
-#if defined(LTC_PKCS_1)
+#if defined(LTC_MRSA)
 
 #include "../notes/rsa-testvectors/pkcs1v15sign-vectors.c"
 

--- a/tests/pkcs_1_oaep_test.c
+++ b/tests/pkcs_1_oaep_test.c
@@ -2,7 +2,7 @@
 /* SPDX-License-Identifier: Unlicense */
 #include <tomcrypt_test.h>
 
-#if defined(LTC_PKCS_1)
+#if defined(LTC_MRSA)
 
 #include "../notes/rsa-testvectors/oaep-vect.c"
 

--- a/tests/pkcs_1_pss_test.c
+++ b/tests/pkcs_1_pss_test.c
@@ -2,7 +2,7 @@
 /* SPDX-License-Identifier: Unlicense */
 #include <tomcrypt_test.h>
 
-#if defined(LTC_PKCS_1)
+#if defined(LTC_MRSA)
 
 #include "../notes/rsa-testvectors/pss-vect.c"
 

--- a/tests/pkcs_1_test.c
+++ b/tests/pkcs_1_test.c
@@ -2,7 +2,7 @@
 /* SPDX-License-Identifier: Unlicense */
 #include <tomcrypt_test.h>
 
-#ifdef LTC_PKCS_1
+#ifdef LTC_MRSA
 
 #ifdef LTC_TEST_REAL_RAND
 #define LTC_TEST_RAND_SEED  time(NULL)

--- a/tests/x25519_test.c
+++ b/tests/x25519_test.c
@@ -180,6 +180,21 @@ static int s_x25519_pkcs8_test(void)
    return CRYPT_OK;
 }
 
+/* RFC 8410 requires the parameters field of the AlgorithmIdentifier to be absent */
+static int s_x25519_pkcs8_params_test(void)
+{
+   /* `openssl genpkey -algorithm x25519`, with an OID parameters element added */
+   const char *b64 = "MDMCAQAwCgYDK2VuBgMrZXAEIgQgQAidpR3H59AV+CGkLPD9Z0i1FPf4Wc9KStT1NwhlNlY=";
+   curve25519_key key;
+   unsigned char buf[1024];
+   unsigned long buflen = sizeof(buf);
+
+   DO(base64_decode(b64, XSTRLEN(b64), buf, &buflen));
+   SHOULD_FAIL_WITH(x25519_import_pkcs8(buf, buflen, NULL, &key), CRYPT_INVALID_PACKET);
+
+   return CRYPT_OK;
+}
+
 static int s_x25519_compat_test(void)
 {
    curve25519_key priv, pub, imported;
@@ -258,6 +273,7 @@ int x25519_mpi_test(void)
 {
    if (ltc_mp.name == NULL) return CRYPT_NOP;
    DO(s_x25519_pkcs8_test());
+   DO(s_x25519_pkcs8_params_test());
    DO(s_rfc_8410_10_test());
    DO(s_x25519_compat_test());
    return CRYPT_OK;


### PR DESCRIPTION
* fix #799 - minor formatting issues
* fix #796 - pkcs_1_pss_decode: drop the unused salt buffer
* fix #795 - ecc_sign_hash_internal: return an error when signing retries are exhausted
* fix #794 - gate all CPU-specific code behind LTC_NO_ACCEL
* fix "make CFLAGS=-DLTC_NO_PK" build
* fix pkcs8: reject AlgorithmIdentifier parameters where RFC 8410 forbids them