### PR TITLE
Validate siglen against modulus_len in PSS decode

### DIFF
--- a/src/pk/pkcs1/pkcs_1_pss_decode.c
+++ b/src/pk/pkcs1/pkcs_1_pss_decode.c
@@ -50,7 +50,8 @@ int ltc_pkcs_1_pss_decode_mgf1(const unsigned char *msghash, unsigned long  msgh
 
    /* check sizes */
    if ((saltlen > modulus_len) ||
-       (modulus_len < hLen + saltlen + 2)) {
+       (modulus_len < hLen + saltlen + 2) ||
+       (siglen != modulus_len)) {
       return CRYPT_PK_INVALID_SIZE;
    }
 

--- a/tests/pkcs_1_pss_test.c
+++ b/tests/pkcs_1_pss_test.c
@@ -158,7 +158,7 @@ int pkcs_1_pss_test(void)
         rsaData_t* s = &t->data[j];
         unsigned char buf[20], obuf[256];
         unsigned long buflen = sizeof(buf), obuflen = sizeof(obuf);
-        int stat;
+        int stat, err;
         prng_descriptor[rsa_params.wprng].add_entropy(s->o2, s->o2_l, rsa_params.prng);
         DOX(hash_memory(hash_idx, s->o1, s->o1_l, buf, &buflen), s->name);
         rsa_params.params.saltlen = s->o2_l;
@@ -166,6 +166,28 @@ int pkcs_1_pss_test(void)
         COMPARE_TESTVECTOR(obuf, obuflen, s->o3, s->o3_l,s->name, j);
         DOX(rsa_verify_hash_v2(obuf, obuflen, buf, buflen, &rsa_params, &stat, key), s->name);
         ENSUREX(stat == 1, s->name);
+
+        /* pkcs_1_pss_decode() (unlike rsa_verify_hash_v2()) forwards siglen
+         * straight to ltc_pkcs_1_pss_decode_mgf1() with no check that it
+         * matches modulus_len. That function copies modulus_len - 1 bytes
+         * total out of `sig` based on modulus_len alone, so a caller
+         * passing a genuinely truncated buffer used to walk past its end
+         * instead of failing early.
+         */
+        {
+          unsigned long modulus_bitlen = ltc_mp_count_bits(key->N);
+          const unsigned char *em = obuf;
+          unsigned long emlen = obuflen;
+          if (modulus_bitlen % 8 == 1) {
+            em++;
+            emlen--;
+          }
+          stat = 1;
+          err = pkcs_1_pss_decode(buf, buflen, em, emlen - 1, s->o2_l,
+                                   hash_idx, modulus_bitlen, &stat);
+          ENSUREX(err == CRYPT_PK_INVALID_SIZE, s->name);
+          ENSUREX(stat == 0, s->name);
+        }
     } /* for */
 
     ltc_mp_deinit_multi(key->d,  key->e, key->N, key->dQ, key->dP, key->qP, key->p, key->q, LTC_NULL);


### PR DESCRIPTION
Fixes #802.

`ltc_pkcs_1_pss_decode_mgf1` checks `saltlen` and `modulus_len` but never checks that `siglen` actually matches `modulus_len`. Later on it does:

```c
XMEMCPY(DB, sig + x, modulus_len - hLen - 1);
x += modulus_len - hLen - 1;
XMEMCPY(hash, sig + x, hLen);
```

which copies `modulus_len - 1` bytes total out of `sig`, based purely on `modulus_len`. If `siglen < modulus_len`, this reads past the end of the caller's buffer.

`rsa_verify_hash_v2` happens to avoid triggering this today, because it always passes a buffer of exactly `modulus_len` (or `modulus_len - 1` when `modulus_bitlen % 8 == 1`, handled via its own `x - 1` adjustment) into the decode call. But `ltc_pkcs_1_pss_decode_mgf1` is also reachable directly through the public (deprecated) `pkcs_1_pss_decode()` API, which forwards whatever `siglen` the caller passes with no validation at all — so a caller of that API supplying a genuinely truncated signature buffer hits the out-of-bounds read.

Fix: add `siglen != modulus_len` to the existing size-check `if`, matching the suggested fix in the issue.

Added a regression test in `tests/pkcs_1_pss_test.c` that calls `pkcs_1_pss_decode()` directly with a signature one byte shorter than the modulus and asserts it's rejected with `CRYPT_PK_INVALID_SIZE` rather than being processed. Verified with git-stash: reverting only the fix in `pkcs_1_pss_decode.c` makes the new assertion fail (on the very first PSS test vector) while everything else still passes; with the fix restored, the full suite passes (`SUCCESS: passed=30 failed=0 nop=1`).

Built and tested locally against LibTomMath (`USE_LTM`/`LTM_DESC`) on macOS/arm64.